### PR TITLE
Replace Yandex Metrica with Plausible Analytics

### DIFF
--- a/mapsurvey/settings.py
+++ b/mapsurvey/settings.py
@@ -89,6 +89,7 @@ TEMPLATES = [
                 'survey.context_processors.mapbox',
                 'survey.context_processors.contact',
                 'survey.context_processors.active_org',
+                'survey.context_processors.analytics',
             ],
         },
     },
@@ -236,6 +237,9 @@ EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'False').lower() in ('true', '1')
 EMAIL_USE_SSL = os.environ.get('EMAIL_USE_SSL', 'False').lower() in ('true', '1')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@mapsurvey.org')
+
+# Plausible Analytics
+PLAUSIBLE_SCRIPT_URL = os.environ.get('PLAUSIBLE_SCRIPT_URL', '')
 
 # Landing page
 CONTACT_EMAIL = os.environ.get('CONTACT_EMAIL', 'konuchovartem@gmail.com')

--- a/openspec/changes/plausible-analytics/.openspec.yaml
+++ b/openspec/changes/plausible-analytics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-17

--- a/openspec/changes/plausible-analytics/design.md
+++ b/openspec/changes/plausible-analytics/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The platform has 4 separate base templates (`base_survey_template.html`, `base.html`, `base_landing.html`, `editor/editor_base.html`). Yandex Metrica is hardcoded (counter ID 53686546) only in `base_survey_template.html` — covering just survey section pages. Landing, editor, auth, and thanks pages have zero analytics. The counter ID is not configurable.
+
+The established pattern for site-wide configuration: environment variable → `settings.py` → context processor → template variable (used by Mapbox tokens, contact info).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Plausible Analytics script on all pages, configurable via environment variables
+- Remove hardcoded Yandex Metrica
+- Track survey funnel events: start, section complete, survey complete
+- Zero analytics output when not configured (safe for dev/test)
+
+**Non-Goals:**
+- Server-side event tracking (e.g., via Plausible API) — client-side only
+- Per-survey analytics dashboards or in-app analytics display
+- Yandex Metrica as a configurable option (removed entirely)
+- Session replay or heatmaps (Plausible doesn't support these)
+
+## Decisions
+
+### 1. Single template partial with `{% include %}`
+
+Include `partials/_analytics.html` in all 4 base templates' `<head>` sections. The partial renders nothing when `PLAUSIBLE_DOMAIN` is empty.
+
+**Why over per-template inline code**: DRY — one file to change if the script tag format changes. All 4 base templates are independent (no shared ancestor), so a partial is the cleanest way to share.
+
+**Why over Django template tag**: A simple `{% include %}` is sufficient. A custom template tag would be over-engineering for a single `<script>` element.
+
+### 2. Context processor (not direct `settings` access in templates)
+
+New `analytics()` context processor exposes `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL`.
+
+**Why over `{% load settings %}` or `django.conf.settings` in templates**: Follows the established codebase pattern (mapbox, contact processors). Templates don't import settings directly anywhere in this project.
+
+### 3. Client-side custom events via Plausible JS API
+
+Fire `plausible('event_name', {props: {...}})` from inline `<script>` tags in survey templates.
+
+- `survey_start`: fires on page load of the first section (detected by `section_current == 1`)
+- `survey_section_complete`: fires on form submit via `addEventListener('submit', ...)`
+- `survey_complete`: fires on page load of thanks page
+
+**Why form submit listener for `survey_section_complete`**: POST always redirects (no template rendered after save). The `submit` event fires before navigation, and Plausible uses `navigator.sendBeacon()` internally which survives page unload.
+
+**Why not server-side events**: Would require adding `requests` dependency and async HTTP calls in views. Client-side is simpler, matches Plausible's design, and the data (pageviews + funnel) doesn't need 100% accuracy.
+
+### 4. `PLAUSIBLE_SCRIPT_URL` for self-hosted support
+
+Default: `https://plausible.io/js/script.js`. Override for self-hosted Plausible instances.
+
+**Why a separate env var**: The script URL differs between cloud and self-hosted. Hardcoding the cloud URL would break self-hosted setups.
+
+## Risks / Trade-offs
+
+- **Ad-blockers block Plausible** → Accepted. This is inherent to all client-side analytics. Data will undercount by ~15-30%. Mitigation: can use a proxied script URL via `PLAUSIBLE_SCRIPT_URL` if needed.
+- **`defer` script timing** → The Plausible script loads with `defer`. Custom event scripts in `{% block section_scripts %}` run after DOM parse, so `plausible()` function is available. Guard with `typeof plausible !== 'undefined'` for ad-blocker edge cases.
+- **No rollback needed** → Feature is purely additive (env var controlled). Unsetting `PLAUSIBLE_DOMAIN` disables everything. Yandex Metrica removal is intentional and non-reversible.

--- a/openspec/changes/plausible-analytics/proposal.md
+++ b/openspec/changes/plausible-analytics/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The platform has hardcoded Yandex Metrica (counter 53686546) only on survey section pages. The landing page, editor, thanks page, and auth pages have no analytics. The counter ID is not configurable via environment variables. We need privacy-friendly, configurable analytics across all pages with survey funnel event tracking to understand user behavior.
+
+## What Changes
+
+- **Remove** hardcoded Yandex Metrica script from `base_survey_template.html`
+- **Add** Plausible Analytics integration configurable via environment variables (`PLAUSIBLE_DOMAIN`, `PLAUSIBLE_SCRIPT_URL`)
+- **Add** analytics context processor to inject config into all templates
+- **Add** shared template partial (`partials/_analytics.html`) included in all 4 base templates
+- **Add** custom Plausible events for survey funnel: `survey_start`, `survey_section_complete`, `survey_complete`
+- **No analytics rendered** when `PLAUSIBLE_DOMAIN` is unset (safe default for development)
+
+## Capabilities
+
+### New Capabilities
+- `plausible-analytics`: Configurable Plausible Analytics integration with pageview tracking on all pages and custom survey funnel events
+
+### Modified Capabilities
+_(none — this is a new cross-cutting capability, no existing spec requirements change)_
+
+## Impact
+
+- **Templates**: All 4 base templates modified to include analytics partial (`base_survey_template.html`, `base.html`, `base_landing.html`, `editor/editor_base.html`). Event scripts added to `survey_section.html` and `survey_thanks.html`
+- **Settings**: Two new env vars (`PLAUSIBLE_DOMAIN`, `PLAUSIBLE_SCRIPT_URL`)
+- **Context processors**: New `analytics()` context processor registered in settings
+- **No database changes**: No migrations needed
+- **No new dependencies**: Uses Plausible's CDN script, no Python packages

--- a/openspec/changes/plausible-analytics/specs/plausible-analytics/spec.md
+++ b/openspec/changes/plausible-analytics/specs/plausible-analytics/spec.md
@@ -1,30 +1,26 @@
 ## ADDED Requirements
 
-### Requirement: Plausible script is configurable via environment variables
-The system SHALL read `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL` from environment variables. `PLAUSIBLE_DOMAIN` defaults to empty string. `PLAUSIBLE_SCRIPT_URL` defaults to `https://plausible.io/js/script.js`. Both values SHALL be exposed to all templates via an `analytics` context processor.
+### Requirement: Plausible script is configurable via environment variable
+The system SHALL read `PLAUSIBLE_SCRIPT_URL` from an environment variable. It defaults to empty string (analytics disabled). The value SHALL be exposed to all templates via an `analytics` context processor.
 
-#### Scenario: Environment variables are set
-- **WHEN** `PLAUSIBLE_DOMAIN` is set to `example.com` in the environment
-- **THEN** the context processor SHALL inject `PLAUSIBLE_DOMAIN='example.com'` and `PLAUSIBLE_SCRIPT_URL` into every template context
+#### Scenario: Environment variable is set
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is set to a Plausible script URL (e.g., `https://plausible.io/js/pa-lwntAkTnmyk5UaA7Vjaw4.js`)
+- **THEN** the context processor SHALL inject `PLAUSIBLE_SCRIPT_URL` into every template context
 
-#### Scenario: Environment variables are not set
-- **WHEN** `PLAUSIBLE_DOMAIN` is not set in the environment
-- **THEN** the context processor SHALL inject `PLAUSIBLE_DOMAIN=''` (empty string) into every template context
+#### Scenario: Environment variable is not set
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is not set in the environment
+- **THEN** the context processor SHALL inject `PLAUSIBLE_SCRIPT_URL=''` (empty string) into every template context
 
 ### Requirement: Plausible script tag renders on all pages when configured
-The system SHALL render a `<script defer data-domain="..." src="..."></script>` tag in the `<head>` of every page when `PLAUSIBLE_DOMAIN` is non-empty. The script tag SHALL be included via a shared template partial (`partials/_analytics.html`) in all 4 base templates: `base_survey_template.html`, `base.html`, `base_landing.html`, `editor/editor_base.html`.
+The system SHALL render the Plausible `<script async src="..."></script>` tag and init block in the `<head>` of every page when `PLAUSIBLE_SCRIPT_URL` is non-empty. The script SHALL be included via a shared template partial (`partials/_analytics.html`) in all 4 base templates: `base_survey_template.html`, `base.html`, `base_landing.html`, `editor/editor_base.html`.
 
 #### Scenario: Analytics enabled
-- **WHEN** `PLAUSIBLE_DOMAIN` is set to `mapsurvey.org`
-- **THEN** every page SHALL contain `<script defer data-domain="mapsurvey.org" src="https://plausible.io/js/script.js"></script>` in the HTML head
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is set
+- **THEN** every page SHALL contain the async script tag and `plausible.init()` block in the HTML head
 
 #### Scenario: Analytics disabled
-- **WHEN** `PLAUSIBLE_DOMAIN` is empty or unset
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is empty or unset
 - **THEN** no Plausible script tag SHALL appear in any page's HTML
-
-#### Scenario: Self-hosted Plausible
-- **WHEN** `PLAUSIBLE_SCRIPT_URL` is set to `https://stats.example.com/js/script.js`
-- **THEN** the script tag's `src` attribute SHALL use that URL instead of the default
 
 ### Requirement: Yandex Metrica is removed
 The hardcoded Yandex Metrica script (counter ID 53686546) SHALL be removed from `base_survey_template.html`. No Yandex Metrica code SHALL remain in any template.
@@ -37,7 +33,7 @@ The hardcoded Yandex Metrica script (counter ID 53686546) SHALL be removed from 
 The system SHALL fire a `survey_start` Plausible custom event when a respondent views the first section of a survey. The event SHALL include a `survey` property with the survey name.
 
 #### Scenario: First section loaded
-- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent loads the first section of a survey (no previous section exists)
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is configured AND the respondent loads the first section of a survey (no previous section exists)
 - **THEN** the page SHALL call `plausible('survey_start', {props: {survey: '<survey_name>'}})` on page load
 
 #### Scenario: Non-first section loaded
@@ -48,14 +44,14 @@ The system SHALL fire a `survey_start` Plausible custom event when a respondent 
 The system SHALL fire a `survey_section_complete` Plausible custom event when a respondent submits a section form. The event SHALL include `survey`, `section`, and `section_number` properties.
 
 #### Scenario: Section form submitted
-- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent submits a section form
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is configured AND the respondent submits a section form
 - **THEN** the page SHALL call `plausible('survey_section_complete', {props: {survey: '<name>', section: '<section_name>', section_number: <N>}})` before the form navigates away
 
 ### Requirement: Survey complete event fires on thanks page
 The system SHALL fire a `survey_complete` Plausible custom event when the thanks page loads. The event SHALL include a `survey` property with the survey name.
 
 #### Scenario: Thanks page loaded
-- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent reaches the thanks page
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is configured AND the respondent reaches the thanks page
 - **THEN** the page SHALL call `plausible('survey_complete', {props: {survey: '<survey_name>'}})` on page load
 
 ### Requirement: Events are guarded against blocked scripts

--- a/openspec/changes/plausible-analytics/specs/plausible-analytics/spec.md
+++ b/openspec/changes/plausible-analytics/specs/plausible-analytics/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Plausible script is configurable via environment variables
+The system SHALL read `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL` from environment variables. `PLAUSIBLE_DOMAIN` defaults to empty string. `PLAUSIBLE_SCRIPT_URL` defaults to `https://plausible.io/js/script.js`. Both values SHALL be exposed to all templates via an `analytics` context processor.
+
+#### Scenario: Environment variables are set
+- **WHEN** `PLAUSIBLE_DOMAIN` is set to `example.com` in the environment
+- **THEN** the context processor SHALL inject `PLAUSIBLE_DOMAIN='example.com'` and `PLAUSIBLE_SCRIPT_URL` into every template context
+
+#### Scenario: Environment variables are not set
+- **WHEN** `PLAUSIBLE_DOMAIN` is not set in the environment
+- **THEN** the context processor SHALL inject `PLAUSIBLE_DOMAIN=''` (empty string) into every template context
+
+### Requirement: Plausible script tag renders on all pages when configured
+The system SHALL render a `<script defer data-domain="..." src="..."></script>` tag in the `<head>` of every page when `PLAUSIBLE_DOMAIN` is non-empty. The script tag SHALL be included via a shared template partial (`partials/_analytics.html`) in all 4 base templates: `base_survey_template.html`, `base.html`, `base_landing.html`, `editor/editor_base.html`.
+
+#### Scenario: Analytics enabled
+- **WHEN** `PLAUSIBLE_DOMAIN` is set to `mapsurvey.org`
+- **THEN** every page SHALL contain `<script defer data-domain="mapsurvey.org" src="https://plausible.io/js/script.js"></script>` in the HTML head
+
+#### Scenario: Analytics disabled
+- **WHEN** `PLAUSIBLE_DOMAIN` is empty or unset
+- **THEN** no Plausible script tag SHALL appear in any page's HTML
+
+#### Scenario: Self-hosted Plausible
+- **WHEN** `PLAUSIBLE_SCRIPT_URL` is set to `https://stats.example.com/js/script.js`
+- **THEN** the script tag's `src` attribute SHALL use that URL instead of the default
+
+### Requirement: Yandex Metrica is removed
+The hardcoded Yandex Metrica script (counter ID 53686546) SHALL be removed from `base_survey_template.html`. No Yandex Metrica code SHALL remain in any template.
+
+#### Scenario: Yandex Metrica absent
+- **WHEN** any page is rendered
+- **THEN** the HTML SHALL NOT contain any reference to `mc.yandex.ru` or Yandex Metrica counter code
+
+### Requirement: Survey start event fires on first section
+The system SHALL fire a `survey_start` Plausible custom event when a respondent views the first section of a survey. The event SHALL include a `survey` property with the survey name.
+
+#### Scenario: First section loaded
+- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent loads the first section of a survey (no previous section exists)
+- **THEN** the page SHALL call `plausible('survey_start', {props: {survey: '<survey_name>'}})` on page load
+
+#### Scenario: Non-first section loaded
+- **WHEN** the respondent navigates to a section that is not the first section
+- **THEN** the `survey_start` event SHALL NOT fire
+
+### Requirement: Survey section complete event fires on form submit
+The system SHALL fire a `survey_section_complete` Plausible custom event when a respondent submits a section form. The event SHALL include `survey`, `section`, and `section_number` properties.
+
+#### Scenario: Section form submitted
+- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent submits a section form
+- **THEN** the page SHALL call `plausible('survey_section_complete', {props: {survey: '<name>', section: '<section_name>', section_number: <N>}})` before the form navigates away
+
+### Requirement: Survey complete event fires on thanks page
+The system SHALL fire a `survey_complete` Plausible custom event when the thanks page loads. The event SHALL include a `survey` property with the survey name.
+
+#### Scenario: Thanks page loaded
+- **WHEN** `PLAUSIBLE_DOMAIN` is configured AND the respondent reaches the thanks page
+- **THEN** the page SHALL call `plausible('survey_complete', {props: {survey: '<survey_name>'}})` on page load
+
+### Requirement: Events are guarded against blocked scripts
+All custom event calls SHALL be guarded with `typeof plausible !== 'undefined'` to gracefully handle cases where the Plausible script is blocked by ad-blockers.
+
+#### Scenario: Plausible script blocked by ad-blocker
+- **WHEN** the Plausible script fails to load (e.g., blocked by browser extension)
+- **THEN** the event scripts SHALL NOT throw JavaScript errors

--- a/openspec/changes/plausible-analytics/tasks.md
+++ b/openspec/changes/plausible-analytics/tasks.md
@@ -1,28 +1,28 @@
 ## 1. Settings and Context Processor
 
-- [ ] 1.1 Add `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL` to `mapsurvey/settings.py`
-- [ ] 1.2 Add `analytics()` context processor to `survey/context_processors.py`
-- [ ] 1.3 Register `survey.context_processors.analytics` in `TEMPLATES` config in `settings.py`
+- [x] 1.1 Add `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL` to `mapsurvey/settings.py`
+- [x] 1.2 Add `analytics()` context processor to `survey/context_processors.py`
+- [x] 1.3 Register `survey.context_processors.analytics` in `TEMPLATES` config in `settings.py`
 
 ## 2. Analytics Template Partial
 
-- [ ] 2.1 Create `survey/templates/partials/_analytics.html` with conditional Plausible script tag
+- [x] 2.1 Create `survey/templates/partials/_analytics.html` with conditional Plausible script tag
 
 ## 3. Base Template Integration
 
-- [ ] 3.1 Remove Yandex Metrica from `base_survey_template.html` and add analytics include
-- [ ] 3.2 Add analytics include to `base.html`
-- [ ] 3.3 Add analytics include to `base_landing.html`
-- [ ] 3.4 Add analytics include to `editor/editor_base.html`
+- [x] 3.1 Remove Yandex Metrica from `base_survey_template.html` and add analytics include
+- [x] 3.2 Add analytics include to `base.html`
+- [x] 3.3 Add analytics include to `base_landing.html`
+- [x] 3.4 Add analytics include to `editor/editor_base.html`
 
 ## 4. Custom Funnel Events
 
-- [ ] 4.1 Add `survey_start` and `survey_section_complete` event scripts to `survey_section.html`
-- [ ] 4.2 Add `survey_complete` event script to `survey_thanks.html`
+- [x] 4.1 Add `survey_start` and `survey_section_complete` event scripts to `survey_section.html`
+- [x] 4.2 Add `survey_complete` event script to `survey_thanks.html`
 
 ## 5. Tests
 
-- [ ] 5.1 Test: no Plausible script when `PLAUSIBLE_DOMAIN` is unset
-- [ ] 5.2 Test: Plausible script present when `PLAUSIBLE_DOMAIN` is set
-- [ ] 5.3 Test: Yandex Metrica code is absent from all pages
-- [ ] 5.4 Test: custom event scripts present on survey section and thanks pages
+- [x] 5.1 Test: no Plausible script when `PLAUSIBLE_DOMAIN` is unset
+- [x] 5.2 Test: Plausible script present when `PLAUSIBLE_DOMAIN` is set
+- [x] 5.3 Test: Yandex Metrica code is absent from all pages
+- [x] 5.4 Test: custom event scripts present on survey section and thanks pages

--- a/openspec/changes/plausible-analytics/tasks.md
+++ b/openspec/changes/plausible-analytics/tasks.md
@@ -1,0 +1,28 @@
+## 1. Settings and Context Processor
+
+- [ ] 1.1 Add `PLAUSIBLE_DOMAIN` and `PLAUSIBLE_SCRIPT_URL` to `mapsurvey/settings.py`
+- [ ] 1.2 Add `analytics()` context processor to `survey/context_processors.py`
+- [ ] 1.3 Register `survey.context_processors.analytics` in `TEMPLATES` config in `settings.py`
+
+## 2. Analytics Template Partial
+
+- [ ] 2.1 Create `survey/templates/partials/_analytics.html` with conditional Plausible script tag
+
+## 3. Base Template Integration
+
+- [ ] 3.1 Remove Yandex Metrica from `base_survey_template.html` and add analytics include
+- [ ] 3.2 Add analytics include to `base.html`
+- [ ] 3.3 Add analytics include to `base_landing.html`
+- [ ] 3.4 Add analytics include to `editor/editor_base.html`
+
+## 4. Custom Funnel Events
+
+- [ ] 4.1 Add `survey_start` and `survey_section_complete` event scripts to `survey_section.html`
+- [ ] 4.2 Add `survey_complete` event script to `survey_thanks.html`
+
+## 5. Tests
+
+- [ ] 5.1 Test: no Plausible script when `PLAUSIBLE_DOMAIN` is unset
+- [ ] 5.2 Test: Plausible script present when `PLAUSIBLE_DOMAIN` is set
+- [ ] 5.3 Test: Yandex Metrica code is absent from all pages
+- [ ] 5.4 Test: custom event scripts present on survey section and thanks pages

--- a/survey/context_processors.py
+++ b/survey/context_processors.py
@@ -19,6 +19,12 @@ def contact(request):
     }
 
 
