### PR TITLE
Fix geo questions and layer controls layout bugs

### DIFF
--- a/survey/assets/css/main.css
+++ b/survey/assets/css/main.css
@@ -102,6 +102,54 @@ ul {
   margin-bottom: 0px;
 }
 
+/* Geo Question styling */
+.geo-question {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  text-align: left;
+}
+
+.geo-question-icon {
+  flex-shrink: 0;
+  width: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.geo-question-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.geo-question-title {
+  margin: 0;
+  font-weight: 500;
+}
+
+.geo-question-subtitle {
+  margin: 0;
+  font-size: 0.9em;
+  color: #666;
+}
+
+/* Layer popup controls (save/edit/delete buttons) */
+.layer-controls {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-top: 15px;
+  justify-content: center;
+}
+
+.layer-controls .btn {
+  flex: 1;
+  font-size: 1.5em;
+  padding: 8px 12px;
+  min-width: 50px;
+}
+
 .next_button {
   float:right;
 }

--- a/survey/templates/leaflet_draw_button.html
+++ b/survey/templates/leaflet_draw_button.html
@@ -1,12 +1,12 @@
 <div>
-	<button name = "{{ widget.name }}" type="button" class="drawbutton btn btn-light {{ widget.draw_type }} container" draw-type="{{widget.draw_type}}" data-color="{{widget.color}}" data-icon="{{widget.icon_class}}" >
-		<div class="row">
-			<div class="col-sm-2" style="text-align: center; ">
-				<i class="{{ widget.draw_icon_class }}" style="font-size:50px; position:relative;top: calc(50% - 25px); color: {{ widget.color }}"></i>
+	<button name = "{{ widget.name }}" type="button" class="drawbutton btn btn-light {{ widget.draw_type }}" draw-type="{{widget.draw_type}}" data-color="{{widget.color}}" data-icon="{{widget.icon_class}}" >
+		<div class="geo-question">
+			<div class="geo-question-icon">
+				<i class="{{ widget.draw_icon_class }}" style="font-size:50px; color: {{ widget.color }}"></i>
 			</div>
-			<div class="col-sm-10" style="padding-left:0px">
-				<p style="text-align: left">{{ widget.title }}</p>
-				<p style="text-align: left">{{widget.subtitle}}</p>
+			<div class="geo-question-text">
+				<p class="geo-question-title">{{ widget.title }}</p>
+				{% if widget.subtitle %}<p class="geo-question-subtitle">{{widget.subtitle}}</p>{% endif %}
 			</div>
 		</div>
 	</button>

--- a/survey/templates/survey_section.html
+++ b/survey/templates/survey_section.html
@@ -67,9 +67,11 @@
         props.question_id = currentQ;
 
         layer.bindPopup('<form action="" onsubmit="return false;" id="subquestion_form">' + subquestions_forms[currentQ]
-            + '<div class="container mt-auto" style="padding-left:0px"><div class="row"><div class="col"><button type="button" class="btn btn-success layer-apply" style="width:85%; font-size:2em"><i class="far fa-save"></i></button></div> \
-            <div class="col"><button type="button" class="btn btn-primary layer-edit" style="width:85%; font-size:2em"><i class="far fa-edit"></i></button></div> \
-            <div class="col"><button type="button" class="btn btn-danger layer-delete" style="width:85%; font-size:2em"><i class="far fa-trash-alt"></i></button></div></div></div>'
+            + '<div class="layer-controls">\
+            <button type="button" class="btn btn-success layer-apply"><i class="far fa-save"></i></button>\
+            <button type="button" class="btn btn-primary layer-edit"><i class="far fa-edit"></i></button>\
+            <button type="button" class="btn btn-danger layer-delete"><i class="far fa-trash-alt"></i></button>\
+            </div>'
             + '</form>', {
                 maxHeight: $(document).height()*0.8,
             });


### PR DESCRIPTION
## Summary
- Fix geo question icon overlapping text and incorrect subtext wrapping
- Fix layer popup buttons (save/edit/delete) displaying vertically instead of horizontally

## Changes
- Replace Bootstrap grid with flexbox for geo questions layout
- Replace Bootstrap grid with flexbox for layer popup controls
- Add CSS classes: `.geo-question`, `.geo-question-icon`, `.geo-question-text`, `.layer-controls`

## Test plan
- [x] Open a survey with geo questions (point/line/polygon)
- [x] Verify icon and text are aligned horizontally, subtext doesn't wrap around icon
- [x] Draw a geo object and open its popup
- [x] Verify save/edit/delete buttons are always in a horizontal row

🤖 Generated with [Claude Code](https://claude.ai/claude-code)