### PR TITLE
Fix FontAwesome icons disappearing on respondent map page

### DIFF
--- a/survey/templates/base_survey_template.html
+++ b/survey/templates/base_survey_template.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
    integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
    crossorigin=""/>
-   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
+   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
     <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
    integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
    crossorigin=""></script>


### PR DESCRIPTION
## Summary

Respondents on `/surveys/<uuid>/<section>/` were silently losing every FontAwesome icon (draw buttons, layer switcher, navigation) because `base_survey_template.html` was the only template loading the FA stylesheet with Subresource Integrity:

```html
<link rel="stylesheet"
      href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
      integrity="sha384-50oBUHEmvpQ..."
      crossorigin="anonymous">
```

SRI forces a CORS-validated request. `use.fontawesome.com` no longer responds with `Access-Control-Allow-Origin`, so the browser blocks the stylesheet and all icons render as boxes. Editor pages (`base.html`, `editor.html`, `editor_base.html`, `question_preview_frame.html`) load the same URL without SRI/crossorigin and were unaffected — so the regression was respondent-only.

This drops the SRI hash and crossorigin attribute, matching every other template that pulls FontAwesome from this CDN.

## Test plan

- [x] Hard reload (Ctrl+Shift+R) on a survey page — icons render
- [ ] Verify after deploy on https://mapsurvey.org/surveys/.../section_1/

🤖 Generated with [Claude Code](https://claude.com/claude-code)