+def analytics(request):
+    return {
+        'PLAUSIBLE_SCRIPT_URL': getattr(settings, 'PLAUSIBLE_SCRIPT_URL', ''),
+    }
+
+
 def active_org(request):
     """Inject active organization and user's org list into template context."""
     if not hasattr(request, 'user') or not request.user.is_authenticated:

--- a/survey/templates/base.html
+++ b/survey/templates/base.html
@@ -3,6 +3,7 @@
 <html>
     <head>
         <title>{% block title %}Mapsurvey{% endblock %}</title>
+        {% include "partials/_analytics.html" %}
         <link rel="icon" href="{% static 'favicon.ico' %}" sizes="any">
         <link rel="icon" href="{% static 'favicon-32x32.png' %}" type="image/png" sizes="32x32">
         <link rel="apple-touch-icon" href="{% static 'favicon-180x180.png' %}">

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% trans "Mapsurvey — Open-Source Participatory Mapping Platform | Free PPGIS Tool" %}{% endblock %}</title>
+    {% include "partials/_analytics.html" %}
     <link rel="icon" href="{% static 'favicon.ico' %}" sizes="any">
     <link rel="icon" href="{% static 'favicon-32x32.png' %}" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="{% static 'favicon-180x180.png' %}">

--- a/survey/templates/base_survey_template.html
+++ b/survey/templates/base_survey_template.html
@@ -1,20 +1,6 @@
 {% load static i18n i18n_extras %}
 <head>
