### PR TITLE
Enable Render PR preview environments with per-PR databases

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ databases:
     user: mapsurvey
     postgresMajorVersion: 16
     ipAllowList: []
+    previewPlan: basic-256mb
 
 services:
   - type: web
@@ -13,6 +14,8 @@ services:
     plan: starter
     dockerfilePath: ./Dockerfile
     dockerContext: .
+    previews:
+      generation: automatic
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
Add previewPlan to database config so each PR gets an isolated
PostGIS database. Enable automatic preview generation on the
web service so Render deploys a preview instance for every PR.

https://claude.ai/code/session_016SLdCQB5vx5UcREtgQd1jp