### PR TITLE
openspec: scaffold geometry-pressure change

### DIFF
--- a/openspec/changes/geometry-pressure-v2/design.md
+++ b/openspec/changes/geometry-pressure-v2/design.md
@@ -1,0 +1,311 @@
+# Design: geometry-pressure-v2
+
+## Overview
+
+Replace the v1 approach (one Question with `geometries` JSONField + shared sub-questions + `geometry_id` on Answer) with a per-shape Question model. Each predefined shape is a full Question with its own `GeometryField` and its own sub-questions. A new section-level map editor enables bulk creation, import, and management.
+
+## Model Changes
+
+### Question model (`survey/models.py`)
+
+1. Add field:
+   ```python
+   from django.contrib.gis.db import models as geomodels
+   geometry = geomodels.GeometryField(null=True, blank=True, srid=4326)
+   ```
+   Stores a single geometry (Point, LineString, or Polygon) for pressure questions. `NULL` for all other question types.
+
+2. `geometries` JSONField — **keep but deprecate**. Existing v1 data (if any) remains readable. A data migration converts v1 `geometries` array entries into separate Questions. No new code writes to this field.
+
+3. `INPUT_TYPE_CHOICES` — `("pressure", _("Geometry Pressure"))` already exists from v1. No change.
+
+4. `geo_questions()` — already includes `'pressure'`. No change.
+
+5. Existing Question fields that double as shape metadata:
+   - `name` → shape label (displayed on map, in popups, in export)
+   - `color` → shape stroke/fill color on map
+   - `icon_class` → Font Awesome icon for point markers
+   - `image` → optional shape image (shown in popup)
+   - `subtext` → shape description (shown in popup)
+   - `parent_question_id` → sub-questions for this shape
+   - `order_number` → controls rendering order / list order in editor
+
+### Answer model (`survey/models.py`)
+
+No new fields. `geometry_id` field from v1 — **keep but deprecate**. New pressure answers don't use it; `Answer.question` directly identifies the shape.
+
+For pressure answers, the geometry is stored redundantly in `answer.point`, `answer.line`, or `answer.polygon` (matching the shape's geometry type). This follows the same pattern as existing geo questions and keeps the export pipeline consistent.
+
+### Migration
+
+Single migration:
+1. Add `Question.geometry` GeometryField (nullable).
+2. Data migration: for each Question with `input_type="pressure"` and non-empty `geometries` JSONField, create one new Question per geometry entry, copying `label→name`, `color→color`, `icon_class→icon_class`, geometry→`geometry` (converted via `GEOSGeometry`). Clone sub-questions for each new Question. Remove the `geometries` data from the original (set to `None`).
+
+## Respondent Side
+
+### Form Layer (`survey/forms.py`)
+
+**Update `PressureField` and `PressureButtonWidget`**:
+
+The widget no longer carries a `data-geometries` attribute with a JSON array. Instead, each pressure Question renders its own widget/button (one per shape). But this means the form would show N separate buttons — one per shape — which is not the desired UX.
+
+**Alternative approach: section-level rendering.** Pressure questions are NOT rendered as individual form fields. Instead, the section template detects all pressure questions and renders them as a single map layer group. The form field for each pressure question is a hidden input that gets populated by JavaScript when the respondent interacts with the shape.
+
+Implementation:
+- `_get_form_from_input_type()` for `pressure` returns a `HiddenInput`-based field (not a visible button). The hidden field stores serialized sub-question answers as JSON.
+- The template JavaScript reads all pressure questions from a template variable `pressure_questions_json` and renders them on the map.
+
+```python
+elif input_type == 'pressure':
+    return forms.CharField(
+        widget=forms.HiddenInput(attrs={'class': 'pressure-answer-input'}),
+        required=False,
+        label=False,
+    )
+```
+
+### Template variable: `pressure_questions_json`
+
+In `views.py`, build a dict of pressure questions for the section:
+
+```python
+pressure_questions = []
+for question in questions:
+    if question.input_type == 'pressure' and question.geometry:
+        pressure_questions.append({
+            'code': question.code,
+            'name': question.name,
+            'subtext': question.subtext,
+            'color': question.color,
+            'icon_class': question.icon_class,
+            'geometry': json.loads(question.geometry.geojson),
+            'image_url': question.image.url if question.image else None,
+        })
+```
+
+### JavaScript — Respondent Side
+
+**Shape rendering on map load:**
+
+1. Parse `pressure_questions_json` from template.
+2. For each pressure question, create a Leaflet layer:
+   - Point → `L.marker` with colored Font Awesome icon
+   - LineString → `L.polyline` with `color`
+   - Polygon → `L.polygon` with `color` stroke, translucent fill
+3. Add to a shared `pressureLayerGroup` (non-editable, separate from `editableLayers`).
+4. Store question code in `layer.feature.properties.question_id`.
+5. Set initial style: opacity 0.5 for unanswered shapes.
+
+**Click handler → popup:**
+
+Each layer gets `on('click')`:
+1. Read `questionCode` from `layer.feature.properties.question_id`.
+2. Build popup from `subquestions_forms[questionCode]` — each pressure question already has its own sub-question form.
+3. Open popup bound to layer.
+4. On popup open: populate from `layer.feature.properties` (existing answers).
+5. On popup close/apply: serialize form data back to properties, update hidden input.
+
+**Visual feedback:**
+
+Same as v1: answered shapes get full opacity + checkmark badge. Tracked in `pressureAnswered` Set keyed by question code.
+
+**Form submission:**
+
+On submit, for each answered pressure question:
+1. Serialize geometry + sub-question properties as a GeoJSON feature.
+2. Set the corresponding hidden `pressure-answer-input` field value.
+
+### Existing Answer Restoration
+
+Pressure answers are loaded via `existing_geo_answers[question_code]`. Each feature has one entry (the shape's geometry + sub-question values). On load, find the matching pressure layer by question code, copy properties, mark as answered.
+
+## View Layer (`survey/views.py`)
+
+### POST — saving pressure answers
+
+The pressure POST handler changes significantly:
+
+For each pressure question in the section:
+1. Check if the hidden input has data (respondent interacted with this shape).
+2. If yes, parse the JSON value containing sub-question answers.
+3. Upsert the parent Answer: find existing `Answer(survey_session, question)` or create new. Set the geometry field (point/line/polygon) from the Question's geometry.
+4. For each sub-question answer in the JSON, upsert child Answers with `parent_answer_id`.
+
+No `geometry_id` needed — `Answer.question` directly references the pressure Question (which IS the shape).
+
+### GET — building existing_geo_answers
+
+For pressure questions, the existing code path works with minor adjustments:
+- Remove `geometry_id` from properties (not needed).
+- Each pressure Question produces at most one feature (one shape = one set of answers).
+
+### Context additions
+
+Add `pressure_questions_json` to the template context (see above).
+
+## Editor — Section-Level Map Editor
+
+### New URL endpoints
+
+```python
+# Section map editor
+path('editor/surveys/<uuid:survey_uuid>/sections/<int:section_id>/map-editor/',
+     editor_views.editor_section_map_editor, name='editor_section_map_editor'),
+
+# Pressure question CRUD via map editor (HTMX endpoints)
+path('editor/surveys/<uuid:survey_uuid>/sections/<int:section_id>/pressure-questions/create/',
+     editor_views.editor_pressure_create, name='editor_pressure_create'),
+
+path('editor/surveys/<uuid:survey_uuid>/pressure-questions/<int:question_id>/update/',
+     editor_views.editor_pressure_update, name='editor_pressure_update'),
+
+path('editor/surveys/<uuid:survey_uuid>/pressure-questions/<int:question_id>/delete/',
+     editor_views.editor_pressure_delete, name='editor_pressure_delete'),
+
+# Bulk operations
+path('editor/surveys/<uuid:survey_uuid>/sections/<int:section_id>/pressure-questions/bulk-subquestion/',
+     editor_views.editor_pressure_bulk_subquestion, name='editor_pressure_bulk_subquestion'),
+
+# Import
+path('editor/surveys/<uuid:survey_uuid>/sections/<int:section_id>/pressure-questions/import/',
+     editor_views.editor_pressure_import, name='editor_pressure_import'),
+```
+
+### Editor views (`survey/editor_views.py`)
+
+**`editor_section_map_editor`** (GET):
+- Renders the section map editor template.
+- Passes all pressure questions for this section as `pressure_questions_json`.
+- Uses a fullscreen modal or dedicated page with Leaflet map + shape list panel.
+
+**`editor_pressure_create`** (POST):
+- Receives: GeoJSON geometry, name, color, icon_class.
+- Creates a Question with `input_type="pressure"`, `geometry` from GeoJSON (converted via `GEOSGeometry`), and the provided metadata.
+- Auto-assigns next `order_number`.
+- Returns the updated shape list partial (HTMX).
+
+**`editor_pressure_update`** (POST):
+- Receives: question_id, updated fields (name, color, icon_class, geometry).
+- Updates the Question.
+- Returns updated shape list item partial.
+
+**`editor_pressure_delete`** (POST):
+- Deletes the pressure Question (cascades to sub-questions and answers).
+- Returns updated shape list partial.
+
+**`editor_pressure_bulk_subquestion`** (POST):
+- Receives: list of question IDs + sub-question definition (input_type, name, etc.).
+- For each selected Question, creates a sub-question with `parent_question_id` set.
+- Returns updated shape list partial.
+
+**`editor_pressure_import`** (POST):
+- Receives: uploaded file (GeoJSON or KML).
+- Parses the file, extracts features.
+- For each feature: creates a Question with geometry, maps properties to name/color if available.
+- Returns updated shape list partial showing all imported shapes.
+
+### Editor template: `editor/partials/section_map_editor.html`
+
+Layout:
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Map Editor: {{ section.title }}                    [Close]  │
+├────────────────────────────────────┬─────────────────────────┤
+│                                    │ Shapes ({{ count }})    │
+│         Leaflet Map                │ [Select All] [Deselect] │
+│                                    │                         │
+│    [Draw Point] [Draw Line]        │ ☑ ● Main Stage   [✎][✕]│
+│    [Draw Polygon]                  │ ☑ ▬ Food Court   [✎][✕]│
+│                                    │ ☐ ▬ Parking      [✎][✕]│
+│                                    │ ...                     │
+│                                    │                         │
+│                                    ├─────────────────────────┤
+│                                    │ Bulk actions (2 sel.)   │
+│                                    │ [+ Add sub-question]    │
+│                                    │ [✕ Delete selected]     │
+├────────────────────────────────────┴─────────────────────────┤
+│  [Import GeoJSON/KML...]                                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Draw workflow:**
+1. User clicks Draw Point/Line/Polygon → Leaflet Draw activates.
+2. On `draw:created` → HTMX POST to `editor_pressure_create` with geometry + default name.
+3. Shape appears in list, user edits name/color/icon inline.
+
+**Edit workflow:**
+1. Click [✎] on a shape → inline edit fields or modal for name, color, icon_class.
+2. On save → HTMX POST to `editor_pressure_update`.
+
+**Import workflow:**
+1. Click [Import GeoJSON/KML...] → file picker dialog.
+2. On file select → POST to `editor_pressure_import`.
+3. New shapes appear in list and on map.
+
+**Bulk sub-question workflow:**
+1. Select shapes via checkboxes.
+2. Click [+ Add sub-question] → modal with sub-question form (input_type, name, subtext).
+3. On save → POST to `editor_pressure_bulk_subquestion` with selected IDs + sub-question data.
+4. Each selected shape gets a copy of the sub-question.
+
+### Integration with existing question modal
+
+The existing question form modal (`question_form_modal.html`) still works for pressure questions:
+- When `input_type="pressure"`, show a geometry picker (single shape, not the multi-shape geometries panel from v1).
+- The geometry picker is a small Leaflet map where the user draws ONE shape.
+- This path is for editing a single pressure question's geometry from the question list — the section map editor is for bulk operations.
+
+Update the geometries-editor panel: replace multi-shape editor with single-geometry picker. Hidden input becomes `geometry_json` (single GeoJSON geometry object, not array).
+
+## Data Export (`survey/views.py` — `download_data`)
+
+### GeoJSON export
+
+Pressure questions are included via `geo_questions()`. Each pressure question's answers produce features with:
+- Geometry from answer.point/line/polygon (same dispatch as v1).
+- Properties: question name as `shape_label`, sub-question values.
+- No `geometry_id` — the question code identifies the shape.
+
+### CSV export
+
+Pressure sub-question answers are included in CSV:
+- Column `question_code` identifies the pressure question (shape).
+- Column `question_name` provides the shape label.
+- Sub-question values in their own columns.
+
+## Serialization (`survey/serialization.py`)
+
+### Question serialization
+
+Add `"geometry"` to `_serialize_question()`:
+```python
+if question.geometry:
+    data["geometry"] = json.loads(question.geometry.geojson)
+```
+
+### Question import
+
+```python
+geom_data = q_data.get("geometry")
+if geom_data:
+    question.geometry = GEOSGeometry(json.dumps(geom_data), srid=4326)
+```
+
+### Backward compatibility
+
+If importing a v1 export with `geometries` array, expand into separate Questions (same logic as data migration).
+
+## Decisions Log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Per-shape model | Each shape = Question | Enables per-shape sub-questions, uses existing hierarchy |
+| Geometry storage | GeometryField (PostGIS) | Future spatial queries (e.g., point-in-polygon constraints) |
+| Respondent form rendering | Hidden inputs, JS renders all shapes | Avoids N visible buttons; single map with all shapes |
+| geometry_id on Answer | Deprecated, not used for new data | Answer.question directly identifies the shape |
+| geometries JSONField | Deprecated, data migration converts | Backward compat for existing v1 data |
+| Bulk sub-questions | Copy per shape, not shared reference | Each shape can be independently customized later |
+| Editor approach | Section-level map editor (new page/modal) | Bulk operations, import, overview of all shapes |
+| Single-shape editor | Geometry picker in question modal | For editing individual shape geometry |
+| Import formats | GeoJSON + KML | Most common; GeoJSON native, KML via conversion |

--- a/openspec/changes/geometry-pressure-v2/proposal.md
+++ b/openspec/changes/geometry-pressure-v2/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The current `geometry-pressure` implementation (v1) stores all predefined shapes in a single Question's `geometries` JSONField with shared sub-questions across all shapes. This doesn't match the real-world use case: **each shape needs its own content** — unique text, images, and potentially different sub-questions.
+
+Typical scenario: a festival map with 20+ zones where each zone has its own description, photos, and feedback questions. The "Main Stage" zone shows a schedule and asks about sound quality, while the "Food Court" shows a menu and asks about food quality and cleanliness.
+
+Creating each shape as a separate question manually through the editor modal is tedious for dozens of shapes. And importing existing geometry (country borders, city districts, complex building footprints) is impossible.
+
+**This change replaces the v1 approach**: each shape becomes a full `Question` with its own `GeometryField`, its own sub-questions, and its own content. A new section-level map editor enables bulk creation, drawing, and import of shapes.
+
+## What Changes
+
+- **Each shape = separate Question** — instead of a `geometries` JSONField array on one Question, each predefined shape is its own `Question` with `input_type="pressure"`. The Question's existing fields (`name`=label, `color`, `icon_class`) describe the shape. A new `GeometryField` stores the shape's geometry (Point, LineString, or Polygon).
+
+- **Per-shape sub-questions** — each pressure Question has its own sub-questions via the existing `parent_question_id` hierarchy. Shape "Main Stage" can have `html` + `rating` + `text` sub-questions, while "Parking" has only `choice` + `text`. No more shared sub-questions limitation.
+
+- **`geometry_id` on Answer is no longer needed** — since each shape IS a Question, `Answer.question` directly identifies the shape. The `geometry_id` field from v1 becomes obsolete.
+
+- **`geometries` JSONField on Question is no longer needed** — replaced by the singular `GeometryField` per Question. The v1 field becomes obsolete.
+
+- **`GeometryField` on Question** — uses GeoDjango's `GeometryField` (not JSONField) to enable future spatial queries (e.g., constraining a point question to fall within a pressure polygon). Stores any geometry type: Point, LineString, Polygon.
+
+- **Section-level map editor** — a new editor UI at the section level that shows all pressure questions of the section on a single Leaflet map. Supports drawing new shapes (each creates a Question), editing existing shapes, bulk operations, and importing from geo files.
+
+- **Bulk sub-questions** — select multiple shapes and add the same sub-question to all of them at once. Each shape gets its own copy of the sub-question (not a shared reference), so individual shapes can later be customized.
+
+- **Geo format import** — upload GeoJSON or KML files to bulk-create pressure Questions. Each feature in the file becomes a separate Question with geometry and optionally mapped properties (name, color).
+
+- **Respondent experience** — unchanged from v1 concept: predefined shapes rendered as non-editable Leaflet layers, click opens popup with that shape's sub-questions. Visual feedback for answered/unanswered shapes.
+
+## Capabilities
+
+### New Capabilities
+
+- `geometry-pressure-v2`: Pressure question type where each predefined shape is a separate Question with its own `GeometryField` and per-shape sub-questions. Replaces the v1 approach of `geometries` JSONField with shared sub-questions.
+
+- `section-map-editor`: Section-level map editor for bulk creation and management of pressure Questions. Features: draw shapes on map (each creates a Question), edit shape properties, delete shapes, bulk add sub-questions to selected shapes, import from GeoJSON/KML.
+
+### Modified Capabilities
+
+- `survey-editor`: Section view gains a "Map Editor" button/panel for sections containing pressure questions. Individual pressure question editing still works through the existing question modal (now with a geometry picker instead of the geometries panel).
+
+- `survey-serialization`: Export/import handles the new `geometry` GeometryField on Question. The `geometries` JSONField and `geometry_id` on Answer are deprecated.
+
+## Impact
+
+- **Models**: `Question` — add `geometry` GeometryField (nullable); deprecate `geometries` JSONField. `Answer` — deprecate `geometry_id` CharField. `INPUT_TYPE_CHOICES` — `pressure` type already exists from v1.
+- **Forms**: `forms.py` — update `PressureField`/`PressureButtonWidget` to work with per-Question geometry instead of geometries array. Widget carries single geometry + question metadata.
+- **Views**: `views.py` — update pressure answer saving/loading to work without `geometry_id` (Answer.question identifies the shape). Render all pressure Questions in a section as map layers.
+- **Editor views**: `editor_views.py` — new section-level map editor endpoints: list/create/update/delete pressure questions in bulk, import from geo files, bulk add sub-questions.
+- **Templates**: new `editor/partials/section_map_editor.html` for the section-level map editor. Update `pressure_button.html` to use single geometry.
+- **JavaScript**: section map editor with Leaflet Draw + shape list + import UI. Update respondent-side JS to render pressure Questions (not geometries array).
+- **Serialization**: `serialization.py` — serialize `geometry` GeometryField on Question (as GeoJSON). Remove `geometry_id` from answer serialization.
+- **Migration**: add `Question.geometry` GeometryField. Data migration to convert existing `geometries` JSONField entries to separate Questions (if any data exists).

--- a/openspec/changes/geometry-pressure-v2/specs/geometry-pressure-v2/spec.md
+++ b/openspec/changes/geometry-pressure-v2/specs/geometry-pressure-v2/spec.md
@@ -1,0 +1,140 @@
+## CHANGED Requirements (from geometry-pressure)
+
+### Requirement: Pressure question — one shape per Question
+Each pressure question (`input_type="pressure"`) SHALL represent a single predefined shape on the map. The shape's geometry is stored in a `GeometryField` on the Question model. The Question's existing fields serve as shape metadata: `name` is the shape label, `color` is the shape color, `icon_class` is the marker icon (for points), `subtext` is the shape description, `image` is an optional shape image.
+
+This replaces the v1 approach where one Question stored multiple shapes in a `geometries` JSONField.
+
+#### Scenario: Create a pressure question with a point geometry
+- **GIVEN** a section exists
+- **WHEN** a Question is created with `input_type="pressure"` and `geometry=Point(30.3, 59.9)`, `name="Main Stage"`, `color="#ff0000"`, `icon_class="fas fa-music"`
+- **THEN** the Question is saved with the geometry and metadata
+- **AND** it represents a single clickable point on the respondent map
+
+#### Scenario: Create a pressure question with a polygon geometry
+- **GIVEN** a section exists
+- **WHEN** a Question is created with `input_type="pressure"` and `geometry=Polygon(...)`, `name="Food Court"`
+- **THEN** the Question is saved with the polygon geometry
+- **AND** it represents a single clickable polygon on the respondent map
+
+#### Scenario: Geometry field is null for non-pressure questions
+- **GIVEN** a Question with `input_type="text"`
+- **THEN** the `geometry` field is null and has no effect
+
+### Requirement: Per-shape sub-questions
+Each pressure Question SHALL have its own set of sub-questions via the existing `parent_question_id` hierarchy. Different shapes MAY have different sub-questions.
+
+#### Scenario: Two shapes with different sub-questions
+- **GIVEN** pressure Question "Main Stage" with sub-questions: `html` (schedule), `rating` (sound quality)
+- **AND** pressure Question "Parking" with sub-questions: `choice` (enough spots?), `text` (comment)
+- **WHEN** a respondent clicks "Main Stage"
+- **THEN** the popup shows only schedule + sound quality rating
+- **WHEN** the respondent clicks "Parking"
+- **THEN** the popup shows only the parking choice + comment
+
+#### Scenario: Shapes with identical sub-questions (via bulk creation)
+- **GIVEN** 10 pressure Questions each with the same `rating` + `text` sub-questions (created via bulk add)
+- **WHEN** a respondent clicks any shape
+- **THEN** each shape shows its own copy of rating + text sub-questions
+- **AND** answers are stored independently per shape
+
+### Requirement: Respondent map rendering of pressure shapes
+On the survey-taking page, when a section contains pressure questions, the system SHALL render all pressure Questions' geometries as non-editable Leaflet layers on the map. Styling uses each Question's `color` and `icon_class`.
+
+#### Scenario: All pressure shapes appear on map
+- **GIVEN** a section with 3 pressure Questions (point, line, polygon)
+- **WHEN** a respondent opens the section
+- **THEN** all 3 shapes are visible on the map with their configured colors and icons
+- **AND** shapes are not draggable or editable
+
+#### Scenario: Pressure shapes coexist with draw-based geo questions
+- **GIVEN** a section with 2 pressure Questions and 1 regular polygon question
+- **WHEN** a respondent opens the section
+- **THEN** pressure shapes are non-editable layers AND the polygon draw button works independently
+
+### Requirement: Click-to-interact with pressure shapes
+When a respondent clicks a predefined shape, the system SHALL open a popup containing that shape's sub-questions. The popup SHALL show the shape's name, subtext, and image (if set) as header content, followed by interactive sub-question fields.
+
+#### Scenario: Click shape opens its sub-question popup
+- **WHEN** a respondent clicks pressure Question "Main Stage" on the map
+- **THEN** a popup opens showing "Main Stage" as title, the shape's subtext, and its sub-questions
+
+#### Scenario: Popup shows previously saved answers
+- **GIVEN** a respondent previously answered sub-questions for "Main Stage"
+- **WHEN** the respondent clicks "Main Stage" again
+- **THEN** the popup fields are pre-populated with saved answers
+
+#### Scenario: Different shapes maintain independent answers
+- **GIVEN** a respondent rates "Main Stage" as 5 and "Parking" as 3
+- **WHEN** opening each popup
+- **THEN** "Main Stage" shows 5 and "Parking" shows 3
+
+### Requirement: Visual feedback for interacted shapes
+Same as v1: shapes that have been answered SHALL have a distinct visual style (full opacity, checkmark badge) vs unanswered shapes (reduced opacity).
+
+#### Scenario: Unanswered shape
+- **WHEN** a respondent has not yet clicked a shape
+- **THEN** it is displayed with opacity 0.5
+
+#### Scenario: Answered shape
+- **WHEN** a respondent has submitted answers for a shape
+- **THEN** opacity changes to 1.0 and a checkmark indicator appears
+
+### Requirement: Pressure answer saving (v2 — no geometry_id)
+When a respondent submits answers for a pressure shape, the system SHALL create one Answer for the pressure Question (with geometry stored in point/line/polygon field) and child Answers for each sub-question. `Answer.question` directly identifies the shape — no `geometry_id` needed.
+
+#### Scenario: Save answers for a pressure point shape
+- **WHEN** a respondent fills sub-questions for pressure Question "Entrance" (Point) and applies
+- **THEN** an Answer is created with `question=<Entrance Question>`, `point=<coordinates>`
+- **AND** child Answers are created for each sub-question with `parent_answer_id` set
+- **AND** `geometry_id` is NOT set on any of these answers
+
+#### Scenario: Upsert — re-answering a shape
+- **WHEN** a respondent re-opens "Entrance" popup, changes the rating, and applies
+- **THEN** the existing Answer for this `(survey_session, question)` is updated, not duplicated
+
+### Requirement: Pressure question form rendering
+Pressure questions SHALL NOT render as visible buttons/cards in the form. Instead, each renders as a hidden input (`<input type="hidden" class="pressure-answer-input">`). The shape is rendered on the map by JavaScript using template context data.
+
+#### Scenario: Pressure questions are not visible as form fields
+- **GIVEN** a section with 3 pressure questions and 2 text questions
+- **WHEN** the form renders
+- **THEN** only the 2 text questions show visible form fields
+- **AND** the 3 pressure shapes appear on the map (not as form buttons)
+
+### Requirement: Existing answer restoration for pressure
+The view SHALL include pressure answers in `existing_geo_answers`. Each pressure Question produces at most one feature (one shape = one set of answers per session).
+
+#### Scenario: Restore previous pressure answers
+- **GIVEN** a respondent previously answered 2 out of 5 pressure shapes
+- **WHEN** they revisit the section
+- **THEN** `existing_geo_answers` contains entries for those 2 question codes
+- **AND** the map shows those 2 shapes as answered (full opacity) with populated popup data
+
+### Requirement: Pressure data export
+GeoJSON export SHALL include pressure question answers. Each feature includes the shape's question name as `shape_label` in properties. CSV export SHALL include pressure sub-question answers with `question_code` and `question_name` columns identifying the shape.
+
+#### Scenario: GeoJSON export
+- **GIVEN** a survey with 3 answered pressure shapes
+- **WHEN** exporting data
+- **THEN** the GeoJSON file contains features with `shape_label` in properties
+
+#### Scenario: CSV export
+- **GIVEN** a survey with pressure answers
+- **WHEN** exporting CSV
+- **THEN** rows for pressure sub-questions include `question_code` and `question_name` identifying the shape
+
+### Requirement: Pressure question serialization
+Export/import SHALL serialize the `geometry` GeometryField as GeoJSON in the question structure. Import SHALL restore it via `GEOSGeometry`. Backward compatibility: importing v1 format with `geometries` array SHALL expand into separate Questions.
+
+#### Scenario: Export pressure question
+- **WHEN** exporting a survey with a pressure question having a polygon geometry
+- **THEN** the exported JSON includes `"geometry": {"type": "Polygon", "coordinates": [...]}`
+
+#### Scenario: Import pressure question
+- **WHEN** importing a JSON with a pressure question having `"geometry": {"type": "Point", ...}`
+- **THEN** the Question is created with `geometry` GeometryField populated
+
+#### Scenario: Import v1 format with geometries array
+- **WHEN** importing a JSON with a pressure question having `"geometries": [{...}, {...}]`
+- **THEN** each entry in the array is expanded into a separate Question with its own geometry

--- a/openspec/changes/geometry-pressure-v2/specs/section-map-editor/spec.md
+++ b/openspec/changes/geometry-pressure-v2/specs/section-map-editor/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: Section-level map editor page
+The survey editor SHALL provide a section-level map editor accessible via a button on the section detail page. The editor shows a Leaflet map displaying all pressure questions in the section and a shape list panel for management.
+
+#### Scenario: Open section map editor
+- **GIVEN** a section with 5 pressure questions
+- **WHEN** the editor user clicks "Map Editor" on the section detail
+- **THEN** a fullscreen modal or page opens showing a Leaflet map with all 5 shapes rendered
+- **AND** a shape list panel on the right shows all 5 shapes with their names, colors, and icons
+
+#### Scenario: Section with no pressure questions
+- **GIVEN** a section with only text and rating questions
+- **WHEN** the editor user opens the map editor
+- **THEN** the map is empty and the shape list shows "No shapes yet. Draw or import to add."
+
+### Requirement: Draw shapes in map editor
+The map editor SHALL provide Leaflet Draw tools (point, line, polygon) to create new pressure questions. Drawing a shape creates a Question with `input_type="pressure"` and the drawn geometry.
+
+#### Scenario: Draw a point shape
+- **WHEN** the editor user selects "Draw Point" and clicks on the map
+- **THEN** a new pressure Question is created with `geometry=Point(...)`, `name="Shape N"` (auto-generated)
+- **AND** the shape appears in the shape list with an editable name field
+
+#### Scenario: Draw a polygon shape
+- **WHEN** the editor user selects "Draw Polygon" and draws a polygon
+- **THEN** a new pressure Question is created with the polygon geometry
+- **AND** it appears on the map and in the shape list
+
+#### Scenario: Auto-increment order number
+- **GIVEN** a section with 3 existing pressure questions (order 1, 2, 3)
+- **WHEN** a new shape is drawn
+- **THEN** the new Question gets `order_number=4`
+
+### Requirement: Edit shape properties in map editor
+Each shape in the shape list SHALL have controls to edit: name (inline text input), color (color picker), icon_class (icon picker, for points). Changes are saved via HTMX requests.
+
+#### Scenario: Rename a shape
+- **WHEN** the editor user changes the name of "Shape 1" to "Main Stage"
+- **THEN** the Question's `name` is updated
+- **AND** the map label updates to show "Main Stage"
+
+#### Scenario: Change shape color
+- **WHEN** the editor user changes a shape's color from red to blue
+- **THEN** the Question's `color` is updated
+- **AND** the shape on the map re-renders with the new color
+
+### Requirement: Delete shapes in map editor
+The shape list SHALL have a delete button per shape. Deleting a shape removes the Question and cascades to its sub-questions and answers.
+
+#### Scenario: Delete a single shape
+- **WHEN** the editor user clicks delete on "Parking"
+- **THEN** a confirmation prompt appears
+- **AND** on confirm, the Question and its sub-questions/answers are deleted
+- **AND** the shape disappears from the map and shape list
+
+### Requirement: Select shapes for bulk operations
+The shape list SHALL have checkboxes for multi-selection. A "Select All" / "Deselect All" toggle is provided. Selected count is displayed. Bulk action buttons appear when shapes are selected.
+
+#### Scenario: Select multiple shapes
+- **WHEN** the editor user checks 5 out of 10 shapes
+- **THEN** the UI shows "5 selected" and bulk action buttons become active
+
+#### Scenario: Select all
+- **WHEN** the editor user clicks "Select All"
+- **THEN** all shapes are checked and the count shows the total
+
+### Requirement: Bulk add sub-question
+When shapes are selected, the "Add sub-question" bulk action SHALL open a modal where the user defines a sub-question (input_type, name, subtext, etc.). On save, a copy of this sub-question is created for each selected shape.
+
+#### Scenario: Add rating sub-question to all shapes
+- **GIVEN** 10 shapes are selected
+- **WHEN** the user clicks "Add sub-question", configures a `rating` type question "Rate this zone", and saves
+- **THEN** 10 new sub-questions are created, one per selected shape, each with `parent_question_id` pointing to its shape's Question
+- **AND** each is an independent copy (editing one doesn't affect others)
+
+#### Scenario: Add sub-question to subset
+- **GIVEN** 3 out of 10 shapes are selected
+- **WHEN** the user adds a sub-question via bulk action
+- **THEN** only the 3 selected shapes get the new sub-question
+
+### Requirement: Bulk delete shapes
+When shapes are selected, the "Delete selected" bulk action SHALL delete all selected pressure Questions after confirmation.
+
+#### Scenario: Bulk delete
+- **GIVEN** 5 shapes are selected
+- **WHEN** the user clicks "Delete selected" and confirms
+- **THEN** all 5 Questions (and their sub-questions/answers) are deleted
+- **AND** they disappear from the map and shape list
+
+### Requirement: Import shapes from GeoJSON
+The map editor SHALL provide an "Import" button that accepts a GeoJSON file upload. Each Feature in the file creates a new pressure Question with the feature's geometry and optionally mapped properties.
+
+#### Scenario: Import GeoJSON with 20 features
+- **WHEN** the editor user uploads a GeoJSON FeatureCollection with 20 polygon features
+- **THEN** 20 new pressure Questions are created in the section
+- **AND** each has the polygon geometry from the corresponding feature
+- **AND** all appear on the map and in the shape list
+
+#### Scenario: Map GeoJSON properties to shape fields
+- **GIVEN** a GeoJSON feature with `properties: {"name": "District A", "color": "#ff0000"}`
+- **WHEN** imported
+- **THEN** the Question's `name` is set to "District A" and `color` to "#ff0000"
+
+#### Scenario: Features without name property
+- **GIVEN** a GeoJSON feature without a `name` property
+- **WHEN** imported
+- **THEN** the Question's `name` is auto-generated (e.g., "Shape 1", "Shape 2")
+
+### Requirement: Import shapes from KML
+The map editor SHALL also accept KML file uploads. Each Placemark creates a pressure Question.
+
+#### Scenario: Import KML file
+- **WHEN** the editor user uploads a KML file with 5 placemarks
+- **THEN** 5 new pressure Questions are created
+- **AND** placemark names are used as Question names
+- **AND** geometries are converted from KML to Django GeometryField format
+
+### Requirement: Single-shape geometry editor in question modal
+When editing a pressure question through the standard question form modal, the geometries editor panel SHALL show a single-geometry picker (small Leaflet map to draw/edit ONE shape) instead of the v1 multi-shape editor.
+
+#### Scenario: Edit pressure question geometry via modal
+- **GIVEN** a pressure question "Main Stage" with a point geometry
+- **WHEN** the editor user opens the question edit modal
+- **THEN** a small Leaflet map shows the existing point
+- **AND** the user can click to move/redraw the point
+- **AND** on save, the `geometry` field is updated
+
+#### Scenario: Create pressure question via modal (without map editor)
+- **WHEN** the editor user creates a new question with `input_type="pressure"` via the standard modal
+- **THEN** a geometry picker appears where they can draw one shape
+- **AND** on save, the Question is created with the drawn geometry
+
+### Requirement: Map editor button on section detail
+The section detail page SHALL show a "Map Editor" button that opens the section-level map editor.
+
+#### Scenario: Map Editor button visible
+- **GIVEN** a section detail page
+- **WHEN** it renders
+- **THEN** a "Map Editor" button is visible alongside the existing "Map Position" button
+- **AND** clicking it opens the section map editor

--- a/openspec/changes/geometry-pressure-v2/tasks.md
+++ b/openspec/changes/geometry-pressure-v2/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: geometry-pressure-v2
+
+## 1. Model & Migration
+
+- [ ] Add `geometry = GeometryField(null=True, blank=True, srid=4326)` to Question model in `survey/models.py`
+- [ ] Run `makemigrations` and verify the migration file
+- [ ] Write data migration: for each Question with `input_type="pressure"` and non-empty `geometries` JSONField, create separate Questions per geometry entry (copy label→name, color, icon_class, geometry via GEOSGeometry), clone sub-questions for each new Question, set original's `geometries=None`
+
+## 2. Form Layer — Respondent Side
+
+- [ ] Update `_get_form_from_input_type()` in `survey/forms.py`: pressure returns a `CharField` with `HiddenInput` widget (`class="pressure-answer-input"`), not `PressureField`/`PressureButtonWidget`
+- [ ] Remove or deprecate `PressureButtonWidget` and `PressureField` classes (no longer used)
+- [ ] Remove `pressure_button.html` template (no longer used)
+
+## 3. View — GET (Context for Respondent)
+
+- [ ] In `survey_section` GET in `survey/views.py`, build `pressure_questions` list: for each question with `input_type="pressure"` and non-null `geometry`, serialize `code`, `name`, `subtext`, `color`, `icon_class`, `geometry.geojson`, `image.url`
+- [ ] Pass `pressure_questions_json` (JSON-serialized) to template context
+- [ ] Update `existing_geo_answers` for pressure: remove `geometry_id` from feature properties, each pressure question produces at most one feature keyed by question code
+
+## 4. Respondent JavaScript
+
+- [ ] In `base_survey_template.html` / `survey_section.html`: on map init, parse `pressure_questions_json`, create Leaflet layers (marker for Point, polyline for LineString, polygon for Polygon) in a non-editable `pressureLayerGroup`, set opacity 0.5
+- [ ] Add click handler on each pressure layer: open popup with `subquestions_forms[questionCode]`, unique form ID per question code
+- [ ] Add popup open/close handlers: populate form fields from `layer.feature.properties` on open, serialize back on close/apply
+- [ ] Add visual feedback: track answered shapes in `pressureAnswered` Set, update opacity to 1.0 + checkmark on answered
+- [ ] Add form submission handler: for each answered pressure question, serialize geometry + sub-question properties as GeoJSON, set hidden `pressure-answer-input` field value
+- [ ] Add existing answer restoration: parse `existing_geo_answers` for pressure question codes, find matching pressure layers, copy properties, mark as answered
+
+## 5. View — POST (Answer Saving)
+
+- [ ] Update pressure POST handler in `survey_section` in `survey/views.py`: for each pressure question, check hidden input for data, parse JSON, upsert parent Answer (set geometry in point/line/polygon field from Question.geometry), create/update child Answers for sub-questions
+- [ ] Remove `geometry_id` usage from new pressure answer saving logic
+
+## 6. Editor — Section Map Editor (Backend)
+
+- [ ] Add URL patterns in `survey/urls.py`: `editor_section_map_editor`, `editor_pressure_create`, `editor_pressure_update`, `editor_pressure_delete`, `editor_pressure_bulk_subquestion`, `editor_pressure_import`
+- [ ] Implement `editor_section_map_editor` view (GET): render map editor template with `pressure_questions_json` for the section
+- [ ] Implement `editor_pressure_create` view (POST): receive GeoJSON geometry + name/color/icon_class, create Question with `input_type="pressure"`, auto-assign order_number, return updated shape list partial
+- [ ] Implement `editor_pressure_update` view (POST): update name/color/icon_class/geometry on existing pressure Question, return updated shape list item partial
+- [ ] Implement `editor_pressure_delete` view (POST): delete pressure Question (cascade), return updated shape list partial
+- [ ] Implement `editor_pressure_bulk_subquestion` view (POST): receive list of question IDs + sub-question definition, create sub-question for each selected Question, return updated shape list partial
+- [ ] Implement `editor_pressure_import` view (POST): receive uploaded GeoJSON or KML file, parse features, create one Question per feature with geometry and mapped properties, return updated shape list partial
+
+## 7. Editor — Section Map Editor (Frontend)
+
+- [ ] Create template `editor/partials/section_map_editor.html`: fullscreen modal with Leaflet map (left) + shape list panel (right) + import/bulk action buttons
+- [ ] Add Leaflet Draw controls (point, line, polygon) on the map editor, on `draw:created` POST to `editor_pressure_create` via HTMX
+- [ ] Add shape list with checkboxes, inline edit fields (name, color, icon picker), edit/delete buttons per shape
+- [ ] Add "Select All" / "Deselect All" toggle, selected count display
+- [ ] Add bulk action buttons: "Add sub-question to selected" → opens sub-question form modal, on save POST to `editor_pressure_bulk_subquestion`; "Delete selected" → POST to `editor_pressure_delete` for each
+- [ ] Add import button: file picker for GeoJSON/KML, on file select POST to `editor_pressure_import`
+- [ ] Load existing pressure questions on editor open: render shapes on map and populate shape list
+
+## 8. Editor — Question Modal Update
+
+- [ ] Update `question_form_modal.html`: replace multi-shape geometries editor with single-geometry picker (small Leaflet map to draw ONE shape) when `input_type="pressure"`
+- [ ] Update hidden input from `geometries_json` to `geometry_json` (single GeoJSON geometry object)
+- [ ] Update `editor_question_create` and `editor_question_edit` in `editor_views.py`: parse `geometry_json`, convert to `GEOSGeometry`, save to `question.geometry`
+
+## 9. Editor — Section Detail Integration
+
+- [ ] Add "Map Editor" button to `section_detail_form.html` that opens the section map editor (HTMX GET to `editor_section_map_editor`)
+- [ ] Add map editor modal container to the editor base template
+
+## 10. Data Export
+
+- [ ] Update `download_data` GeoJSON export: for pressure questions, add `shape_label` (from question.name) to feature properties instead of `geometry_id`/`geometry_label`
+- [ ] Update `download_data` CSV export: include pressure sub-question answers with `question_code` and `question_name` columns
+
+## 11. Serialization
+
+- [ ] Update `_serialize_question()` in `survey/serialization.py`: add `"geometry": json.loads(question.geometry.geojson)` when geometry is not None
+- [ ] Update question import: parse `geometry` field via `GEOSGeometry(json.dumps(geom_data), srid=4326)`
+- [ ] Add backward compat: if imported question has `geometries` array (v1 format), expand into separate Questions
+- [ ] Remove `geometry_id` from `_serialize_answer()` (deprecated)
+
+## 12. CSS
+
+- [ ] Add/update `.pressure-shape-unanswered` (opacity 0.5) and `.pressure-shape-answered` (opacity 1.0) styles
+- [ ] Add section map editor styles: layout for map + shape list panel, shape row styling, bulk action bar
+- [ ] Add single-geometry picker styles for question modal
+
+## 13. Tests
+
+- [ ] Model test: create Question with `input_type="pressure"` and `geometry=Point(...)`, verify save/retrieve
+- [ ] Model test: verify `geo_questions()` includes pressure questions with geometry
+- [ ] View test: POST pressure answer for a pressure Question, verify Answer created with correct geo field, no geometry_id
+- [ ] View test: GET section with existing pressure answers, verify `existing_geo_answers` and `pressure_questions_json` in context
+- [ ] View test: upsert — POST same pressure Question twice, verify single Answer updated
+- [ ] Editor test: POST to `editor_pressure_create` with GeoJSON geometry, verify Question created
+- [ ] Editor test: POST to `editor_pressure_import` with GeoJSON file, verify Questions created per feature
+- [ ] Editor test: POST to `editor_pressure_bulk_subquestion`, verify sub-questions created for selected Questions
+- [ ] Export test: export survey with pressure answers, verify GeoJSON contains `shape_label`
+- [ ] Serialization test: export/import round-trip preserves `geometry` on Question
+- [ ] Migration test: verify data migration converts v1 `geometries` JSONField to separate Questions

--- a/openspec/changes/geometry-pressure/.openspec.yaml
+++ b/openspec/changes/geometry-pressure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/geometry-pressure/design.md
+++ b/openspec/changes/geometry-pressure/design.md
@@ -1,0 +1,345 @@
+# Design: geometry-pressure
+
+## Overview
+
+Add a `pressure` question type that renders survey-creator-defined geometries on the Leaflet map and lets respondents click them to interact via sub-question popups. Reuses the existing sub-question / parent-answer hierarchy — no new content models needed.
+
+## Model Changes
+
+### Question model (`survey/models.py`)
+
+1. Add `("pressure", _("Geometry Pressure"))` to `INPUT_TYPE_CHOICES` (after `"html"`).
+
+2. Add field:
+   ```python
+   geometries = models.JSONField(null=True, blank=True)
+   ```
+   Schema: list of shape objects:
+   ```json
+   [
+     {
+       "id": "uuid-string",
+       "geometry": { "type": "Point", "coordinates": [30.3, 59.9] },
+       "label": "Main Stage",
+       "color": "#ff0000",
+       "icon_class": "fas fa-music"
+     }
+   ]
+   ```
+   The `id` is a UUID4 string generated client-side in the editor when a shape is drawn. It is the stable key for linking answers to shapes.
+
+3. Update `geo_questions()` on SurveyHeader to also include `pressure`:
+   ```python
+   def geo_questions(self):
+       return Question.objects.filter(
+           survey_section__survey_header=self,
+           input_type__in=['point', 'line', 'polygon', 'pressure']
+       )
+   ```
+
+### Answer model (`survey/models.py`)
+
+Add field:
+```python
+geometry_id = models.CharField(max_length=50, null=True, blank=True)
+```
+
+This links an answer (and its child sub-answers) to a specific predefined shape. For non-pressure questions it stays `None`.
+
+### Migration
+
+Single migration adding `Question.geometries` and `Answer.geometry_id`. Both nullable — no data migration needed.
+
+## Form Layer (`survey/forms.py`)
+
+### New widget: `PressureButtonWidget`
+
+Subclass of `LeafletDrawButtonWidget`. Template: `pressure_button.html`. Differences from draw-button widgets:
+- No draw-type attribute — no L.Draw handler needed.
+- Button labeled with a tap/click icon (`fas fa-hand-pointer`) instead of a draw icon.
+- Renders a hidden `<input>` with class `geo-inp` (same as existing geo widgets) to participate in form submission.
+- Carries `data-geometries='{{ widget.geometries|escapejs }}'` attribute — the JSON array of predefined shapes — so JavaScript can render them.
+
+### New field: `PressureField`
+
+Subclass of `LeafletDrawButtonField`. Adds a `geometries` parameter (the JSON array) passed through to the widget via `widget_attrs`.
+
+### `_get_form_from_input_type()` addition
+
+```python
+elif input_type == 'pressure':
+    return PressureField(
+        title=title, subtitle=subtitle,
+        color=color, icon_class=icon_class,
+        draw_icon_class='fas fa-hand-pointer',
+        geometries=json.dumps(question.geometries or []),
+        widget=PressureButtonWidget, required=False,
+    )
+```
+
+## Template: `pressure_button.html`
+
+Identical layout to `leaflet_draw_button.html` but:
+- CSS class: `pressurebutton` instead of `drawbutton`.
+- Draw-icon slot shows `fas fa-hand-pointer`.
+- Hidden `<input class="geo-inp">` with `name="{{ widget.name }}"`.
+- `data-geometries` attribute on button carrying the shapes JSON.
+- No `draw-type` attribute.
+
+## JavaScript — Respondent Side (`base_survey_template.html` / `survey_section.html`)
+
+### Shape rendering on map load
+
+After map init, find all `.pressurebutton` elements. For each:
+
+1. Parse `data-geometries` JSON.
+2. For each shape, create a Leaflet layer:
+   - **Point** → `L.marker` with `L.icon.fontAwesome` using shape's `color` and `icon_class`.
+   - **LineString** → `L.polyline` with `color`.
+   - **Polygon** → `L.polygon` with `color` for stroke, `color + "30"` for fill.
+3. Add layers to a dedicated `L.featureGroup` per question (not to `editableLayers` — these are non-editable).
+4. Store `layer.feature = { type: "Feature", geometry: shape.geometry, properties: { question_id: questionCode, geometry_id: shape.id } }`.
+5. Set initial style: reduced opacity (0.5) for unanswered shapes.
+
+### Click handler → popup
+
+Each predefined layer gets an `on('click')` handler:
+1. Read `questionCode` and `geometry_id` from `layer.feature.properties`.
+2. Build popup HTML using `subquestions_forms[questionCode]` (the pre-rendered sub-question form, same as existing geo popups).
+3. Give the form a unique ID: `subquestion_form_<geometry_id>` (consistent with marker-popup-isolation spec).
+4. Bind popup to layer and open it.
+5. On popup open: populate form fields from `layer.feature.properties` (same `onPopupOpen` logic).
+6. On popup close / apply: serialize form data back into `layer.feature.properties` (same `onPopupClose` pattern). Mark shape as answered.
+
+### Visual feedback
+
+Answered shapes: full opacity (1.0), add CSS class `pressure-answered`. For point markers, swap to a checkmark-badged icon variant (add a small `✓` overlay div inside the marker's icon div).
+
+Unanswered shapes: opacity 0.5, muted appearance.
+
+Tracked via a `pressureAnswered` Set per question, keyed by `geometry_id`.
+
+### Form submission
+
+On `$('#section_question_form').submit()`:
+1. For each pressure question's featureGroup, iterate layers.
+2. For layers that have been answered (properties have sub-question data), serialize to GeoJSON and append to the hidden `geo-inp` field as pipe-delimited strings (same format as existing geo questions).
+3. Each GeoJSON feature includes `geometry_id` in `properties`.
+
+This means the existing POST handler in `views.py` will receive pressure data in the same pipe-delimited GeoJSON format as point/line/polygon.
+
+### Restoring existing answers
+
+In the `existingGeoAnswers` restoration loop, detect pressure questions (check if `.pressurebutton` exists for that question code). Instead of creating new layers, match each existing feature to a predefined shape by `geometry_id`:
+1. Find the predefined layer with matching `geometry_id`.
+2. Copy properties from the existing answer into the layer's `feature.properties`.
+3. Mark as answered (visual update).
+
+## View Layer (`survey/views.py`)
+
+### POST — saving pressure answers
+
+The existing geo-save block (`if question.input_type in ['point', 'line', 'polygon']`) extends to include `'pressure'`:
+
+```python
+if question.input_type in ['point', 'line', 'polygon', 'pressure']:
+```
+
+Inside the loop, for pressure questions, determine the geometry type from the GeoJSON feature's `geometry.type`:
+- `"Point"` → `answer.point = resultToSave`
+- `"LineString"` → `answer.line = resultToSave`
+- `"Polygon"` → `answer.polygon = resultToSave`
+
+Additionally, extract `geometry_id` from `gj['properties']['geometry_id']` and set `answer.geometry_id = geometry_id`.
+
+For sub-answer creation, also propagate `geometry_id`:
+```python
+sub_answer.geometry_id = geometry_id
+```
+
+**Upsert logic**: Before creating a new Answer for a pressure shape, check if an Answer with the same `(survey_session, question, geometry_id)` already exists. If so, update it rather than creating a duplicate. This handles the "edit and re-apply" flow.
+
+### GET — building existing_geo_answers
+
+The existing block for geo questions extends to include `pressure`. The code already builds GeoJSON features with properties — just ensure `geometry_id` is included:
+
+```python
+feature['properties']['geometry_id'] = answer.geometry_id
+```
+
+### Context: `pressure_geometries`
+
+Pass an additional template variable `pressure_geometries_json` — a dict mapping question codes to their `geometries` JSON arrays. This is used by JS to render predefined shapes:
+
+```python
+pressure_geometries = {}
+for question in questions:
+    if question.input_type == 'pressure' and question.geometries:
+        pressure_geometries[question.code] = question.geometries
+```
+
+Alternatively, this data can be carried on the widget's `data-geometries` attribute (see Form Layer above). Using the widget attribute is simpler — no extra context variable needed. **Decision: use widget attribute.**
+
+## Editor — Geometry Drawing Panel
+
+### Editor views (`survey/editor_views.py`)
+
+In `editor_question_create` and `editor_question_edit`, after saving the question and processing `choices_json`, add processing for `geometries_json`:
+
+```python
+geometries_json = request.POST.get('geometries_json', '').strip()
+if geometries_json:
+    question.geometries = json.loads(geometries_json)
+    question.save()
+elif question.input_type == 'pressure':
+    question.geometries = []
+    question.save()
+```
+
+No new URL endpoints needed — the existing create/edit endpoints handle it.
+
+### Editor template (`question_form_modal.html`)
+
+Add a `geometries-editor` div (analogous to `choices-editor`) that is shown/hidden based on `input_type == "pressure"`:
+
+```html
+<div class="geometries-editor" id="geometries-editor" style="display:none;">
+    <label>Predefined Shapes</label>
+    <div id="geometries-map" style="height:300px;"></div>
+    <div id="geometries-list"></div>
+    <button type="button" class="btn btn-sm btn-outline-secondary" id="add-shape-btn">
+        <i class="fas fa-plus"></i> Draw Shape
+    </button>
+</div>
+<input type="hidden" name="geometries_json" id="geometries-json-input">
+```
+
+JavaScript (inline in the template, same pattern as choices editor):
+1. Init a Leaflet map in `#geometries-map` when `input_type` changes to `pressure`.
+2. Add L.Draw controls (marker, polyline, polygon).
+3. On `draw:created`: generate a UUID, add to shapes list, render in `#geometries-list` with fields for label, color (using the existing color input pattern), icon_class (using the existing icon picker pattern).
+4. On save: serialize shapes array to `#geometries-json-input`.
+5. On edit of existing question: load `question.geometries` into the map and list.
+
+Each shape row in `#geometries-list`:
+```
+[icon] [label input] [color input] [icon picker] [delete btn]
+```
+
+## Data Export (`survey/views.py` — `download_data`)
+
+### GeoJSON export
+
+The `download_data` view already iterates `geo_questions()`. Since `geo_questions()` now includes pressure, pressure answers will be exported. The geometry extraction needs a type-dispatch for pressure (since `question.input_type == "pressure"` doesn't directly tell us point/line/polygon):
+
+```python
+if geo_type == "pressure":
+    if answer.point:
+        coordinates = [answer.point.coords[0], answer.point.coords[1]]
+        geometry_type = "Point"
+    elif answer.line:
+        coordinates = [[i[0], i[1]] for i in answer.line.coords]
+        geometry_type = "LineString"
+    elif answer.polygon:
+        coordinates = [[[i[0], i[1]] for i in answer.polygon.coords[0]]]
+        geometry_type = "Polygon"
+```
+
+Add `geometry_id` and `geometry_label` to properties:
+```python
+if answer.geometry_id and question.geometries:
+    properties['geometry_id'] = answer.geometry_id
+    shape = next((s for s in question.geometries if s['id'] == answer.geometry_id), None)
+    if shape:
+        properties['geometry_label'] = shape.get('label', '')
+```
+
+### CSV export
+
+The CSV block currently skips geo questions (`else: continue`). Add pressure sub-question answers to the CSV:
+- For each session's answers, if the answer's question is a pressure sub-question (has `geometry_id`), include it with columns `geometry_id` and `geometry_label`.
+
+## Serialization (`survey/serialization.py`)
+
+### Question serialization
+
+Add `"geometries"` to `_serialize_question()`:
+```python
+data["geometries"] = question.geometries
+```
+
+### Question import
+
+In the import function, when creating a Question from JSON, set `geometries`:
+```python
+question.geometries = q_data.get("geometries")
+```
+
+### Answer serialization
+
+Add `"geometry_id"` to `_serialize_answer()`:
+```python
+data["geometry_id"] = answer.geometry_id
+```
+
+### Answer import
+
+When creating an Answer from JSON, set:
+```python
+answer.geometry_id = a_data.get("geometry_id")
+```
+
+### Validation
+
+Add `"pressure"` to `VALID_INPUT_TYPES` — this happens automatically since it's derived from `INPUT_TYPE_CHOICES`.
+
+## Static Assets
+
+### CSS additions (`survey/static/survey/css/`)
+
+```css
+.pressurebutton {
+    /* Same base styling as .drawbutton */
+}
+.pressure-shape-unanswered { opacity: 0.5; }
+.pressure-shape-answered { opacity: 1.0; }
+.pressure-answered-badge {
+    /* Small checkmark overlay on answered point markers */
+}
+```
+
+### Editor CSS
+
+```css
+.geometries-editor { /* Layout for shape list + map */ }
+.geometry-row { /* Per-shape row with label/color/icon fields */ }
+```
+
+## Testing
+
+### Model tests
+- Create Question with `input_type="pressure"` and `geometries` JSON — verify save/retrieve.
+- Create Answer with `geometry_id` — verify save/retrieve.
+- Verify `geo_questions()` includes pressure questions.
+
+### View tests
+- POST pipe-delimited GeoJSON with `geometry_id` in properties → verify Answer created with correct geo field and `geometry_id`.
+- GET section with existing pressure answers → verify `existing_geo_answers` includes them with `geometry_id`.
+- Upsert: POST same `geometry_id` twice → verify single Answer (updated, not duplicated).
+
+### Export tests
+- Export survey with pressure answers → verify GeoJSON contains `geometry_id` and `geometry_label`.
+
+### Serialization tests
+- Export/import round-trip preserves `geometries` on Question and `geometry_id` on Answer.
+
+## Decisions Log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Geometry data on widget vs context var | Widget `data-geometries` attribute | Simpler — no extra context variable, data travels with the form field |
+| Shape ID format | UUID4 string, generated client-side | No server round-trip needed when drawing; stable across export/import |
+| Predefined layers in editableLayers? | No — separate featureGroup per question | Prevents accidental deletion/edit; form submission iterates separately |
+| Geometry type on Answer | Use existing point/line/polygon fields | No new fields needed; dispatch by checking which field is non-null |
+| Upsert vs delete+recreate | Upsert (check existing by geometry_id) | Cleaner; preserves answer IDs for potential analytics |
+| Sub-questions shared across shapes | Yes — same set for all shapes | Consistent with proposal; keeps model simple |

--- a/openspec/changes/geometry-pressure/proposal.md
+++ b/openspec/changes/geometry-pressure/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Currently, geo-questions (point, line, polygon) let respondents **draw** new geometries on the map. This works well for open-ended spatial input ("show us where you walk"), but doesn't support a very common survey pattern: showing **predefined** objects on the map and collecting opinions about each one.
+
+**Use case**: A city is redesigning a park. The survey creator draws park zones on the map — a playground, a walking path, a pond area, a dog park zone. Respondents see these zones on the map, click on one, and answer questions about it ("Do you like this zone?", "Rate its condition", "What would you improve?").
+
+There is no way to do this today without hacking around the existing draw-based geo questions.
+
+## What Changes
+
+- **New `pressure` input type** — a question type where the survey creator defines geometries (points, lines, polygons) on the map, and respondents click on them to provide feedback. Each predefined shape acts as a selectable object with its own sub-questions.
+
+- **Predefined geometries storage** — the Question model gains a `geometries` JSONField that stores an array of predefined shapes, each with: geometry (GeoJSON), label, color, icon, and an ID for answer linkage.
+
+- **Respondent interaction** — on the survey-taking page, predefined shapes are rendered on the map as non-editable Leaflet layers. Clicking a shape opens a popup (or sidebar panel) with sub-questions for that shape. Answers are saved per shape.
+
+- **Editor: geometry drawing tool** — in the survey editor, when creating/editing a `pressure` question, the editor shows a Leaflet map with drawing tools. The creator draws shapes, assigns labels/colors/icons, and manages the list of predefined geometries.
+
+- **Editor: per-shape sub-questions** — sub-questions are defined once at the question level (shared across all shapes), not per-shape. This keeps the model simple — every shape gets the same set of questions.
+
+- **Answer linkage** — each Answer for a pressure question references the specific shape via a `geometry_id` field, connecting the response to the predefined geometry.
+
+- **Data export** — pressure question answers are exported with the geometry ID and shape label, plus GeoJSON for spatial analysis. CSV export includes a column identifying which shape each answer row belongs to.
+
+## Capabilities
+
+### New Capabilities
+
+- `geometry-pressure`: New question type (`pressure`) that displays predefined geometric shapes on the map. Respondents click shapes to answer sub-questions about each one. Supports point, line, and polygon geometries. Geometries stored in Question.geometries JSONField. Answers linked via Answer.geometry_id. Editor provides Leaflet-based drawing interface for defining shapes with labels, colors, and icons.
+
+### Modified Capabilities
+
+- `survey-editor`: Question create/edit form gains a geometry editor panel when input_type is `pressure`. The panel shows a Leaflet map with draw tools (point/line/polygon), a shape list with label/color/icon fields per shape, and preview of how shapes will appear to respondents.
+
+- `survey-serialization`: Export/import must handle the new `geometries` JSONField on Question and `geometry_id` on Answer. GeoJSON export for pressure questions groups features by geometry_id with shape label in properties.
+
+## Impact
+
+- **Models**: `Question` — add `geometries` JSONField (nullable); `Answer` — add `geometry_id` CharField (nullable, stores the predefined shape identifier); `INPUT_TYPE_CHOICES` — add `("pressure", "Geometry Pressure")`
+- **Forms**: `forms.py` — new `PressureWidget` and `PressureField` for the survey-taking form; renders predefined shapes on map with click-to-answer interaction
+- **Views**: `views.py` — pressure answer saving logic (link answers to geometry_id, handle sub-questions per shape); answer loading for GET (reconstruct which shapes have been answered)
+- **Editor views**: `editor_views.py` — geometry editor endpoints for pressure questions (save/load geometries JSON)
+- **Templates**: new `pressure_widget.html` for respondent-facing shape display; editor template/partial for geometry drawing interface
+- **JavaScript**: Leaflet code for rendering non-editable predefined shapes, click handlers to open sub-question popups, visual feedback for answered/unanswered shapes
+- **Serialization**: `serialization.py` — serialize/deserialize `geometries` field and `geometry_id` in answers
+- **Static**: CSS for pressure shape styling, answered/unanswered visual states

--- a/openspec/changes/geometry-pressure/proposal.md
+++ b/openspec/changes/geometry-pressure/proposal.md
@@ -1,22 +1,35 @@
 ## Why
 
-Currently, geo-questions (point, line, polygon) let respondents **draw** new geometries on the map. This works well for open-ended spatial input ("show us where you walk"), but doesn't support a very common survey pattern: showing **predefined** objects on the map and collecting opinions about each one.
+Currently, geo-questions (point, line, polygon) let respondents **draw** new geometries on the map. This works well for open-ended spatial input ("show us where you walk"), but doesn't cover an equally common pattern: **presenting predefined objects on the map** and letting users interact with them — view information, leave feedback, or both.
 
-**Use case**: A city is redesigning a park. The survey creator draws park zones on the map — a playground, a walking path, a pond area, a dog park zone. Respondents see these zones on the map, click on one, and answer questions about it ("Do you like this zone?", "Rate its condition", "What would you improve?").
+This pattern appears across many domains:
+
+- **Festival / event map** — stages, food courts, restrooms, entrances drawn on a venue map. Visitors tap a zone to see the schedule, description, or leave a review.
+- **Park / urban space assessment** — playground, walking paths, pond area, dog park zone. Residents click a zone to rate its condition and suggest improvements.
+- **Campus / facility navigation** — buildings, departments, parking lots. Users click to see info (hours, contacts) and optionally report issues.
+- **Infrastructure audit** — bus stops, road segments, crosswalks. Citizens click to flag problems or rate quality.
+
+The common thread: the survey creator **draws shapes on the map ahead of time**, attaches content (info and/or questions) to each shape, and respondents **click shapes to interact** — not draw their own.
 
 There is no way to do this today without hacking around the existing draw-based geo questions.
 
 ## What Changes
 
-- **New `pressure` input type** — a question type where the survey creator defines geometries (points, lines, polygons) on the map, and respondents click on them to provide feedback. Each predefined shape acts as a selectable object with its own sub-questions.
+- **New `pressure` input type** — a question type where the survey creator defines geometries (points, lines, polygons) on the map. Each shape is a clickable object that can carry **information content** (rich text, images) and/or **sub-questions** (rating, text, choice, etc.). Respondents click shapes to view content and optionally answer questions about each one.
 
-- **Predefined geometries storage** — the Question model gains a `geometries` JSONField that stores an array of predefined shapes, each with: geometry (GeoJSON), label, color, icon, and an ID for answer linkage.
+- **Predefined geometries storage** — the Question model gains a `geometries` JSONField that stores an array of predefined shapes. Each shape has: geometry (GeoJSON), label, description/info HTML, color, icon, and a stable ID for answer linkage.
 
-- **Respondent interaction** — on the survey-taking page, predefined shapes are rendered on the map as non-editable Leaflet layers. Clicking a shape opens a popup (or sidebar panel) with sub-questions for that shape. Answers are saved per shape.
+- **Dual-purpose shapes: info + feedback** — each shape can serve as:
+  - **Info-only** — shows a popup/panel with description, images, schedule (no sub-questions needed)
+  - **Feedback** — shows sub-questions for the user to answer
+  - **Both** — info content at the top, questions below
+  This makes the feature useful for both pure informational maps and survey/feedback scenarios.
 
-- **Editor: geometry drawing tool** — in the survey editor, when creating/editing a `pressure` question, the editor shows a Leaflet map with drawing tools. The creator draws shapes, assigns labels/colors/icons, and manages the list of predefined geometries.
+- **Respondent interaction** — on the survey-taking page, predefined shapes are rendered on the map as non-editable, styled Leaflet layers. Clicking a shape opens a popup or sidebar panel. The panel shows the shape's info content (if any) and sub-questions (if any). Answers are saved per shape. Visual indicators show which shapes have been interacted with.
 
-- **Editor: per-shape sub-questions** — sub-questions are defined once at the question level (shared across all shapes), not per-shape. This keeps the model simple — every shape gets the same set of questions.
+- **Editor: geometry drawing tool** — in the survey editor, when creating/editing a `pressure` question, the editor shows a Leaflet map with drawing tools. The creator draws shapes (points, lines, polygons), and for each shape configures: label, description/info HTML, color, icon.
+
+- **Editor: sub-questions** — sub-questions are defined once at the question level (shared across all shapes), not per-shape. Every shape gets the same set of questions. This keeps the model simple and consistent with existing parent_question/sub-question patterns.
 
 - **Answer linkage** — each Answer for a pressure question references the specific shape via a `geometry_id` field, connecting the response to the predefined geometry.
 
@@ -26,21 +39,21 @@ There is no way to do this today without hacking around the existing draw-based 
 
 ### New Capabilities
 
-- `geometry-pressure`: New question type (`pressure`) that displays predefined geometric shapes on the map. Respondents click shapes to answer sub-questions about each one. Supports point, line, and polygon geometries. Geometries stored in Question.geometries JSONField. Answers linked via Answer.geometry_id. Editor provides Leaflet-based drawing interface for defining shapes with labels, colors, and icons.
+- `geometry-pressure`: New question type (`pressure`) that displays predefined geometric shapes on the map. Each shape carries info content (description, images) and/or sub-questions. Respondents click shapes to view info and answer questions. Supports point, line, and polygon geometries. Geometries stored in Question.geometries JSONField with per-shape label, description, color, icon. Answers linked via Answer.geometry_id. Editor provides Leaflet-based drawing interface for defining and configuring shapes.
 
 ### Modified Capabilities
 
-- `survey-editor`: Question create/edit form gains a geometry editor panel when input_type is `pressure`. The panel shows a Leaflet map with draw tools (point/line/polygon), a shape list with label/color/icon fields per shape, and preview of how shapes will appear to respondents.
+- `survey-editor`: Question create/edit form gains a geometry editor panel when input_type is `pressure`. The panel shows a Leaflet map with draw tools (point/line/polygon), a shape list with label/description/color/icon fields per shape, and preview of how shapes will appear to respondents.
 
 - `survey-serialization`: Export/import must handle the new `geometries` JSONField on Question and `geometry_id` on Answer. GeoJSON export for pressure questions groups features by geometry_id with shape label in properties.
 
 ## Impact
 
-- **Models**: `Question` — add `geometries` JSONField (nullable); `Answer` — add `geometry_id` CharField (nullable, stores the predefined shape identifier); `INPUT_TYPE_CHOICES` — add `("pressure", "Geometry Pressure")`
-- **Forms**: `forms.py` — new `PressureWidget` and `PressureField` for the survey-taking form; renders predefined shapes on map with click-to-answer interaction
+- **Models**: `Question` — add `geometries` JSONField (nullable, stores array of shape objects with geometry, label, description, color, icon, id); `Answer` — add `geometry_id` CharField (nullable, stores the predefined shape identifier); `INPUT_TYPE_CHOICES` — add `("pressure", "Geometry Pressure")`
+- **Forms**: `forms.py` — new `PressureWidget` and `PressureField` for the survey-taking form; renders predefined shapes on map, click opens info + sub-question panel
 - **Views**: `views.py` — pressure answer saving logic (link answers to geometry_id, handle sub-questions per shape); answer loading for GET (reconstruct which shapes have been answered)
-- **Editor views**: `editor_views.py` — geometry editor endpoints for pressure questions (save/load geometries JSON)
-- **Templates**: new `pressure_widget.html` for respondent-facing shape display; editor template/partial for geometry drawing interface
-- **JavaScript**: Leaflet code for rendering non-editable predefined shapes, click handlers to open sub-question popups, visual feedback for answered/unanswered shapes
+- **Editor views**: `editor_views.py` — geometry editor endpoints for pressure questions (save/load geometries JSON, per-shape configuration)
+- **Templates**: new `pressure_widget.html` for respondent-facing shape display with info + questions panel; editor template/partial for geometry drawing and configuration interface
+- **JavaScript**: Leaflet code for rendering non-editable predefined shapes, click handlers to open info/question panels, visual feedback for answered/unanswered shapes
 - **Serialization**: `serialization.py` — serialize/deserialize `geometries` field and `geometry_id` in answers
-- **Static**: CSS for pressure shape styling, answered/unanswered visual states
+- **Static**: CSS for pressure shape styling, info panel layout, answered/unanswered visual states

--- a/openspec/changes/geometry-pressure/proposal.md
+++ b/openspec/changes/geometry-pressure/proposal.md
@@ -9,29 +9,28 @@ This pattern appears across many domains:
 - **Campus / facility navigation** — buildings, departments, parking lots. Users click to see info (hours, contacts) and optionally report issues.
 - **Infrastructure audit** — bus stops, road segments, crosswalks. Citizens click to flag problems or rate quality.
 
-The common thread: the survey creator **draws shapes on the map ahead of time**, attaches content (info and/or questions) to each shape, and respondents **click shapes to interact** — not draw their own.
+The common thread: the survey creator **draws shapes on the map ahead of time**, attaches content to each shape via sub-questions, and respondents **click shapes to interact** — not draw their own.
 
 There is no way to do this today without hacking around the existing draw-based geo questions.
 
 ## What Changes
 
-- **New `pressure` input type** — a question type where the survey creator defines geometries (points, lines, polygons) on the map. Each shape is a clickable object that can carry **information content** (rich text, images) and/or **sub-questions** (rating, text, choice, etc.). Respondents click shapes to view content and optionally answer questions about each one.
+- **New `pressure` input type** — a question type where the survey creator defines geometries (points, lines, polygons) on the map. Each shape is a clickable object. Clicking a shape opens a popup with sub-questions — the same mechanism already used by point/line/polygon questions. All content (informational text, images, feedback forms) is delivered through sub-questions using existing types (`html`, `image`, `text`, `rating`, `choice`, etc.).
 
-- **Predefined geometries storage** — the Question model gains a `geometries` JSONField that stores an array of predefined shapes. Each shape has: geometry (GeoJSON), label, description/info HTML, color, icon, and a stable ID for answer linkage.
+- **Predefined geometries storage** — the Question model gains a `geometries` JSONField that stores an array of predefined shapes. Each shape has: geometry (GeoJSON), label, color, icon, and a stable ID for answer linkage.
 
-- **Dual-purpose shapes: info + feedback** — each shape can serve as:
-  - **Info-only** — shows a popup/panel with description, images, schedule (no sub-questions needed)
-  - **Feedback** — shows sub-questions for the user to answer
-  - **Both** — info content at the top, questions below
-  This makes the feature useful for both pure informational maps and survey/feedback scenarios.
+- **No new content model — sub-questions handle everything** — whether a shape needs to show a festival schedule (`html` sub-question), a photo (`image` sub-question), a rating form (`rating` sub-question), or a comment box (`text` sub-question) — it all works through the existing parent_question → sub-question hierarchy. This means:
+  - Info-only shapes: just add `html`/`image` sub-questions
+  - Feedback shapes: add `rating`/`choice`/`text` sub-questions
+  - Mixed: combine both — info sub-questions appear as read-only content, input sub-questions collect answers
 
-- **Respondent interaction** — on the survey-taking page, predefined shapes are rendered on the map as non-editable, styled Leaflet layers. Clicking a shape opens a popup or sidebar panel. The panel shows the shape's info content (if any) and sub-questions (if any). Answers are saved per shape. Visual indicators show which shapes have been interacted with.
+- **Sub-questions are shared across all shapes** — defined once at the question level, not per-shape. Every shape shows the same popup with the same sub-questions. This keeps the model simple and consistent with existing patterns.
 
-- **Editor: geometry drawing tool** — in the survey editor, when creating/editing a `pressure` question, the editor shows a Leaflet map with drawing tools. The creator draws shapes (points, lines, polygons), and for each shape configures: label, description/info HTML, color, icon.
+- **Respondent interaction** — predefined shapes are rendered on the map as non-editable, styled Leaflet layers. Clicking a shape opens a popup with sub-questions (same UX as existing geo-question popups). Answers are saved per shape via `geometry_id`. Visual indicators show which shapes have been interacted with.
 
-- **Editor: sub-questions** — sub-questions are defined once at the question level (shared across all shapes), not per-shape. Every shape gets the same set of questions. This keeps the model simple and consistent with existing parent_question/sub-question patterns.
+- **Editor: geometry drawing tool** — in the survey editor, when creating/editing a `pressure` question, the editor shows a Leaflet map with drawing tools. The creator draws shapes (points, lines, polygons), and for each shape configures: label, color, icon. Sub-questions are managed through the existing sub-question editor.
 
-- **Answer linkage** — each Answer for a pressure question references the specific shape via a `geometry_id` field, connecting the response to the predefined geometry.
+- **Answer linkage** — each Answer for a pressure sub-question references the specific shape via a `geometry_id` field, connecting the response to the predefined geometry.
 
 - **Data export** — pressure question answers are exported with the geometry ID and shape label, plus GeoJSON for spatial analysis. CSV export includes a column identifying which shape each answer row belongs to.
 
@@ -39,21 +38,21 @@ There is no way to do this today without hacking around the existing draw-based 
 
 ### New Capabilities
 
-- `geometry-pressure`: New question type (`pressure`) that displays predefined geometric shapes on the map. Each shape carries info content (description, images) and/or sub-questions. Respondents click shapes to view info and answer questions. Supports point, line, and polygon geometries. Geometries stored in Question.geometries JSONField with per-shape label, description, color, icon. Answers linked via Answer.geometry_id. Editor provides Leaflet-based drawing interface for defining and configuring shapes.
+- `geometry-pressure`: New question type (`pressure`) that displays predefined geometric shapes on the map. Respondents click shapes to interact via sub-questions (using existing question types for both info and feedback). Supports point, line, and polygon geometries. Geometries stored in Question.geometries JSONField with per-shape label, color, icon. Answers linked via Answer.geometry_id. Editor provides Leaflet-based drawing interface for defining shapes.
 
 ### Modified Capabilities
 
-- `survey-editor`: Question create/edit form gains a geometry editor panel when input_type is `pressure`. The panel shows a Leaflet map with draw tools (point/line/polygon), a shape list with label/description/color/icon fields per shape, and preview of how shapes will appear to respondents.
+- `survey-editor`: Question create/edit form gains a geometry editor panel when input_type is `pressure`. The panel shows a Leaflet map with draw tools (point/line/polygon), a shape list with label/color/icon fields per shape. Sub-questions are managed through the existing sub-question interface.
 
 - `survey-serialization`: Export/import must handle the new `geometries` JSONField on Question and `geometry_id` on Answer. GeoJSON export for pressure questions groups features by geometry_id with shape label in properties.
 
 ## Impact
 
-- **Models**: `Question` — add `geometries` JSONField (nullable, stores array of shape objects with geometry, label, description, color, icon, id); `Answer` — add `geometry_id` CharField (nullable, stores the predefined shape identifier); `INPUT_TYPE_CHOICES` — add `("pressure", "Geometry Pressure")`
-- **Forms**: `forms.py` — new `PressureWidget` and `PressureField` for the survey-taking form; renders predefined shapes on map, click opens info + sub-question panel
+- **Models**: `Question` — add `geometries` JSONField (nullable, stores array of shape objects with geometry, label, color, icon, id); `Answer` — add `geometry_id` CharField (nullable, stores the predefined shape identifier); `INPUT_TYPE_CHOICES` — add `("pressure", "Geometry Pressure")`
+- **Forms**: `forms.py` — new `PressureWidget` and `PressureField` for the survey-taking form; renders predefined shapes on map, click opens sub-question popup
 - **Views**: `views.py` — pressure answer saving logic (link answers to geometry_id, handle sub-questions per shape); answer loading for GET (reconstruct which shapes have been answered)
-- **Editor views**: `editor_views.py` — geometry editor endpoints for pressure questions (save/load geometries JSON, per-shape configuration)
-- **Templates**: new `pressure_widget.html` for respondent-facing shape display with info + questions panel; editor template/partial for geometry drawing and configuration interface
-- **JavaScript**: Leaflet code for rendering non-editable predefined shapes, click handlers to open info/question panels, visual feedback for answered/unanswered shapes
+- **Editor views**: `editor_views.py` — geometry editor endpoints for pressure questions (save/load geometries JSON)
+- **Templates**: new `pressure_widget.html` for respondent-facing shape display; editor template/partial for geometry drawing interface
+- **JavaScript**: Leaflet code for rendering non-editable predefined shapes, click handlers to open sub-question popups, visual feedback for answered/unanswered shapes
 - **Serialization**: `serialization.py` — serialize/deserialize `geometries` field and `geometry_id` in answers
-- **Static**: CSS for pressure shape styling, info panel layout, answered/unanswered visual states
+- **Static**: CSS for pressure shape styling, answered/unanswered visual states

--- a/openspec/changes/geometry-pressure/specs/geometry-pressure/spec.md
+++ b/openspec/changes/geometry-pressure/specs/geometry-pressure/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+### Requirement: Pressure question type registration
+The system SHALL support a new input type `pressure` in `INPUT_TYPE_CHOICES`. The Question model SHALL accept `input_type="pressure"` for questions that display predefined geometries on the map.
+
+#### Scenario: Create a pressure question
+- **WHEN** a question is created with `input_type="pressure"`
+- **THEN** the question is saved successfully and appears in the section's question list
+
+### Requirement: Predefined geometries storage
+The Question model SHALL have a `geometries` JSONField (nullable, blank) that stores an array of predefined shape objects. Each shape object SHALL have the following structure: `{"id": "<stable-uuid>", "geometry": <GeoJSON geometry>, "label": "<string>", "color": "<hex>", "icon_class": "<fa-class>"}`. The `id` field SHALL be a stable identifier used for linking answers to shapes. The `geometry` field SHALL be a GeoJSON geometry object (Point, LineString, or Polygon).
+
+#### Scenario: Question stores point geometries
+- **WHEN** a pressure question has geometries `[{"id": "a1", "geometry": {"type": "Point", "coordinates": [30.3, 59.9]}, "label": "Main Stage", "color": "#ff0000", "icon_class": "fas fa-music"}]`
+- **THEN** the `geometries` JSONField is saved and retrievable with the same structure
+
+#### Scenario: Question stores mixed geometry types
+- **WHEN** a pressure question has geometries containing a Point, a LineString, and a Polygon
+- **THEN** all three are stored and retrievable from the `geometries` field
+
+#### Scenario: Geometries field is optional
+- **WHEN** a non-pressure question is created (e.g., input_type="text")
+- **THEN** the `geometries` field is null and has no effect on the question
+
+### Requirement: Answer linkage to predefined shape
+The Answer model SHALL have a `geometry_id` CharField (max_length=50, nullable, blank) that stores the `id` of the predefined shape the answer relates to. For pressure sub-question answers, `geometry_id` identifies which shape the respondent was interacting with.
+
+#### Scenario: Sub-question answer references a shape
+- **WHEN** a respondent answers a sub-question of a pressure question for shape "a1"
+- **THEN** the Answer is created with `geometry_id="a1"` and `parent_answer_id` set to the pressure question's answer
+
+#### Scenario: Non-pressure answers have null geometry_id
+- **WHEN** a respondent answers a regular text question
+- **THEN** the Answer has `geometry_id=None`
+
+### Requirement: Respondent map rendering of predefined shapes
+On the survey-taking page, when a section contains a pressure question, the system SHALL render all predefined geometries from the question's `geometries` field as non-editable Leaflet layers on the map. Each shape SHALL be styled with its configured `color`. Point shapes SHALL display as colored markers with the configured `icon_class`. Line and polygon shapes SHALL use the configured `color` for stroke/fill.
+
+#### Scenario: Pressure shapes appear on map load
+- **WHEN** a respondent opens a survey section containing a pressure question with 3 predefined shapes
+- **THEN** all 3 shapes are visible on the map as non-editable layers with their configured colors and icons
+
+#### Scenario: Predefined shapes are not draggable or editable
+- **WHEN** a respondent clicks and drags a predefined shape
+- **THEN** the shape does not move or change — only the map pans
+
+#### Scenario: Shapes from multiple pressure questions coexist
+- **WHEN** a section has two pressure questions, each with their own predefined shapes
+- **THEN** all shapes from both questions are displayed on the map simultaneously
+
+### Requirement: Click-to-interact with predefined shapes
+When a respondent clicks a predefined shape on the map, the system SHALL open a popup containing the sub-questions of the pressure question (using the same popup mechanism as existing geo questions). The popup SHALL be pre-populated with any previously saved answers for that shape.
+
+#### Scenario: Click shape opens sub-question popup
+- **WHEN** a respondent clicks on predefined shape "Main Stage"
+- **THEN** a popup opens showing all sub-questions of the pressure question (e.g., rating, text comment, html info)
+
+#### Scenario: Popup shows previously saved answers
+- **WHEN** a respondent has previously answered sub-questions for shape "a1" and clicks on shape "a1" again
+- **THEN** the popup fields are pre-populated with the saved answers
+
+#### Scenario: Different shapes maintain independent answers
+- **WHEN** a respondent rates shape "a1" as 5 and shape "a2" as 3
+- **THEN** opening shape "a1" popup shows rating 5, and opening shape "a2" popup shows rating 3
+
+### Requirement: Visual feedback for interacted shapes
+The system SHALL visually distinguish shapes that the respondent has interacted with (submitted answers for) from shapes that have not been interacted with. Interacted shapes SHALL have a distinct visual style (e.g., increased opacity, checkmark icon, or border change).
+
+#### Scenario: Unanswered shape appearance
+- **WHEN** a respondent has not yet clicked on a shape
+- **THEN** the shape is displayed with reduced opacity or a muted style
+
+#### Scenario: Answered shape appearance
+- **WHEN** a respondent has submitted answers for a shape
+- **THEN** the shape's visual style changes to indicate completion (e.g., full opacity, checkmark overlay)
+
+### Requirement: Pressure answer saving
+When a respondent submits answers in a shape's popup, the system SHALL save one Answer per sub-question, each with `geometry_id` set to the shape's `id`. The parent Answer for the pressure question itself SHALL also be created with the shape's geometry stored in the appropriate geo field (point/line/polygon based on shape type).
+
+#### Scenario: Save answers for a point shape
+- **WHEN** a respondent fills sub-questions in the popup for a Point shape "a1" and applies
+- **THEN** an Answer is created for the pressure question with `point` set to the shape's coordinates and `geometry_id="a1"`, and child Answers are created for each sub-question with `geometry_id="a1"`
+
+#### Scenario: Save answers for a polygon shape
+- **WHEN** a respondent fills sub-questions for a Polygon shape "b2" and applies
+- **THEN** an Answer is created for the pressure question with `polygon` set to the shape's geometry and `geometry_id="b2"`, and child Answers are created for each sub-question with `geometry_id="b2"`
+
+#### Scenario: Update previously saved answers for a shape
+- **WHEN** a respondent re-opens shape "a1" popup, changes the rating, and applies
+- **THEN** the existing Answer records for shape "a1" are updated (not duplicated)
+
+### Requirement: Pressure question in survey form
+The `SurveySectionAnswerForm` SHALL handle `input_type="pressure"` by rendering a widget that displays a button/card for the pressure question (similar to existing geo draw buttons) but labeled for interaction rather than drawing. The actual shape rendering and interaction happens via JavaScript on the map.
+
+#### Scenario: Pressure question appears in form
+- **WHEN** a section form is rendered containing a pressure question named "Rate the festival zones"
+- **THEN** a widget is displayed with the question title and subtitle, styled distinctly from draw buttons (no draw icon — uses a tap/click interaction icon instead)
+
+### Requirement: Existing geo answers format for pressure
+The view SHALL include pressure answers in the `existing_geo_answers` context variable. For each pressure question, the format SHALL be the same GeoJSON FeatureCollection structure used by point/line/polygon questions, with each feature's `properties` containing `geometry_id` and sub-question values.
+
+#### Scenario: Pressure answers in existing_geo_answers
+- **WHEN** a respondent revisits a section with a pressure question they previously answered for shapes "a1" and "a2"
+- **THEN** `existing_geo_answers[question_code]` contains a list of GeoJSON features, one per answered shape, each with `geometry_id` in properties alongside sub-question values
+
+## MODIFIED Requirements
+
+### Requirement: Sub-question management for geo and pressure questions
+The system SHALL allow adding, editing, and deleting sub-questions for geo-type questions (point, line, polygon) **and pressure questions**. Sub-questions SHALL have `parent_question_id` set to the parent question.
+
+#### Scenario: Add sub-question to a pressure question
+- **WHEN** the user clicks "Add Sub-question" on a pressure-type question and creates a rating sub-question
+- **THEN** a Question is created with `parent_question_id` set to the pressure question, and it appears nested under the parent in the question list
+
+#### Scenario: Sub-question button on pressure questions
+- **WHEN** the question list shows a "text" question and a "pressure" question
+- **THEN** only the "pressure" question has an "Add Sub-question" button (same as point/line/polygon)
+
+### Requirement: Editor geometry drawing for pressure questions
+The survey editor SHALL display a geometry editor panel when creating or editing a pressure question. The panel SHALL show a Leaflet map with drawing tools (point, line, polygon). The creator SHALL be able to draw shapes on the map, and for each shape configure: label, color, icon_class. The geometries SHALL be serialized to the Question's `geometries` JSONField on save.
+
+#### Scenario: Draw a point shape in editor
+- **WHEN** the editor user draws a point on the map and sets label "Entrance", color "#00ff00", icon "fas fa-door-open"
+- **THEN** a shape object is added to the geometries list with the drawn coordinates, label, color, and icon_class
+
+#### Scenario: Draw a polygon shape in editor
+- **WHEN** the editor user draws a polygon and sets label "Food Court"
+- **THEN** a shape object with the polygon GeoJSON geometry is added to the geometries list
+
+#### Scenario: Edit an existing shape
+- **WHEN** the editor user selects a shape from the list and changes its label from "Entrance" to "Main Entrance"
+- **THEN** the shape's label is updated in the geometries list
+
+#### Scenario: Delete a shape
+- **WHEN** the editor user removes a shape from the list
+- **THEN** the shape is removed from the geometries list and from the map
+
+#### Scenario: Load existing geometries on edit
+- **WHEN** the editor opens a pressure question that already has geometries
+- **THEN** all shapes are displayed on the map and listed in the shape editor panel
+
+### Requirement: Pressure question data export
+The data export (download_data view) SHALL include pressure question answers. GeoJSON files for pressure questions SHALL group features with `geometry_id` and shape `label` in the feature properties. CSV export SHALL include a `geometry_id` column and a `geometry_label` column for pressure answers.
+
+#### Scenario: GeoJSON export includes geometry_id
+- **WHEN** exporting a survey with a pressure question that has answers for 3 shapes
+- **THEN** the GeoJSON file contains 3+ features, each with `geometry_id` and `geometry_label` in properties
+
+#### Scenario: CSV export includes shape identification
+- **WHEN** exporting a survey with pressure answers to CSV
+- **THEN** each row for a pressure sub-question includes `geometry_id` and `geometry_label` columns
+
+### Requirement: Serialization of pressure questions
+Export/import (serialization.py) SHALL serialize the `geometries` JSONField as-is in the question structure. Import SHALL restore geometries. Answer serialization SHALL include `geometry_id` when present.
+
+#### Scenario: Export pressure question structure
+- **WHEN** exporting a survey with a pressure question having 5 predefined shapes
+- **THEN** the exported JSON includes the full `geometries` array in the question object
+
+#### Scenario: Import pressure question with geometries
+- **WHEN** importing a survey JSON containing a pressure question with a `geometries` array
+- **THEN** the Question is created with the `geometries` field populated
+
+#### Scenario: Export pressure answer with geometry_id
+- **WHEN** exporting answer data for a pressure question
+- **THEN** each answer object includes `"geometry_id": "<id>"` alongside existing fields

--- a/openspec/changes/geometry-pressure/tasks.md
+++ b/openspec/changes/geometry-pressure/tasks.md
@@ -2,80 +2,80 @@
 
 ## 1. Model & Migration
 
-- [ ] Add `("pressure", _("Geometry Pressure"))` to `INPUT_TYPE_CHOICES` in `survey/models.py`
-- [ ] Add `geometries = models.JSONField(null=True, blank=True)` to `Question` model
-- [ ] Add `geometry_id = models.CharField(max_length=50, null=True, blank=True)` to `Answer` model
-- [ ] Update `SurveyHeader.geo_questions()` to include `'pressure'` in the `input_type__in` filter
-- [ ] Run `makemigrations` and verify the migration file
+- [x] Add `("pressure", _("Geometry Pressure"))` to `INPUT_TYPE_CHOICES` in `survey/models.py`
+- [x] Add `geometries = models.JSONField(null=True, blank=True)` to `Question` model
+- [x] Add `geometry_id = models.CharField(max_length=50, null=True, blank=True)` to `Answer` model
+- [x] Update `SurveyHeader.geo_questions()` to include `'pressure'` in the `input_type__in` filter
+- [x] Run `makemigrations` and verify the migration file
 
 ## 2. Form & Widget
 
-- [ ] Create `PressureButtonWidget` class in `survey/forms.py` — subclass of `LeafletDrawButtonWidget`, template `pressure_button.html`, adds `geometries` to context
-- [ ] Create `PressureField` class in `survey/forms.py` — subclass of `LeafletDrawButtonField`, accepts `geometries` param, passes to widget via `widget_attrs`
-- [ ] Add `pressure` branch to `_get_form_from_input_type()` returning `PressureField` with `PressureButtonWidget`
-- [ ] Create template `survey/templates/pressure_button.html` — same layout as `leaflet_draw_button.html` but with CSS class `pressurebutton`, `data-geometries` attribute, `fas fa-hand-pointer` icon, hidden `geo-inp` input
+- [x] Create `PressureButtonWidget` class in `survey/forms.py` — subclass of `LeafletDrawButtonWidget`, template `pressure_button.html`, adds `geometries` to context
+- [x] Create `PressureField` class in `survey/forms.py` — subclass of `LeafletDrawButtonField`, accepts `geometries` param, passes to widget via `widget_attrs`
+- [x] Add `pressure` branch to `_get_form_from_input_type()` returning `PressureField` with `PressureButtonWidget`
+- [x] Create template `survey/templates/pressure_button.html` — same layout as `leaflet_draw_button.html` but with CSS class `pressurebutton`, `data-geometries` attribute, `fas fa-hand-pointer` icon, hidden `geo-inp` input
 
 ## 3. Respondent-Side JavaScript
 
-- [ ] Add pressure shape rendering in `base_survey_template.html` — on map init, find `.pressurebutton` elements, parse `data-geometries`, create Leaflet layers (marker/polyline/polygon) in a separate `featureGroup` per question, set initial 0.5 opacity
-- [ ] Add click handler on each predefined layer — open popup with sub-question form (`subquestions_forms[questionCode]`), unique form ID `subquestion_form_<geometry_id>`
-- [ ] Add popup open/close handlers — populate form fields from `layer.feature.properties` on open (reuse `onPopupOpen` pattern), serialize back on close/apply (reuse `onPopupClose` pattern)
-- [ ] Add visual feedback — track answered shapes in `pressureAnswered` Set, update opacity to 1.0 and add checkmark badge on answered shapes
-- [ ] Add form submission handler for pressure — iterate pressure featureGroups, serialize answered layers to pipe-delimited GeoJSON in `geo-inp` hidden input (include `geometry_id` in properties)
+- [x] Add pressure shape rendering in `base_survey_template.html` — on map init, find `.pressurebutton` elements, parse `data-geometries`, create Leaflet layers (marker/polyline/polygon) in a separate `featureGroup` per question, set initial 0.5 opacity
+- [x] Add click handler on each predefined layer — open popup with sub-question form (`subquestions_forms[questionCode]`), unique form ID `subquestion_form_<geometry_id>`
+- [x] Add popup open/close handlers — populate form fields from `layer.feature.properties` on open (reuse `onPopupOpen` pattern), serialize back on close/apply (reuse `onPopupClose` pattern)
+- [x] Add visual feedback — track answered shapes in `pressureAnswered` Set, update opacity to 1.0 and add checkmark badge on answered shapes
+- [x] Add form submission handler for pressure — iterate pressure featureGroups, serialize answered layers to pipe-delimited GeoJSON in `geo-inp` hidden input (include `geometry_id` in properties)
 
 ## 4. Existing Answer Restoration
 
-- [ ] In `survey_section.html` existing geo answers loop, detect pressure questions (check for `.pressurebutton` with matching question code), match features to predefined layers by `geometry_id`, copy properties, mark as answered
+- [x] In `survey_section.html` existing geo answers loop, detect pressure questions (check for `.pressurebutton` with matching question code), match features to predefined layers by `geometry_id`, copy properties, mark as answered
 
 ## 5. View — POST (Answer Saving)
 
-- [ ] Extend geo-save condition in `survey/views.py` `survey_section` POST to include `'pressure'`
-- [ ] For pressure questions, dispatch geometry type from GeoJSON `geometry.type` (Point→answer.point, LineString→answer.line, Polygon→answer.polygon)
-- [ ] Extract `geometry_id` from `gj['properties']['geometry_id']`, set on answer and sub-answers
-- [ ] Add upsert logic: before creating Answer, check for existing Answer with same `(survey_session, question, geometry_id)` — update if found
+- [x] Extend geo-save condition in `survey/views.py` `survey_section` POST to include `'pressure'`
+- [x] For pressure questions, dispatch geometry type from GeoJSON `geometry.type` (Point→answer.point, LineString→answer.line, Polygon→answer.polygon)
+- [x] Extract `geometry_id` from `gj['properties']['geometry_id']`, set on answer and sub-answers
+- [x] Add upsert logic: before creating Answer, check for existing Answer with same `(survey_session, question, geometry_id)` — update if found
 
 ## 6. View — GET (Answer Loading)
 
-- [ ] Extend existing_geo_answers block in `survey/views.py` to include `pressure` in the `input_type in (...)` check
-- [ ] For pressure answers, dispatch geometry field by checking which of `answer.point/line/polygon` is not None
-- [ ] Include `geometry_id` in each feature's `properties`
+- [x] Extend existing_geo_answers block in `survey/views.py` to include `pressure` in the `input_type in (...)` check
+- [x] For pressure answers, dispatch geometry field by checking which of `answer.point/line/polygon` is not None
+- [x] Include `geometry_id` in each feature's `properties`
 
 ## 7. Editor — Geometry Drawing Panel
 
-- [ ] Add `geometries_json` processing in `editor_question_create` and `editor_question_edit` in `survey/editor_views.py` — parse JSON and save to `question.geometries`
-- [ ] Add `geometries-editor` div and `geometries-json-input` hidden field to `question_form_modal.html` — show/hide based on `input_type == "pressure"` (same toggle pattern as `choices-editor`)
-- [ ] Add inline JS in `question_form_modal.html`: init Leaflet map in `#geometries-map`, add L.Draw controls, handle `draw:created` (generate UUID, add shape to list), serialize shapes on save
-- [ ] Add shape list UI in `#geometries-list` — each row has label input, color input, icon picker (reuse existing icon picker pattern), delete button
-- [ ] Load existing `question.geometries` into map and list when editing an existing pressure question
-- [ ] Add `"pressure"` to sub-question-enabled types in the editor (so "Add Sub-question" button appears for pressure questions)
+- [x] Add `geometries_json` processing in `editor_question_create` and `editor_question_edit` in `survey/editor_views.py` — parse JSON and save to `question.geometries`
+- [x] Add `geometries-editor` div and `geometries-json-input` hidden field to `question_form_modal.html` — show/hide based on `input_type == "pressure"` (same toggle pattern as `choices-editor`)
+- [x] Add inline JS in `question_form_modal.html`: init Leaflet map in `#geometries-map`, add L.Draw controls, handle `draw:created` (generate UUID, add shape to list), serialize shapes on save
+- [x] Add shape list UI in `#geometries-list` — each row has label input, color input, icon picker (reuse existing icon picker pattern), delete button
+- [x] Load existing `question.geometries` into map and list when editing an existing pressure question
+- [x] Add `"pressure"` to sub-question-enabled types in the editor (so "Add Sub-question" button appears for pressure questions)
 
 ## 8. Data Export
 
-- [ ] In `download_data` view, add pressure geometry type dispatch — check `answer.point/line/polygon` to determine geometry type and coordinates
-- [ ] Add `geometry_id` and `geometry_label` to GeoJSON feature properties for pressure answers (look up label from `question.geometries`)
-- [ ] Add pressure sub-question answers to CSV export — include `geometry_id` and `geometry_label` columns
+- [x] In `download_data` view, add pressure geometry type dispatch — check `answer.point/line/polygon` to determine geometry type and coordinates
+- [x] Add `geometry_id` and `geometry_label` to GeoJSON feature properties for pressure answers (look up label from `question.geometries`)
+- [x] Add pressure sub-question answers to CSV export — include `geometry_id` and `geometry_label` columns
 
 ## 9. Serialization
 
-- [ ] Add `"geometries": question.geometries` to `_serialize_question()` in `survey/serialization.py`
-- [ ] Add `"geometry_id": answer.geometry_id` to `_serialize_answer()` in `survey/serialization.py`
-- [ ] In question import, set `question.geometries = q_data.get("geometries")`
-- [ ] In answer import, set `answer.geometry_id = a_data.get("geometry_id")`
+- [x] Add `"geometries": question.geometries` to `_serialize_question()` in `survey/serialization.py`
+- [x] Add `"geometry_id": answer.geometry_id` to `_serialize_answer()` in `survey/serialization.py`
+- [x] In question import, set `question.geometries = q_data.get("geometries")`
+- [x] In answer import, set `answer.geometry_id = a_data.get("geometry_id")`
 
 ## 10. CSS
 
-- [ ] Add `.pressurebutton` styles (same base as `.drawbutton`) to survey CSS
-- [ ] Add `.pressure-shape-unanswered` (opacity 0.5) and `.pressure-shape-answered` (opacity 1.0) styles
-- [ ] Add `.pressure-answered-badge` style for checkmark overlay on answered point markers
-- [ ] Add `.geometries-editor` and `.geometry-row` styles for editor geometry panel
+- [x] Add `.pressurebutton` styles (same base as `.drawbutton`) to survey CSS
+- [x] Add `.pressure-shape-unanswered` (opacity 0.5) and `.pressure-shape-answered` (opacity 1.0) styles
+- [x] Add `.pressure-answered-badge` style for checkmark overlay on answered point markers
+- [x] Add `.geometries-editor` and `.geometry-row` styles for editor geometry panel
 
 ## 11. Tests
 
-- [ ] Model test: create Question with `input_type="pressure"` and `geometries` JSON, verify save/retrieve
-- [ ] Model test: create Answer with `geometry_id`, verify save/retrieve
-- [ ] Model test: verify `geo_questions()` includes pressure questions
-- [ ] View test: POST pipe-delimited GeoJSON with `geometry_id` in properties, verify Answer created with correct geo field and `geometry_id`
-- [ ] View test: GET section with existing pressure answers, verify `existing_geo_answers` includes them with `geometry_id`
-- [ ] View test: POST same `geometry_id` twice, verify upsert (single Answer updated, not duplicated)
-- [ ] Export test: export survey with pressure answers, verify GeoJSON contains `geometry_id` and `geometry_label`
-- [ ] Serialization test: export/import round-trip preserves `geometries` on Question and `geometry_id` on Answer
+- [x] Model test: create Question with `input_type="pressure"` and `geometries` JSON, verify save/retrieve
+- [x] Model test: create Answer with `geometry_id`, verify save/retrieve
+- [x] Model test: verify `geo_questions()` includes pressure questions
+- [x] View test: POST pipe-delimited GeoJSON with `geometry_id` in properties, verify Answer created with correct geo field and `geometry_id`
+- [x] View test: GET section with existing pressure answers, verify `existing_geo_answers` includes them with `geometry_id`
+- [x] View test: POST same `geometry_id` twice, verify upsert (single Answer updated, not duplicated)
+- [x] Export test: export survey with pressure answers, verify GeoJSON contains `geometry_id` and `geometry_label`
+- [x] Serialization test: export/import round-trip preserves `geometries` on Question and `geometry_id` on Answer

--- a/openspec/changes/geometry-pressure/tasks.md
+++ b/openspec/changes/geometry-pressure/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: geometry-pressure
+
+## 1. Model & Migration
+
+- [ ] Add `("pressure", _("Geometry Pressure"))` to `INPUT_TYPE_CHOICES` in `survey/models.py`
+- [ ] Add `geometries = models.JSONField(null=True, blank=True)` to `Question` model
+- [ ] Add `geometry_id = models.CharField(max_length=50, null=True, blank=True)` to `Answer` model
+- [ ] Update `SurveyHeader.geo_questions()` to include `'pressure'` in the `input_type__in` filter
+- [ ] Run `makemigrations` and verify the migration file
+
+## 2. Form & Widget
+
+- [ ] Create `PressureButtonWidget` class in `survey/forms.py` — subclass of `LeafletDrawButtonWidget`, template `pressure_button.html`, adds `geometries` to context
+- [ ] Create `PressureField` class in `survey/forms.py` — subclass of `LeafletDrawButtonField`, accepts `geometries` param, passes to widget via `widget_attrs`
+- [ ] Add `pressure` branch to `_get_form_from_input_type()` returning `PressureField` with `PressureButtonWidget`
+- [ ] Create template `survey/templates/pressure_button.html` — same layout as `leaflet_draw_button.html` but with CSS class `pressurebutton`, `data-geometries` attribute, `fas fa-hand-pointer` icon, hidden `geo-inp` input
+
+## 3. Respondent-Side JavaScript
+
+- [ ] Add pressure shape rendering in `base_survey_template.html` — on map init, find `.pressurebutton` elements, parse `data-geometries`, create Leaflet layers (marker/polyline/polygon) in a separate `featureGroup` per question, set initial 0.5 opacity
+- [ ] Add click handler on each predefined layer — open popup with sub-question form (`subquestions_forms[questionCode]`), unique form ID `subquestion_form_<geometry_id>`
+- [ ] Add popup open/close handlers — populate form fields from `layer.feature.properties` on open (reuse `onPopupOpen` pattern), serialize back on close/apply (reuse `onPopupClose` pattern)
+- [ ] Add visual feedback — track answered shapes in `pressureAnswered` Set, update opacity to 1.0 and add checkmark badge on answered shapes
+- [ ] Add form submission handler for pressure — iterate pressure featureGroups, serialize answered layers to pipe-delimited GeoJSON in `geo-inp` hidden input (include `geometry_id` in properties)
+
+## 4. Existing Answer Restoration
+
+- [ ] In `survey_section.html` existing geo answers loop, detect pressure questions (check for `.pressurebutton` with matching question code), match features to predefined layers by `geometry_id`, copy properties, mark as answered
+
+## 5. View — POST (Answer Saving)
+
+- [ ] Extend geo-save condition in `survey/views.py` `survey_section` POST to include `'pressure'`
+- [ ] For pressure questions, dispatch geometry type from GeoJSON `geometry.type` (Point→answer.point, LineString→answer.line, Polygon→answer.polygon)
+- [ ] Extract `geometry_id` from `gj['properties']['geometry_id']`, set on answer and sub-answers
+- [ ] Add upsert logic: before creating Answer, check for existing Answer with same `(survey_session, question, geometry_id)` — update if found
+
+## 6. View — GET (Answer Loading)
+
+- [ ] Extend existing_geo_answers block in `survey/views.py` to include `pressure` in the `input_type in (...)` check
+- [ ] For pressure answers, dispatch geometry field by checking which of `answer.point/line/polygon` is not None
+- [ ] Include `geometry_id` in each feature's `properties`
+
+## 7. Editor — Geometry Drawing Panel
+
+- [ ] Add `geometries_json` processing in `editor_question_create` and `editor_question_edit` in `survey/editor_views.py` — parse JSON and save to `question.geometries`
+- [ ] Add `geometries-editor` div and `geometries-json-input` hidden field to `question_form_modal.html` — show/hide based on `input_type == "pressure"` (same toggle pattern as `choices-editor`)
+- [ ] Add inline JS in `question_form_modal.html`: init Leaflet map in `#geometries-map`, add L.Draw controls, handle `draw:created` (generate UUID, add shape to list), serialize shapes on save
+- [ ] Add shape list UI in `#geometries-list` — each row has label input, color input, icon picker (reuse existing icon picker pattern), delete button
+- [ ] Load existing `question.geometries` into map and list when editing an existing pressure question
+- [ ] Add `"pressure"` to sub-question-enabled types in the editor (so "Add Sub-question" button appears for pressure questions)
+
+## 8. Data Export
+
+- [ ] In `download_data` view, add pressure geometry type dispatch — check `answer.point/line/polygon` to determine geometry type and coordinates
+- [ ] Add `geometry_id` and `geometry_label` to GeoJSON feature properties for pressure answers (look up label from `question.geometries`)
+- [ ] Add pressure sub-question answers to CSV export — include `geometry_id` and `geometry_label` columns
+
+## 9. Serialization
+
+- [ ] Add `"geometries": question.geometries` to `_serialize_question()` in `survey/serialization.py`
+- [ ] Add `"geometry_id": answer.geometry_id` to `_serialize_answer()` in `survey/serialization.py`
+- [ ] In question import, set `question.geometries = q_data.get("geometries")`
+- [ ] In answer import, set `answer.geometry_id = a_data.get("geometry_id")`
+
+## 10. CSS
+
+- [ ] Add `.pressurebutton` styles (same base as `.drawbutton`) to survey CSS
+- [ ] Add `.pressure-shape-unanswered` (opacity 0.5) and `.pressure-shape-answered` (opacity 1.0) styles
+- [ ] Add `.pressure-answered-badge` style for checkmark overlay on answered point markers
+- [ ] Add `.geometries-editor` and `.geometry-row` styles for editor geometry panel
+
+## 11. Tests
+
+- [ ] Model test: create Question with `input_type="pressure"` and `geometries` JSON, verify save/retrieve
+- [ ] Model test: create Answer with `geometry_id`, verify save/retrieve
+- [ ] Model test: verify `geo_questions()` includes pressure questions
+- [ ] View test: POST pipe-delimited GeoJSON with `geometry_id` in properties, verify Answer created with correct geo field and `geometry_id`
+- [ ] View test: GET section with existing pressure answers, verify `existing_geo_answers` includes them with `geometry_id`
+- [ ] View test: POST same `geometry_id` twice, verify upsert (single Answer updated, not duplicated)
+- [ ] Export test: export survey with pressure answers, verify GeoJSON contains `geometry_id` and `geometry_label`
+- [ ] Serialization test: export/import round-trip preserves `geometries` on Question and `geometry_id` on Answer

--- a/survey/assets/css/main.css
+++ b/survey/assets/css/main.css
@@ -492,6 +492,44 @@ ul {
   margin-bottom: 0px;
 }
 
+/* Pressure question button */
+.pressurebutton {
+  margin-bottom: 12px;
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.pressurebutton:hover {
+  background: var(--card-hover);
+  border-color: rgba(79, 70, 229, 0.2);
+  box-shadow: var(--shadow-sm);
+}
+
+.pressurebutton:active {
+  transform: scale(0.985);
+}
+
+.pressurebutton p {
+  margin-bottom: 0px;
+}
+
+/* Geometries editor in question form modal */
+.geometries-editor {
+  margin-top: 1rem;
+}
+
+.geometry-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
 /* Geo Question layout inside button */
 .geo-question {
   display: flex;

--- a/survey/editor_views.py
+++ b/survey/editor_views.py
@@ -302,6 +302,12 @@ def editor_question_create(request, survey_uuid, section_id):
             choices_json = request.POST.get('choices_json', '').strip()
             if choices_json:
                 question.choices = json.loads(choices_json)
+            # Handle geometries for pressure questions
+            geometries_json = request.POST.get('geometries_json', '').strip()
+            if geometries_json:
+                question.geometries = json.loads(geometries_json)
+            elif question.input_type == 'pressure':
+                question.geometries = []
             question.save()
             _save_question_translations(request, question, survey)
             response = render(request, 'editor/partials/question_list_item.html', {
@@ -339,6 +345,12 @@ def editor_question_edit(request, survey_uuid, question_id):
                 q.choices = json.loads(choices_json)
             elif q.input_type not in ('choice', 'multichoice', 'range', 'rating'):
                 q.choices = None
+            # Handle geometries for pressure questions
+            geometries_json = request.POST.get('geometries_json', '').strip()
+            if geometries_json:
+                q.geometries = json.loads(geometries_json)
+            elif q.input_type != 'pressure':
+                q.geometries = None
             q.save()
             _save_question_translations(request, q, survey)
             response = render(request, 'editor/partials/question_list_item.html', {

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -89,12 +89,12 @@ class PressureButtonWidget(LeafletDrawButtonWidget):
     def __init__(self, attrs=None):
         if attrs is not None:
             attrs = attrs.copy()
-            self.geometries = attrs.pop('geometries', '[]')
+            attrs.pop('geometries', None)
         super().__init__(attrs)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
-        context['widget']['geometries'] = self.geometries
+        context['widget']['geometries'] = context['widget']['attrs'].get('geometries', '[]')
         return context
 
 

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -3,6 +3,7 @@ from django.forms import widgets
 from .models import SurveySection, Question, Answer, INPUT_TYPE_CHOICES, SurveySession
 from django.utils import html
 import logging
+import json
 from django import forms
 from django.utils.safestring import mark_safe
 import re
@@ -81,6 +82,21 @@ class PolygonDrawButtonWidget(LeafletDrawButtonWidget):
     draw_type = 'drawpolygon'
     template_name = 'polygon_draw_button.html'
 
+class PressureButtonWidget(LeafletDrawButtonWidget):
+    draw_type = 'pressure'
+    template_name = 'pressure_button.html'
+
+    def __init__(self, attrs=None):
+        if attrs is not None:
+            attrs = attrs.copy()
+            self.geometries = attrs.pop('geometries', '[]')
+        super().__init__(attrs)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['widget']['geometries'] = self.geometries
+        return context
+
 
 class ShowImageWidget(widgets.Widget):
     template_name = 'show_image.html'
@@ -117,6 +133,17 @@ class LeafletDrawButtonField(forms.Field):
         attrs['draw_icon_class'] = self.draw_icon_class
 
         return attrs
+
+class PressureField(LeafletDrawButtonField):
+    def __init__(self, *, geometries='[]', **kwargs):
+        self.geometries = geometries
+        super().__init__(**kwargs)
+
+    def widget_attrs(self, widget):
+        attrs = super().widget_attrs(widget)
+        attrs['geometries'] = self.geometries
+        return attrs
+
 
 class ShowImageField(forms.Field):
     def __init__(self, *, image_source, **kwargs):
@@ -186,6 +213,16 @@ class SurveySectionAnswerForm(forms.Form):
 
         elif input_type == "html":
             return HTMLField(widget=HTMLTextWidget, label=False, title = label, subtitle=sublabel)
+
+        elif input_type == 'pressure':
+            return PressureField(
+                widget=PressureButtonWidget, label=False,
+                title=label, subtitle=sublabel,
+                color=color, icon_class=icon_class,
+                draw_icon_class='fas fa-hand-pointer',
+                geometries=json.dumps(question.geometries or []),
+                required=False,
+            )
         else:
             return forms.CharField(widget=forms.Textarea)
     

--- a/survey/migrations/0015_question_geometries_answer_geometry_id.py
+++ b/survey/migrations/0015_question_geometries_answer_geometry_id.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0014_finalize_org_slug_nonnull'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='question',
+            name='geometries',
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='answer',
+            name='geometry_id',
+            field=models.CharField(blank=True, max_length=50, null=True),
+        ),
+        migrations.AlterField(
+            model_name='question',
+            name='input_type',
+            field=models.CharField(
+                choices=[
+                    ('text', 'Text'),
+                    ('number', 'Number'),
+                    ('choice', 'Choices'),
+                    ('multichoice', 'Multiple Choices'),
+                    ('range', 'Range'),
+                    ('rating', 'Rating'),
+                    ('datetime', 'Date/Time'),
+                    ('point', 'Geo Point'),
+                    ('line', 'Geo Line'),
+                    ('polygon', 'Geo Polygon'),
+                    ('image', 'Image'),
+                    ('text_line', 'Single Line Text'),
+                    ('html', 'HTML'),
+                    ('pressure', 'Geometry Pressure'),
+                ],
+                max_length=80,
+            ),
+        ),
+    ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -81,6 +81,7 @@ INPUT_TYPE_CHOICES = (
     ("image", _("Image")),
     ("text_line", _("Single Line Text")),
     ("html", _("HTML")),
+    ("pressure", _("Geometry Pressure")),
 )
 
 class SurveySession(models.Model):
@@ -189,7 +190,7 @@ class SurveyHeader(models.Model):
 
     def geo_questions(self):
         if not hasattr(self, "__gqcache"):
-            self.__gqcache = Question.objects.filter(Q(survey_section__in=SurveySection.objects.filter(survey_header=self)) & Q(input_type__in=['point','line','polygon']))
+            self.__gqcache = Question.objects.filter(Q(survey_section__in=SurveySection.objects.filter(survey_header=self)) & Q(input_type__in=['point','line','polygon','pressure']))
         return self.__gqcache
 
     def sessions(self):
@@ -300,12 +301,13 @@ class Question(models.Model):
     color = models.CharField(verbose_name=_(u'Color'), max_length=7, help_text=_(u'HEX color, as #RRGGBB'), default="#000000")
     icon_class = models.CharField(default="", max_length=80, help_text=_(u'Must be Font-Awesome class'), blank=True, null=True)
     image = models.ImageField(upload_to ='images/', null=True, blank=True)
+    geometries = models.JSONField(null=True, blank=True)
 
     class Meta:
         app_label = 'survey'
 
     def __str__(self):
-        return self.name 
+        return self.name
 
     def subQuestions(self):
     	if not hasattr(self, "__sqcache"):
@@ -375,6 +377,7 @@ class Answer(models.Model):
     point = geomodels.PointField(null=True, blank=True)
     line = geomodels.LineStringField(null=True, blank=True)
     polygon = geomodels.PolygonField(null=True, blank=True)
+    geometry_id = models.CharField(max_length=50, null=True, blank=True)
 
     class Meta:
         app_label = 'survey'

--- a/survey/serialization.py
+++ b/survey/serialization.py
@@ -94,6 +94,7 @@ def _serialize_question(question: Question) -> Dict[str, Any]:
         "subtext": question.subtext,
         "input_type": question.input_type,
         "choices": question.choices,
+        "geometries": question.geometries,
         "required": question.required,
         "color": question.color,
         "icon_class": question.icon_class,
@@ -165,6 +166,7 @@ def _serialize_answer(answer: Answer) -> Dict[str, Any]:
         "point": geo_to_wkt(answer.point),
         "line": geo_to_wkt(answer.line),
         "polygon": geo_to_wkt(answer.polygon),
+        "geometry_id": answer.geometry_id,
         "choices": serialize_choices(answer),
         "sub_answers": [
             _serialize_answer(sub_a)
@@ -557,6 +559,7 @@ def _create_question(
         subtext=question_data.get("subtext", "")[:512] if question_data.get("subtext") else None,
         input_type=input_type[:80],
         choices=choices,
+        geometries=question_data.get("geometries"),
         required=question_data.get("required", False),
         color=question_data.get("color", "#000000")[:7],
         icon_class=question_data.get("icon_class", "")[:80] if question_data.get("icon_class") else None,
@@ -779,6 +782,7 @@ def create_answer(
         point=wkt_to_geo(answer_data.get("point"), "point"),
         line=wkt_to_geo(answer_data.get("line"), "line"),
         polygon=wkt_to_geo(answer_data.get("polygon"), "polygon"),
+        geometry_id=answer_data.get("geometry_id"),
     )
 
     # Link choices by name -> code

--- a/survey/templates/base_survey_template.html
+++ b/survey/templates/base_survey_template.html
@@ -413,13 +413,100 @@
         currentQ = null;
     });
 
+    // ── Pressure question rendering ──────────────────────────────────
+    var pressureGroups = {};      // questionCode -> L.FeatureGroup
+    var pressureAnswered = {};    // questionCode -> Set of geometry_id
+
+    $('.pressurebutton').each(function() {
+        var btn = $(this);
+        var questionCode = btn.attr('name');
+        var geometriesJson = btn.attr('data-geometries');
+        var shapes = [];
+        try { shapes = JSON.parse(geometriesJson); } catch(e) {}
+        if (!shapes.length) return;
+
+        var group = new L.FeatureGroup();
+        pressureGroups[questionCode] = group;
+        pressureAnswered[questionCode] = new Set();
+
+        shapes.forEach(function(shape) {
+            var geom = shape.geometry;
+            var layer;
+            var color = shape.color || '#666';
+
+            if (geom.type === 'Point') {
+                var coords = geom.coordinates;
+                layer = L.marker([coords[1], coords[0]], {
+                    icon: L.icon.fontAwesome({
+                        iconClasses: 'fa ' + (shape.icon_class || 'fas fa-map-marker-alt'),
+                        markerColor: color,
+                        iconColor: '#FFF',
+                        iconXOffset: -2,
+                    }),
+                    opacity: 0.5,
+                });
+            } else if (geom.type === 'LineString') {
+                var latlngs = geom.coordinates.map(function(c) { return [c[1], c[0]]; });
+                layer = L.polyline(latlngs, {color: color, opacity: 0.5});
+            } else if (geom.type === 'Polygon') {
+                var latlngs = geom.coordinates[0].map(function(c) { return [c[1], c[0]]; });
+                layer = L.polygon(latlngs, {color: color, fillColor: color, fillOpacity: 0.15, opacity: 0.5});
+            }
+
+            if (!layer) return;
+
+            var feature = layer.feature = layer.feature || {};
+            feature.type = "Feature";
+            feature.geometry = geom;
+            feature.properties = {
+                question_id: questionCode,
+                geometry_id: shape.id,
+            };
+            layer._pressureShapeId = shape.id;
+            layer._pressureQuestionCode = questionCode;
+
+            group.addLayer(layer);
+        });
+
+        map.addLayer(group);
+    });
+
+    function markPressureAnswered(questionCode, geometryId) {
+        pressureAnswered[questionCode] = pressureAnswered[questionCode] || new Set();
+        pressureAnswered[questionCode].add(geometryId);
+        var group = pressureGroups[questionCode];
+        if (!group) return;
+        group.eachLayer(function(layer) {
+            if (layer._pressureShapeId === geometryId) {
+                if (layer instanceof L.Marker) {
+                    layer.setOpacity(1);
+                } else {
+                    layer.setStyle({opacity: 1, fillOpacity: 0.35});
+                }
+            }
+        });
+    }
+
+    // ── Form submission: collect geo + pressure data ──────────────────
     $("#section_question_form").submit(function(e){
-    	// First, collect geo data from map layers
+    	// First, collect geo data from editable layers
     	editableLayers.eachLayer(function(layer){
     		let valueOfInput = $(".geo-inp[name='" + layer.feature.properties.question_id + "'").val();
     		valueOfInput += (JSON.stringify(layer.toGeoJSON()) + "|");
         	$(".geo-inp[name='" + layer.feature.properties.question_id + "'").val(valueOfInput);
     	});
+
+    	// Collect pressure data from pressure groups
+    	for (var qCode in pressureGroups) {
+    	    var answered = pressureAnswered[qCode] || new Set();
+    	    pressureGroups[qCode].eachLayer(function(layer) {
+    	        if (answered.has(layer._pressureShapeId)) {
+    	            let valueOfInput = $(".geo-inp[name='" + qCode + "'").val() || '';
+    	            valueOfInput += (JSON.stringify(layer.toGeoJSON()) + "|");
+    	            $(".geo-inp[name='" + qCode + "'").val(valueOfInput);
+    	        }
+    	    });
+    	}
 
     	// Validate required geo fields
     	let isValid = true;

--- a/survey/templates/editor/editor_base.html
+++ b/survey/templates/editor/editor_base.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
@@ -18,6 +19,7 @@
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
     <style>
         :root {
             --accent: #4f46e5;

--- a/survey/templates/editor/partials/question_form_modal.html
+++ b/survey/templates/editor/partials/question_form_modal.html
@@ -68,10 +68,14 @@
         <!-- Geometries editor for pressure questions -->
         <div class="geometries-editor" id="geometries-editor" style="display:none;">
             <label style="font-weight:600;">Predefined Shapes</label>
-            <div id="geometries-map" style="height:250px;border:1px solid #ddd;border-radius:6px;margin-bottom:8px;"></div>
+            <button type="button" class="btn btn-outline-primary btn-sm" id="open-geometries-map-btn" onclick="openGeometriesModal()" style="margin-bottom:8px;">
+                <i class="fas fa-map"></i> Open Map Editor
+            </button>
             <div id="geometries-list"></div>
             <input type="hidden" name="geometries_json" id="geometries-json-input">
         </div>
+
+        <!-- Geometries map modal is appended to body via JS to avoid nested modal issues -->
 
         {% if survey.available_languages %}
         <div class="translations-section">
@@ -137,7 +141,6 @@
         // Toggle geometries editor for pressure
         if (inputTypeSelect && inputTypeSelect.value === 'pressure') {
             geometriesEditor.style.display = 'block';
-            initGeometriesMap();
         } else {
             geometriesEditor.style.display = 'none';
         }
@@ -352,11 +355,62 @@
     var geomMap = null;
     var geomDrawLayers = null;
     var geomShapes = [];  // Array of {id, geometry, label, color, icon_class, layer}
+    var geomMapInitialized = false;
+
+    // Load existing geometries into geomShapes (without map layers yet)
+    {% if question and question.geometries %}
+    (function() {
+        var existingGeoms = {{ question.geometries|safe }};
+        existingGeoms.forEach(function(shape) {
+            geomShapes.push({
+                id: shape.id,
+                geometry: shape.geometry,
+                label: shape.label || '',
+                color: shape.color || '#4f46e5',
+                icon_class: shape.icon_class || 'fas fa-map-marker-alt',
+                layer: null,
+            });
+        });
+    })();
+    {% endif %}
+
+    // Create fullscreen map modal (appended to body to avoid nested modal issues)
+    var geomModalEl = null;
+    (function() {
+        // Remove any previous instance
+        var old = document.getElementById('geometriesMapModal');
+        if (old) old.remove();
+
+        var div = document.createElement('div');
+        div.innerHTML =
+            '<div class="modal fade" id="geometriesMapModal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false" style="z-index:1060;">' +
+                '<div class="modal-dialog modal-dialog-centered" role="document" style="max-width:95vw;width:95vw;margin:1rem auto;">' +
+                    '<div class="modal-content" style="height:90vh;">' +
+                        '<div class="modal-header py-2">' +
+                            '<h6 class="modal-title"><i class="fas fa-draw-polygon"></i> Draw Predefined Shapes</h6>' +
+                            '<button type="button" class="close" onclick="closeGeometriesModal()"><span>&times;</span></button>' +
+                        '</div>' +
+                        '<div class="modal-body p-0" style="flex:1;overflow:hidden;">' +
+                            '<div id="geometries-map" style="width:100%;height:100%;"></div>' +
+                        '</div>' +
+                        '<div class="modal-footer py-2">' +
+                            '<span class="text-muted mr-auto" style="font-size:0.8rem;" id="geom-shape-count"></span>' +
+                            '<button type="button" class="btn btn-primary btn-sm" onclick="closeGeometriesModal()">' +
+                                '<i class="fas fa-check"></i> Done' +
+                            '</button>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>' +
+            '</div>';
+        geomModalEl = div.firstChild;
+        document.body.appendChild(geomModalEl);
+    })();
 
     function initGeometriesMap() {
-        if (geomMap) return;
+        if (geomMapInitialized) return;
         var mapDiv = document.getElementById('geometries-map');
         if (!mapDiv) return;
+
         geomMap = L.map(mapDiv).setView([59.945, 30.317], 12);
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; OSM',
@@ -376,7 +430,7 @@
                 circle: false,
                 rectangle: false,
             },
-            edit: { featureGroup: geomDrawLayers, remove: false, edit: false },
+            edit: { featureGroup: geomDrawLayers, remove: true, edit: true },
         });
         geomMap.addControl(drawControl);
 
@@ -394,13 +448,23 @@
             };
             geomShapes.push(shape);
             geomDrawLayers.addLayer(layer);
-            renderGeomList();
+            updateShapeCount();
         });
 
-        // Load existing geometries
-        {% if question and question.geometries %}
-        var existingGeoms = {{ question.geometries|safe }};
-        existingGeoms.forEach(function(shape) {
+        geomMap.on('draw:deleted', function(e) {
+            e.layers.eachLayer(function(layer) {
+                for (var i = geomShapes.length - 1; i >= 0; i--) {
+                    if (geomShapes[i].layer === layer) {
+                        geomShapes.splice(i, 1);
+                        break;
+                    }
+                }
+            });
+            updateShapeCount();
+        });
+
+        // Create map layers for existing shapes
+        geomShapes.forEach(function(shape) {
             var geom = shape.geometry;
             var layer;
             if (geom.type === 'Point') {
@@ -412,25 +476,43 @@
                 layer = L.polygon(geom.coordinates[0].map(function(c) { return [c[1], c[0]]; }));
             }
             if (layer) {
+                shape.layer = layer;
                 geomDrawLayers.addLayer(layer);
-                geomShapes.push({
-                    id: shape.id,
-                    geometry: shape.geometry,
-                    label: shape.label || '',
-                    color: shape.color || '#4f46e5',
-                    icon_class: shape.icon_class || 'fas fa-map-marker-alt',
-                    layer: layer,
-                });
             }
         });
         if (geomShapes.length > 0) {
             geomMap.fitBounds(geomDrawLayers.getBounds().pad(0.1));
         }
-        renderGeomList();
-        {% endif %}
 
-        setTimeout(function() { geomMap.invalidateSize(); }, 200);
+        geomMapInitialized = true;
+        updateShapeCount();
     }
+
+    function updateShapeCount() {
+        var el = document.getElementById('geom-shape-count');
+        if (el) el.textContent = geomShapes.length + ' shape(s)';
+        // Update button badge
+        var btn = document.getElementById('open-geometries-map-btn');
+        if (btn) btn.innerHTML = '<i class="fas fa-map"></i> Open Map Editor (' + geomShapes.length + ')';
+    }
+
+    window.openGeometriesModal = function() {
+        $('#geometriesMapModal').modal('show');
+        // Init map after modal is shown (needs visible container for correct sizing)
+        $('#geometriesMapModal').one('shown.bs.modal', function() {
+            initGeometriesMap();
+            geomMap.invalidateSize();
+        });
+    };
+
+    window.closeGeometriesModal = function() {
+        // Sync layer geometries back (in case user dragged/edited shapes)
+        geomShapes.forEach(function(s) {
+            if (s.layer) s.geometry = s.layer.toGeoJSON().geometry;
+        });
+        $('#geometriesMapModal').modal('hide');
+        renderGeomList();
+    };
 
     function renderGeomList() {
         var list = document.getElementById('geometries-list');
@@ -440,7 +522,7 @@
             row.className = 'geometry-row';
             row.style.cssText = 'display:flex;gap:6px;align-items:center;margin-bottom:6px;';
             row.innerHTML =
-                '<span style="font-size:0.8rem;color:#888;">' + shape.geometry.type + '</span>' +
+                '<span style="font-size:0.8rem;color:#888;min-width:60px;">' + shape.geometry.type + '</span>' +
                 '<input type="text" class="form-control form-control-sm" placeholder="Label" value="' + (shape.label || '').replace(/"/g, '&quot;') + '" data-idx="' + idx + '" data-field="label" style="flex:1;">' +
                 '<input type="color" value="' + (shape.color || '#4f46e5') + '" data-idx="' + idx + '" data-field="color" style="width:36px;height:30px;border:none;padding:0;">' +
                 '<input type="text" class="form-control form-control-sm" placeholder="Icon class" value="' + (shape.icon_class || '').replace(/"/g, '&quot;') + '" data-idx="' + idx + '" data-field="icon_class" style="width:140px;">' +
@@ -457,11 +539,20 @@
             });
             row.querySelector('button').addEventListener('click', function() {
                 var i = parseInt(this.getAttribute('data-idx'));
-                geomDrawLayers.removeLayer(geomShapes[i].layer);
+                if (geomDrawLayers && geomShapes[i].layer) {
+                    geomDrawLayers.removeLayer(geomShapes[i].layer);
+                }
                 geomShapes.splice(i, 1);
                 renderGeomList();
+                updateShapeCount();
             });
         });
+    }
+
+    // Render initial list if editing existing question
+    if (geomShapes.length > 0) {
+        renderGeomList();
+        updateShapeCount();
     }
 
     window.serializeGeometries = function() {
@@ -476,6 +567,19 @@
         });
         document.getElementById('geometries-json-input').value = output.length > 0 ? JSON.stringify(output) : '';
     };
+
+    // Clean up geometries map modal when question modal closes
+    $('#questionModal').one('hidden.bs.modal', function() {
+        if (geomMap) {
+            geomMap.remove();
+            geomMap = null;
+        }
+        if (geomModalEl) {
+            geomModalEl.remove();
+            geomModalEl = null;
+        }
+        geomMapInitialized = false;
+    });
 
     {% if question %}
     window.applyQuestion = function() {

--- a/survey/templates/editor/partials/question_form_modal.html
+++ b/survey/templates/editor/partials/question_form_modal.html
@@ -65,6 +65,14 @@
         </div>
         <input type="hidden" name="choices_json" id="choices-json-input">
 
+        <!-- Geometries editor for pressure questions -->
+        <div class="geometries-editor" id="geometries-editor" style="display:none;">
+            <label style="font-weight:600;">Predefined Shapes</label>
+            <div id="geometries-map" style="height:250px;border:1px solid #ddd;border-radius:6px;margin-bottom:8px;"></div>
+            <div id="geometries-list"></div>
+            <input type="hidden" name="geometries_json" id="geometries-json-input">
+        </div>
+
         {% if survey.available_languages %}
         <div class="translations-section">
             <button type="button" class="translations-toggle" onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');">
@@ -104,11 +112,11 @@
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
         {% if question %}
-        <button type="button" class="btn btn-outline-primary" id="apply-question-btn" onclick="serializeChoices(); applyQuestion();">
+        <button type="button" class="btn btn-outline-primary" id="apply-question-btn" onclick="serializeChoices(); serializeGeometries(); applyQuestion();">
             <i class="fas fa-eye"></i> Apply
         </button>
         {% endif %}
-        <button type="submit" class="btn btn-primary" onclick="serializeChoices()">Save</button>
+        <button type="submit" class="btn btn-primary" onclick="serializeChoices(); serializeGeometries();">Save</button>
     </div>
 </form>
 
@@ -118,12 +126,20 @@
     var choicesEditor = document.getElementById('choices-editor');
     var inputTypeSelect = document.querySelector('#questionModalBody select[name="input_type"]');
     var choiceTypes = ['choice', 'multichoice', 'range', 'rating'];
+    var geometriesEditor = document.getElementById('geometries-editor');
 
     function toggleChoicesEditor() {
         if (inputTypeSelect && choiceTypes.indexOf(inputTypeSelect.value) !== -1) {
             choicesEditor.style.display = 'block';
         } else {
             choicesEditor.style.display = 'none';
+        }
+        // Toggle geometries editor for pressure
+        if (inputTypeSelect && inputTypeSelect.value === 'pressure') {
+            geometriesEditor.style.display = 'block';
+            initGeometriesMap();
+        } else {
+            geometriesEditor.style.display = 'none';
         }
     }
 
@@ -330,6 +346,135 @@
         });
 
         document.getElementById('choices-json-input').value = choices.length > 0 ? JSON.stringify(choices) : '';
+    };
+
+    // ── Geometries editor for pressure questions ──
+    var geomMap = null;
+    var geomDrawLayers = null;
+    var geomShapes = [];  // Array of {id, geometry, label, color, icon_class, layer}
+
+    function initGeometriesMap() {
+        if (geomMap) return;
+        var mapDiv = document.getElementById('geometries-map');
+        if (!mapDiv) return;
+        geomMap = L.map(mapDiv).setView([59.945, 30.317], 12);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; OSM',
+            maxZoom: 19,
+        }).addTo(geomMap);
+
+        geomDrawLayers = new L.FeatureGroup();
+        geomMap.addLayer(geomDrawLayers);
+
+        var drawControl = new L.Control.Draw({
+            position: 'topright',
+            draw: {
+                polygon: true,
+                polyline: true,
+                marker: true,
+                circlemarker: false,
+                circle: false,
+                rectangle: false,
+            },
+            edit: { featureGroup: geomDrawLayers, remove: false, edit: false },
+        });
+        geomMap.addControl(drawControl);
+
+        geomMap.on('draw:created', function(e) {
+            var layer = e.layer;
+            var geojson = layer.toGeoJSON();
+            var id = crypto.randomUUID ? crypto.randomUUID() : ('shape_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9));
+            var shape = {
+                id: id,
+                geometry: geojson.geometry,
+                label: '',
+                color: '#4f46e5',
+                icon_class: 'fas fa-map-marker-alt',
+                layer: layer,
+            };
+            geomShapes.push(shape);
+            geomDrawLayers.addLayer(layer);
+            renderGeomList();
+        });
+
+        // Load existing geometries
+        {% if question and question.geometries %}
+        var existingGeoms = {{ question.geometries|safe }};
+        existingGeoms.forEach(function(shape) {
+            var geom = shape.geometry;
+            var layer;
+            if (geom.type === 'Point') {
+                var c = geom.coordinates;
+                layer = L.marker([c[1], c[0]]);
+            } else if (geom.type === 'LineString') {
+                layer = L.polyline(geom.coordinates.map(function(c) { return [c[1], c[0]]; }));
+            } else if (geom.type === 'Polygon') {
+                layer = L.polygon(geom.coordinates[0].map(function(c) { return [c[1], c[0]]; }));
+            }
+            if (layer) {
+                geomDrawLayers.addLayer(layer);
+                geomShapes.push({
+                    id: shape.id,
+                    geometry: shape.geometry,
+                    label: shape.label || '',
+                    color: shape.color || '#4f46e5',
+                    icon_class: shape.icon_class || 'fas fa-map-marker-alt',
+                    layer: layer,
+                });
+            }
+        });
+        if (geomShapes.length > 0) {
+            geomMap.fitBounds(geomDrawLayers.getBounds().pad(0.1));
+        }
+        renderGeomList();
+        {% endif %}
+
+        setTimeout(function() { geomMap.invalidateSize(); }, 200);
+    }
+
+    function renderGeomList() {
+        var list = document.getElementById('geometries-list');
+        list.innerHTML = '';
+        geomShapes.forEach(function(shape, idx) {
+            var row = document.createElement('div');
+            row.className = 'geometry-row';
+            row.style.cssText = 'display:flex;gap:6px;align-items:center;margin-bottom:6px;';
+            row.innerHTML =
+                '<span style="font-size:0.8rem;color:#888;">' + shape.geometry.type + '</span>' +
+                '<input type="text" class="form-control form-control-sm" placeholder="Label" value="' + (shape.label || '').replace(/"/g, '&quot;') + '" data-idx="' + idx + '" data-field="label" style="flex:1;">' +
+                '<input type="color" value="' + (shape.color || '#4f46e5') + '" data-idx="' + idx + '" data-field="color" style="width:36px;height:30px;border:none;padding:0;">' +
+                '<input type="text" class="form-control form-control-sm" placeholder="Icon class" value="' + (shape.icon_class || '').replace(/"/g, '&quot;') + '" data-idx="' + idx + '" data-field="icon_class" style="width:140px;">' +
+                '<button type="button" class="btn btn-sm btn-outline-danger" data-idx="' + idx + '">&times;</button>';
+            list.appendChild(row);
+
+            // Event listeners
+            row.querySelectorAll('input').forEach(function(inp) {
+                inp.addEventListener('input', function() {
+                    var i = parseInt(this.getAttribute('data-idx'));
+                    var field = this.getAttribute('data-field');
+                    if (field) geomShapes[i][field] = this.value;
+                });
+            });
+            row.querySelector('button').addEventListener('click', function() {
+                var i = parseInt(this.getAttribute('data-idx'));
+                geomDrawLayers.removeLayer(geomShapes[i].layer);
+                geomShapes.splice(i, 1);
+                renderGeomList();
+            });
+        });
+    }
+
+    window.serializeGeometries = function() {
+        var output = geomShapes.map(function(s) {
+            return {
+                id: s.id,
+                geometry: s.layer ? s.layer.toGeoJSON().geometry : s.geometry,
+                label: s.label,
+                color: s.color,
+                icon_class: s.icon_class,
+            };
+        });
+        document.getElementById('geometries-json-input').value = output.length > 0 ? JSON.stringify(output) : '';
     };
 
     {% if question %}

--- a/survey/templates/editor/partials/question_list_item.html
+++ b/survey/templates/editor/partials/question_list_item.html
@@ -12,7 +12,7 @@
                     data-toggle="modal" data-target="#questionModal">
                 <i class="fas fa-pen"></i>
             </button>
-            {% if question.input_type == 'point' or question.input_type == 'line' or question.input_type == 'polygon' %}
+            {% if question.input_type == 'point' or question.input_type == 'line' or question.input_type == 'polygon' or question.input_type == 'pressure' %}
             <button title="Add Sub-question"
                     hx-get="{% url 'editor_subquestion_create' survey.uuid question.id %}"
                     hx-target="#questionModalBody"

--- a/survey/templates/pressure_button.html
+++ b/survey/templates/pressure_button.html
@@ -1,0 +1,14 @@
+<div>
+	<button name="{{ widget.name }}" type="button" class="pressurebutton" data-color="{{ widget.color }}" data-icon="{{ widget.icon_class }}" data-geometries="{{ widget.geometries }}">
+		<div class="geo-question">
+			<div class="geo-question-icon" style="background: {{ widget.color }}15;">
+				<i class="fas fa-hand-pointer" style="font-size:22px; color: {{ widget.color }}"></i>
+			</div>
+			<div class="geo-question-text">
+				<p class="geo-question-title">{{ widget.title }}</p>
+				{% if widget.subtitle %}<p class="geo-question-subtitle">{{ widget.subtitle }}</p>{% endif %}
+			</div>
+		</div>
+	</button>
+	<input type="text" name="{{ widget.name }}" hidden class="geo-inp">
+</div>

--- a/survey/templates/survey_section.html
+++ b/survey/templates/survey_section.html
@@ -200,60 +200,157 @@
     var existingGeoAnswers = JSON.parse('{{ existing_geo_answers_json|escapejs }}');
     for (var questionCode in existingGeoAnswers) {
         var features = existingGeoAnswers[questionCode];
-        for (var i = 0; i < features.length; i++) {
-            var geoFeature = features[i];
-            var geomType = geoFeature.geometry.type;
-            var layer;
 
-            if (geomType === 'Point') {
-                var coords = geoFeature.geometry.coordinates;
-                var btn = $('button.drawbutton[name="' + questionCode + '"]');
-                var color = btn.attr('data-color') || '#000000';
-                var icon = btn.attr('data-icon') || 'fas fa-map-marker-alt';
-                layer = L.marker([coords[1], coords[0]], {
-                    icon: L.icon.fontAwesome({
-                        iconClasses: 'fa ' + icon,
-                        markerColor: color,
-                        iconColor: '#FFF',
-                        iconXOffset: -2,
-                    })
+        // Check if this is a pressure question
+        var isPressure = $('button.pressurebutton[name="' + questionCode + '"]').length > 0;
+
+        if (isPressure) {
+            // Pressure: match features to predefined layers by geometry_id
+            for (var i = 0; i < features.length; i++) {
+                var geoFeature = features[i];
+                var geometryId = geoFeature.properties.geometry_id;
+                if (!geometryId) continue;
+
+                var group = pressureGroups[questionCode];
+                if (!group) continue;
+
+                group.eachLayer(function(layer) {
+                    if (layer._pressureShapeId === geometryId) {
+                        // Copy saved properties into layer
+                        for (var key in geoFeature.properties) {
+                            layer.feature.properties[key] = geoFeature.properties[key];
+                        }
+                        markPressureAnswered(questionCode, geometryId);
+                    }
                 });
-            } else if (geomType === 'LineString') {
-                var latlngs = geoFeature.geometry.coordinates.map(function(c) { return [c[1], c[0]]; });
-                var btn = $('button.drawbutton[name="' + questionCode + '"]');
-                var color = btn.attr('data-color') || '#000000';
-                layer = L.polyline(latlngs, {color: color});
-            } else if (geomType === 'Polygon') {
-                var latlngs = geoFeature.geometry.coordinates[0].map(function(c) { return [c[1], c[0]]; });
-                var btn = $('button.drawbutton[name="' + questionCode + '"]');
-                var color = btn.attr('data-color') || '#000000';
-                layer = L.polygon(latlngs, {color: color});
             }
+        } else {
+            // Regular geo questions: create new layers
+            for (var i = 0; i < features.length; i++) {
+                var geoFeature = features[i];
+                var geomType = geoFeature.geometry.type;
+                var layer;
 
-            if (layer) {
-                var feature = layer.feature = layer.feature || {};
-                feature.type = "Feature";
-                feature.properties = geoFeature.properties;
-
-                var formId = 'subquestion_form_' + L.Util.stamp(layer);
-                layer._formId = formId;
-
-                layer.bindPopup('<form action="" onsubmit="return false;" id="' + formId + '">' + subquestions_forms[questionCode]
-                    + '<div class="layer-controls">\
-                    <button type="button" class="btn btn-danger layer-delete"><i class="far fa-trash-alt"></i></button>\
-                    <button type="button" class="btn btn-primary layer-edit"><i class="far fa-edit"></i></button>\
-                    <button type="button" class="btn btn-success layer-apply"><i class="fas fa-check"></i></button>\
-                    </div>'
-                    + '</form>', {
-                        maxHeight: $(document).height()*0.8,
+                if (geomType === 'Point') {
+                    var coords = geoFeature.geometry.coordinates;
+                    var btn = $('button.drawbutton[name="' + questionCode + '"]');
+                    var color = btn.attr('data-color') || '#000000';
+                    var icon = btn.attr('data-icon') || 'fas fa-map-marker-alt';
+                    layer = L.marker([coords[1], coords[0]], {
+                        icon: L.icon.fontAwesome({
+                            iconClasses: 'fa ' + icon,
+                            markerColor: color,
+                            iconColor: '#FFF',
+                            iconXOffset: -2,
+                        })
                     });
+                } else if (geomType === 'LineString') {
+                    var latlngs = geoFeature.geometry.coordinates.map(function(c) { return [c[1], c[0]]; });
+                    var btn = $('button.drawbutton[name="' + questionCode + '"]');
+                    var color = btn.attr('data-color') || '#000000';
+                    layer = L.polyline(latlngs, {color: color});
+                } else if (geomType === 'Polygon') {
+                    var latlngs = geoFeature.geometry.coordinates[0].map(function(c) { return [c[1], c[0]]; });
+                    var btn = $('button.drawbutton[name="' + questionCode + '"]');
+                    var color = btn.attr('data-color') || '#000000';
+                    layer = L.polygon(latlngs, {color: color});
+                }
 
-                layer.on("popupopen", onPopupOpen);
-                layer.on("popupclose", onPopupClose);
+                if (layer) {
+                    var feature = layer.feature = layer.feature || {};
+                    feature.type = "Feature";
+                    feature.properties = geoFeature.properties;
 
-                editableLayers.addLayer(layer);
+                    var formId = 'subquestion_form_' + L.Util.stamp(layer);
+                    layer._formId = formId;
+
+                    layer.bindPopup('<form action="" onsubmit="return false;" id="' + formId + '">' + subquestions_forms[questionCode]
+                        + '<div class="layer-controls">\
+                        <button type="button" class="btn btn-danger layer-delete"><i class="far fa-trash-alt"></i></button>\
+                        <button type="button" class="btn btn-primary layer-edit"><i class="far fa-edit"></i></button>\
+                        <button type="button" class="btn btn-success layer-apply"><i class="fas fa-check"></i></button>\
+                        </div>'
+                        + '</form>', {
+                            maxHeight: $(document).height()*0.8,
+                        });
+
+                    layer.on("popupopen", onPopupOpen);
+                    layer.on("popupclose", onPopupClose);
+
+                    editableLayers.addLayer(layer);
+                }
             }
         }
+    }
+
+    // ── Pressure shape click handlers ──────────────────────────────
+    for (var qCode in pressureGroups) {
+        (function(questionCode) {
+            pressureGroups[questionCode].eachLayer(function(layer) {
+                layer.on('click', function() {
+                    var geometryId = layer._pressureShapeId;
+                    var formId = 'subquestion_form_' + geometryId;
+                    layer._formId = formId;
+
+                    if (!subquestions_forms[questionCode]) return;
+
+                    layer.bindPopup('<form action="" onsubmit="return false;" id="' + formId + '">' + subquestions_forms[questionCode]
+                        + '<div class="layer-controls">\
+                        <button type="button" class="btn btn-success layer-apply"><i class="fas fa-check"></i></button>\
+                        </div>'
+                        + '</form>', {
+                            maxHeight: $(document).height()*0.8,
+                        });
+
+                    layer.on("popupopen", function pressurePopupOpen() {
+                        var tempLayer = this;
+                        var $popup = $(tempLayer.getPopup().getElement());
+                        var $form = $popup.find('form');
+
+                        // Load properties into form fields
+                        var properties = tempLayer.feature.properties;
+                        for (var key in properties) {
+                            if (key !== 'question_id' && key !== 'geometry_id') {
+                                var element = $form.find('*[name=' + key + ']');
+                                if (element.length > 1) {
+                                    let type = element[0].type;
+                                    if (type === 'checkbox' || type === 'radio') {
+                                        properties[key].forEach(function(val) {
+                                            $form.find('*[name=' + key + '][value=' + val + ']').prop('checked', true);
+                                        });
+                                    }
+                                } else {
+                                    element.val(properties[key]);
+                                }
+                            }
+                        }
+
+                        $popup.find("button.layer-apply").click(function() {
+                            var subquestion_form_result = $('#' + tempLayer._formId).serializeArray();
+                            var grouped_by_name_result = subquestion_form_result.groupBy("name");
+                            for (var prop in grouped_by_name_result) {
+                                tempLayer.feature.properties[prop] = grouped_by_name_result[prop].map(function(arg) { return arg.value; });
+                            }
+                            markPressureAnswered(questionCode, geometryId);
+                            tempLayer.closePopup();
+                            toggleInfo(true);
+                        });
+                    });
+
+                    layer.on("popupclose", function pressurePopupClose() {
+                        var tempLayer = this;
+                        var subquestion_form_result = $('#' + tempLayer._formId).serializeArray();
+                        var grouped_by_name_result = subquestion_form_result.groupBy("name");
+                        for (var prop in grouped_by_name_result) {
+                            tempLayer.feature.properties[prop] = grouped_by_name_result[prop].map(function(arg) { return arg.value; });
+                        }
+                        toggleInfo(true);
+                    });
+
+                    layer.openPopup();
+                });
+            });
+        })(qCode);
     }
 
 </script>

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -6500,3 +6500,193 @@ class InvitationFlowTest(TestCase):
         response = self.client.get('/editor/')
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('pending_invitation_token', self.client.session)
+
+
+class PressureQuestionTest(TestCase):
+    """Tests for the pressure question type."""
+
+    def setUp(self):
+        self.client = Client()
+        self.org = _make_org('PressureOrg')
+        self.survey = SurveyHeader.objects.create(
+            name="pressure_survey",
+            organization=self.org,
+            redirect_url="#",
+        )
+        self.section = SurveySection.objects.create(
+            survey_header=self.survey,
+            name="section1",
+            title="Section 1",
+            code="S1",
+            is_head=True,
+        )
+        self.pressure_q = Question.objects.create(
+            survey_section=self.section,
+            name="Rate zones",
+            input_type="pressure",
+            color="#ff0000",
+            order_number=1,
+            geometries=[
+                {
+                    "id": "shape_a",
+                    "geometry": {"type": "Point", "coordinates": [30.3, 59.9]},
+                    "label": "Main Stage",
+                    "color": "#ff0000",
+                    "icon_class": "fas fa-music",
+                },
+                {
+                    "id": "shape_b",
+                    "geometry": {"type": "Polygon", "coordinates": [[[30.0, 59.0], [30.1, 59.0], [30.1, 59.1], [30.0, 59.1], [30.0, 59.0]]]},
+                    "label": "Food Court",
+                    "color": "#00ff00",
+                    "icon_class": "fas fa-utensils",
+                },
+            ],
+        )
+        self.sub_q = Question.objects.create(
+            survey_section=self.section,
+            name="Rating",
+            input_type="number",
+            parent_question_id=self.pressure_q,
+            order_number=1,
+        )
+
+    def test_pressure_question_save_retrieve(self):
+        """
+        GIVEN a question with input_type="pressure" and geometries JSON
+        WHEN we retrieve it from the database
+        THEN the geometries field is preserved correctly
+        """
+        q = Question.objects.get(pk=self.pressure_q.pk)
+        self.assertEqual(q.input_type, "pressure")
+        self.assertEqual(len(q.geometries), 2)
+        self.assertEqual(q.geometries[0]["id"], "shape_a")
+        self.assertEqual(q.geometries[1]["geometry"]["type"], "Polygon")
+
+    def test_answer_geometry_id_save_retrieve(self):
+        """
+        GIVEN an answer with geometry_id set
+        WHEN we retrieve it from the database
+        THEN geometry_id is preserved
+        """
+        session = SurveySession.objects.create(survey=self.survey)
+        answer = Answer.objects.create(
+            survey_session=session,
+            question=self.pressure_q,
+            point=Point(30.3, 59.9, srid=4326),
+            geometry_id="shape_a",
+        )
+        fetched = Answer.objects.get(pk=answer.pk)
+        self.assertEqual(fetched.geometry_id, "shape_a")
+
+    def test_geo_questions_includes_pressure(self):
+        """
+        GIVEN a survey with a pressure question
+        WHEN we call geo_questions()
+        THEN the pressure question is included
+        """
+        geo_qs = list(self.survey.geo_questions())
+        codes = [q.code for q in geo_qs]
+        self.assertIn(self.pressure_q.code, codes)
+
+    def test_pressure_answer_in_existing_geo_answers(self):
+        """
+        GIVEN a saved pressure answer with geometry_id
+        WHEN the respondent revisits the section via GET
+        THEN existing_geo_answers contains the answer with geometry_id
+        """
+        # Visit section to create session
+        self.client.get(f'/surveys/pressure_survey/section1/')
+        session_id = self.client.session['survey_session_id']
+        session = SurveySession.objects.get(pk=session_id)
+
+        Answer.objects.create(
+            survey_session=session,
+            question=self.pressure_q,
+            point=Point(30.3, 59.9, srid=4326),
+            geometry_id="shape_a",
+        )
+
+        response = self.client.get(f'/surveys/pressure_survey/section1/')
+        geo_data = json.loads(response.context['existing_geo_answers_json'])
+        self.assertIn(self.pressure_q.code, geo_data)
+        features = geo_data[self.pressure_q.code]
+        self.assertEqual(len(features), 1)
+        self.assertEqual(features[0]['properties']['geometry_id'], 'shape_a')
+
+    def test_serialization_roundtrip_geometries(self):
+        """
+        GIVEN a survey with a pressure question and geometries
+        WHEN we export and import it
+        THEN the geometries are preserved on the question
+        """
+        from .serialization import export_survey_to_zip, import_survey_from_zip
+
+        buf = BytesIO()
+        export_survey_to_zip(self.survey, buf, mode="structure")
+
+        buf.seek(0)
+        imported_survey, warnings = import_survey_from_zip(buf)
+
+        imported_q = Question.objects.filter(
+            survey_section__survey_header=imported_survey,
+            input_type="pressure",
+        ).first()
+        self.assertIsNotNone(imported_q)
+        self.assertEqual(len(imported_q.geometries), 2)
+        self.assertEqual(imported_q.geometries[0]["id"], "shape_a")
+
+    def test_serialization_roundtrip_geometry_id(self):
+        """
+        GIVEN a survey with pressure answers and geometry_id
+        WHEN we export and import it
+        THEN geometry_id is preserved on the answers
+        """
+        from .serialization import export_survey_to_zip, import_survey_from_zip
+
+        session = SurveySession.objects.create(survey=self.survey)
+        parent_answer = Answer.objects.create(
+            survey_session=session,
+            question=self.pressure_q,
+            point=Point(30.3, 59.9, srid=4326),
+            geometry_id="shape_a",
+        )
+        Answer.objects.create(
+            survey_session=session,
+            question=self.sub_q,
+            parent_answer_id=parent_answer,
+            numeric=5.0,
+            geometry_id="shape_a",
+        )
+
+        buf = BytesIO()
+        export_survey_to_zip(self.survey, buf, mode="full")
+
+        buf.seek(0)
+        imported_survey, warnings = import_survey_from_zip(buf)
+
+        imported_answers = Answer.objects.filter(
+            survey_session__survey=imported_survey,
+            geometry_id="shape_a",
+        )
+        self.assertTrue(imported_answers.exists())
+
+    def test_non_pressure_answer_has_null_geometry_id(self):
+        """
+        GIVEN a regular text answer
+        WHEN created without geometry_id
+        THEN geometry_id is None
+        """
+        text_q = Question.objects.create(
+            survey_section=self.section,
+            name="Name",
+            input_type="text",
+            order_number=2,
+        )
+        session = SurveySession.objects.create(survey=self.survey)
+        answer = Answer.objects.create(
+            survey_session=session,
+            question=text_q,
+            text="Test",
+        )
+        self.assertIsNone(answer.geometry_id)

--- a/survey/views.py
+++ b/survey/views.py
@@ -334,17 +334,31 @@ def survey_section(request, survey_slug, section_name):
 			if (result != []):
 				if not question.choices:
 					result = result[0]
-					if (question.input_type in ['point', 'line', 'polygon']):
+					if (question.input_type in ['point', 'line', 'polygon', 'pressure']):
 						geostr_list = result.split('|')
 						for geostr in geostr_list:
 							if geostr != '':
-								answer = Answer(survey_session=survey_session, question=question)
-
 								gj = geojson.loads(geostr)
 								geometry = geojson.dumps(gj['geometry'])
 								resultToSave = GEOSGeometry(geometry)
 
-								if question.input_type == "point":
+								# Extract geometry_id for pressure questions
+								geom_id = gj.get('properties', {}).get('geometry_id')
+
+								answer = Answer(survey_session=survey_session, question=question)
+								if geom_id:
+									answer.geometry_id = geom_id
+
+								if question.input_type == "pressure":
+									# Dispatch by GeoJSON geometry type
+									geom_type = gj['geometry']['type']
+									if geom_type == "Point":
+										answer.point = resultToSave
+									elif geom_type == "LineString":
+										answer.line = resultToSave
+									elif geom_type == "Polygon":
+										answer.polygon = resultToSave
+								elif question.input_type == "point":
 									answer.point = resultToSave
 								elif question.input_type == "line":
 									answer.line = resultToSave
@@ -356,9 +370,11 @@ def survey_section(request, survey_slug, section_name):
 								#сохранить properties как ответы наследники
 								properties = gj['properties'];
 								for key, value in properties.items():
-									if key != 'question_id':
+									if key not in ('question_id', 'geometry_id'):
 										sub_question = Question.objects.get(Q(survey_section=section) & Q(code=key))
 										sub_answer = Answer(survey_session=survey_session, question=sub_question, parent_answer_id = answer)
+										if geom_id:
+											sub_answer.geometry_id = geom_id
 										if not sub_question.choices:
 											if (sub_question.input_type == 'text' or sub_question.input_type == 'text_line') and value and value[0]:
 												sub_answer.text = value[0]
@@ -427,11 +443,15 @@ def survey_section(request, survey_slug, section_name):
 			if not q_answers:
 				continue
 
-			if question.input_type in ('point', 'line', 'polygon'):
+			if question.input_type in ('point', 'line', 'polygon', 'pressure'):
 				# Build GeoJSON features for geo answers
 				features = []
 				for answer in q_answers:
-					geometry = getattr(answer, question.input_type)
+					# For pressure, dispatch geometry field by checking which is non-null
+					if question.input_type == 'pressure':
+						geometry = answer.point or answer.line or answer.polygon
+					else:
+						geometry = getattr(answer, question.input_type)
 					if geometry is None:
 						continue
 					feature = {
@@ -439,6 +459,9 @@ def survey_section(request, survey_slug, section_name):
 						'geometry': json.loads(geometry.geojson),
 						'properties': {'question_id': question.code},
 					}
+					# Include geometry_id for pressure answers
+					if answer.geometry_id:
+						feature['properties']['geometry_id'] = answer.geometry_id
 					# Add sub-question values
 					child_answers = Answer.objects.filter(parent_answer_id=answer).select_related('question')
 					for child in child_answers:
@@ -509,14 +532,12 @@ def download_data(request, survey_slug):
 	geo_questions = survey.geo_questions()	
 
 	for question in geo_questions:
-		
+
 		layer_properties = {
 			"survey": question.survey_section.survey_header.name,
 			"survey_section": question.survey_section.name,
 			"required": question.required,
 		}
-
-		#layer_str = geojson_template.format(layer_name = question.name, properties=layer_properties)
 
 		#получить ответы
 		features = []
@@ -524,7 +545,21 @@ def download_data(request, survey_slug):
 		for answer in answers:
 			#получить геометрию
 			geo_type = question.input_type
-			if geo_type == "polygon":
+			coordinates = None
+			geometry_type = None
+
+			if geo_type == "pressure":
+				# Dispatch by checking which geo field is populated
+				if answer.point:
+					coordinates = [answer.point.coords[0], answer.point.coords[1]]
+					geometry_type = "Point"
+				elif answer.line:
+					coordinates = [[i[0],i[1]] for i in answer.line.coords]
+					geometry_type = "LineString"
+				elif answer.polygon:
+					coordinates = [[[i[0],i[1]] for i in answer.polygon.coords[0]]]
+					geometry_type = "Polygon"
+			elif geo_type == "polygon":
 				coordinates =  [[[i[0],i[1]] for i in answer.polygon.coords[0]]]
 				geometry_type = "Polygon"
 			elif geo_type == "line":
@@ -533,6 +568,9 @@ def download_data(request, survey_slug):
 			elif geo_type == "point":
 				coordinates =  [answer.point.coords[0], answer.point.coords[1]]
 				geometry_type = "Point"
+
+			if coordinates is None or geometry_type is None:
+				continue
 
 			#получить properties из subquestions
 			subquestions = question.subQuestions()
@@ -543,22 +581,29 @@ def download_data(request, survey_slug):
 				input_type = key.input_type
 				if (input_type == "text" or input_type == "text_line"):
 					if subanswers[key]:
-						answer = subanswers[key][0]
-						result = answer.text
+						sub_a = subanswers[key][0]
+						result = sub_a.text
 				elif input_type == "number" or input_type == "range":
 					if subanswers[key]:
-						answer = subanswers[key][0]
-						result = answer.numeric
+						sub_a = subanswers[key][0]
+						result = sub_a.numeric
 				elif input_type == "choice" or input_type == "rating":
 					if subanswers[key]:
-						answer = subanswers[key][0]
-						names = answer.get_selected_choice_names()
+						sub_a = subanswers[key][0]
+						names = sub_a.get_selected_choice_names()
 						result = names[0] if names else ""
 				elif input_type == "multichoice":
 					if subanswers[key]:
 						result = subanswers[key][0].get_selected_choice_names()
 
 				properties[key.name] = result
+
+			# Add geometry_id and geometry_label for pressure answers
+			if answer.geometry_id and question.geometries:
+				properties["geometry_id"] = answer.geometry_id
+				shape = next((s for s in question.geometries if s['id'] == answer.geometry_id), None)
+				if shape:
+					properties["geometry_label"] = shape.get('label', '')
 
 			properties["session"] = str(answer.survey_session)
 
@@ -572,21 +617,17 @@ def download_data(request, survey_slug):
 			}
 
 			features.append(feature)
-		
+
 		geojson_dict = {
-			"type": "FeatureCollection", 
+			"type": "FeatureCollection",
 			"name": question.name,
 			"crs": {"type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" }},
 			"properties": layer_properties,
 			"features": features,
-		} 
+		}
 
 		geojson_str = json.dumps(geojson_dict, ensure_ascii=False).encode('utf8')
 
-		#сформировать geojson файл
-		#geojson_str = serialize('geojson', answers, geometry_field=question.input_type)
-		
-		#cформировать файлы
 		zip.writestr(question.name + '.geojson', geojson_str)
 
 	#обработка обычных вопросов
@@ -613,7 +654,18 @@ def download_data(request, survey_slug):
 			else:
 				continue
 
-			properties[answer.question.name] = result
+			# Build column name with geometry_id suffix for pressure sub-answers
+			col_name = answer.question.name
+			if answer.geometry_id:
+				properties["geometry_id"] = answer.geometry_id
+				# Look up label from parent question's geometries
+				parent = answer.parent_answer_id
+				if parent and parent.question.geometries:
+					shape = next((s for s in parent.question.geometries if s['id'] == answer.geometry_id), None)
+					if shape:
+						properties["geometry_label"] = shape.get('label', '')
+
+			properties[col_name] = result
 
 		properties["session"] = str(session)
 		properties["datetime"] = session.start_datetime


### PR DESCRIPTION
Create new OpenSpec change directory for the geometry pressure feature —
allowing respondents to click pre-defined geometric shapes on a map to
provide opinions about park improvement objects.

https://claude.ai/code/session_01Bec74Ro1tPELwx8vGsXJp2