-	<!-- Yandex.Metrika counter -->
-	<script type="text/javascript" >
-	   (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-	   m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-	   (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
-
-	   ym(53686546, "init", {
-	        clickmap:true,
-	        trackLinks:true,
-	        accurateTrackBounce:true,
-	        webvisor:true
-	   });
-	</script>
-	<noscript><div><img src="https://mc.yandex.ru/watch/53686546" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
-	<!-- /Yandex.Metrika counter -->
+    {% include "partials/_analytics.html" %}
 
     <link rel="icon" href="{% static 'favicon.ico' %}" sizes="any">
     <link rel="icon" href="{% static 'favicon-32x32.png' %}" type="image/png" sizes="32x32">

--- a/survey/templates/editor/editor_base.html
+++ b/survey/templates/editor/editor_base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>{% block page_title %}Survey Editor{% endblock %} – Mapsurvey</title>
+    {% include "partials/_analytics.html" %}
     <link rel="icon" href="{% static 'favicon.ico' %}" sizes="any">
     <link rel="icon" href="{% static 'favicon-32x32.png' %}" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="{% static 'favicon-180x180.png' %}">

--- a/survey/templates/partials/_analytics.html
+++ b/survey/templates/partials/_analytics.html
@@ -1,0 +1,4 @@
+{% if PLAUSIBLE_SCRIPT_URL %}
+<script async src="{{ PLAUSIBLE_SCRIPT_URL }}"></script>
+<script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+{% endif %}

--- a/survey/templates/survey_section.html
+++ b/survey/templates/survey_section.html
@@ -58,6 +58,21 @@
 
 {% block section_scripts %}
 
+{% if PLAUSIBLE_SCRIPT_URL %}
+<script>
+{% if section_current == 1 %}
+if (typeof plausible !== 'undefined') {
+    plausible('survey_start', {props: {survey: '{{ survey.name|escapejs }}'}});
+}
+{% endif %}
+document.getElementById('section_question_form').addEventListener('submit', function() {
+    if (typeof plausible !== 'undefined') {
+        plausible('survey_section_complete', {props: {survey: '{{ survey.name|escapejs }}', section: '{{ section.name|escapejs }}', section_number: {{ section_current }}}});
+    }
+});
+</script>
+{% endif %}
+
 <script type="text/javascript">
 
     //var map = L.map('map', {zoomControl: false}).setView(["{{ section.start_map_postion.y }}".replace(",","."), "{{ section.start_map_postion.x }}".replace(",",".")], "{{ section.start_map_zoom }}");

--- a/survey/templates/survey_thanks.html
+++ b/survey/templates/survey_thanks.html
@@ -1,6 +1,18 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
+{% block extra_head %}
+{% if PLAUSIBLE_SCRIPT_URL %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof plausible !== 'undefined') {
+        plausible('survey_complete', {props: {survey: '{{ survey.name|escapejs }}'}});
+    }
+});
+</script>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 {% if thanks_html %}
     {{ thanks_html|safe }}

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -8679,3 +8679,155 @@ class SessionProtectTest(TestCase):
         # Session still exists on the other survey
         self.session.refresh_from_db()
         self.assertEqual(self.session.survey, other_survey)
+
+
+class PlausibleAnalyticsTest(TestCase):
+    """Tests for Plausible Analytics integration."""
+
+    def setUp(self):
+        self.org = _make_org('AnalyticsOrg')
+        self.user = User.objects.create_user('analyticsuser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+        self.survey = SurveyHeader.objects.create(
+            name='analytics_survey',
+            organization=self.org,
+            redirect_url='#',
+            status='published',
+        )
+        self.section1 = SurveySection.objects.create(
+            survey_header=self.survey,
+            name='section1',
+            start_map_postion=Point(0, 0),
+            start_map_zoom=10,
+        )
+        self.section2 = SurveySection.objects.create(
+            survey_header=self.survey,
+            name='section2',
+            start_map_postion=Point(0, 0),
+            start_map_zoom=10,
+        )
+        self.section1.next_section = self.section2
+        self.section1.save()
+        self.section2.prev_section = self.section1
+        self.section2.save()
+
+    def test_no_plausible_script_when_url_unset(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is empty (default)
+        WHEN any page is rendered
+        THEN no Plausible script tag appears in the HTML
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL=''):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertNotContains(response, 'plausible.io')
+            self.assertNotContains(response, 'plausible.init')
+
+    def test_plausible_script_present_when_url_set(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is set
+        WHEN any page is rendered
+        THEN the Plausible script tag and init block appear
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test123.js'):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertContains(response, 'src="https://plausible.io/js/pa-test123.js"')
+            self.assertContains(response, 'plausible.init')
+
+    def test_plausible_script_with_custom_url(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL points to a self-hosted instance
+        WHEN a page is rendered
+        THEN the script tag uses that URL
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://stats.example.com/js/pa-abc.js'):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertContains(response, 'src="https://stats.example.com/js/pa-abc.js"')
+
+    def test_yandex_metrica_absent(self):
+        """
+        GIVEN any configuration
+        WHEN a survey section page is rendered
+        THEN no Yandex Metrica code appears in the HTML
+        """
+        response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+        self.assertNotContains(response, 'mc.yandex.ru')
+        self.assertNotContains(response, '53686546')
+
+    def test_survey_start_event_on_first_section(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is configured
+        WHEN the first section of a survey is loaded
+        THEN the page contains a survey_start event script
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertContains(response, "plausible('survey_start'")
+            self.assertContains(response, "survey: 'analytics_survey'")
+
+    def test_no_survey_start_event_on_non_first_section(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is configured
+        WHEN a non-first section is loaded
+        THEN the page does NOT contain a survey_start event script
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            # Visit first section to create a session
+            self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section2/')
+            self.assertNotContains(response, "plausible('survey_start'")
+
+    def test_survey_section_complete_event_present(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is configured
+        WHEN a survey section page is loaded
+        THEN the page contains a survey_section_complete event script
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertContains(response, "plausible('survey_section_complete'")
+
+    def test_survey_complete_event_on_thanks_page(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is configured AND a respondent has an active session
+        WHEN the thanks page is loaded
+        THEN the page contains a survey_complete event script
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            # Create a session by visiting first section
+            self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            response = self.client.get(f'/surveys/{self.survey.uuid}/thanks/')
+            self.assertContains(response, "plausible('survey_complete'")
+
+    def test_no_events_when_plausible_disabled(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is empty
+        WHEN survey pages are loaded
+        THEN no custom event scripts appear
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL=''):
+            self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            self.assertNotContains(response, "plausible('survey_start'")
+            self.assertNotContains(response, "plausible('survey_section_complete'")
+
+    def test_plausible_on_editor_page(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is set
+        WHEN the editor page is loaded
+        THEN the Plausible script tag is present
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            self.client.login(username='analyticsuser', password='pass')
+            response = self.client.get('/editor/')
+            self.assertContains(response, 'src="https://plausible.io/js/pa-test.js"')
+
+    def test_events_guarded_against_blocked_scripts(self):
+        """
+        GIVEN PLAUSIBLE_SCRIPT_URL is configured
+        WHEN survey section page is rendered
+        THEN event scripts are guarded with typeof plausible check
+        """
+        with self.settings(PLAUSIBLE_SCRIPT_URL='https://plausible.io/js/pa-test.js'):
+            response = self.client.get(f'/surveys/{self.survey.uuid}/section1/')
+            content = response.content.decode()
+            self.assertIn("typeof plausible !== 'undefined'", content)


### PR DESCRIPTION
## Summary
- Remove hardcoded Yandex Metrica counter from `base_survey_template.html`
- Add Plausible Analytics via single `PLAUSIBLE_SCRIPT_URL` env var (empty = disabled)
- Analytics partial included in all 4 base templates (survey, auth, landing, editor)
- Custom funnel events: `survey_start`, `survey_section_complete`, `survey_complete`
- 11 new tests covering all scenarios

## Test plan
- [x] No Plausible output when `PLAUSIBLE_SCRIPT_URL` is unset
- [x] Script tag + init block present when configured
- [x] Self-hosted URL works
- [x] Yandex Metrica fully removed
- [x] Funnel events fire on correct pages
- [x] Events guarded with `typeof plausible` check
- [x] All 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)