### PR TITLE
Add prominent "+ Add Sub-question" button on geo question cards

### DIFF
--- a/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/design.md
+++ b/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The WYSIWYG editor's question card (`survey/templates/editor/partials/question_list_item.html`) currently exposes the "create sub-question" affordance as one of three icon buttons in a `.q-actions` strip on the right side of the card row (alongside edit and delete). The icon used is `fa-sitemap`, which has no caption and does not visually distinguish itself from the other admin actions. Sub-questions are then listed under the parent in a `<ul class="subquestion-list">` that is rendered only when at least one sub-question exists — so a user who has never opened that menu has no visible cue that nesting is even possible.
+
+Top-level question creation, by contrast, uses a prominent full-width dashed-border button (`.add-question-btn`) below the question list, with a `fa-plus` icon and an explicit "+ New Question" label. The asymmetry is the discoverability problem.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move the sub-question entry point from the q-actions row to a prominent, always-visible button below the (possibly empty) sub-question list, only on geo-type question cards.
+- Reuse the existing `.add-question-btn` look so editor users immediately recognise it as "the add affordance, scoped to this card".
+- Keep the existing read-only state semantics (button disabled with "Create a draft to edit" tooltip when survey is published or closed).
+- Keep parity with the icon button's gating: only point/line/polygon questions get the affordance.
+
+**Non-Goals:**
+- No backend changes — `editor_subquestion_create` already returns the parent question partial via HX-Trigger, and the modal form template (`question_form_modal.html`) already branches on `parent` for the POST URL.
+- No drag-and-drop of sub-questions across geo-question parents (out of scope, tracked separately).
+- No paste-as-subquestion functionality (tracked in #16).
+- No onboarding hints, tooltips beyond the existing read-only one, or empty-state copy ("No sub-questions yet"). Discoverability comes from the button's prominence alone in this change.
+
+## Decisions
+
+### Decision 1: Button styling — reuse `.add-question-btn` with a `--sub` modifier
+
+The base `.add-question-btn` is sized for a section-level "+ New Question" affordance: `padding: 0.75rem`, `font-size: 0.9rem`, `border: 2px dashed`. Dropping that style verbatim inside a question card looks chunky relative to the card itself. We therefore add a small modifier class `.add-question-btn--sub` that reduces padding (`0.5rem 0.75rem`) and font-size (`0.8rem`) for the nested context, while preserving the dashed border, full-width layout, `fa-plus` icon, and disabled-state visuals.
+
+**Alternative considered:** ship a new `.add-subquestion-btn` class with separate styling. **Rejected** because it duplicates the dashed-border / hover-accent / disabled rules and weakens the visual relationship the change is trying to establish ("this is the same kind of button, scoped to this card").
+
+### Decision 2: Wrapper element to handle "above" vs "between" placement
+
+The button needs to sit below the (optional) `<ul class="subquestion-list">`. When the list is non-empty, the list itself already provides a top dashed separator; when empty, the button is a direct sibling of `.question-item-row` and needs its own visual transition. We wrap the button in a `<div class="add-subquestion-wrap">` and rely on the CSS sibling selector `.question-item-row + .add-subquestion-wrap` to apply a dashed top border only in the empty case. This keeps the template free of conditional separator classes.
+
+**Alternative considered:** always render a non-empty `<ul class="subquestion-list">` even with no children, and put the button inside. **Rejected** because it introduces an empty `<ul>` which carries semantic and accessibility implications.
+
+### Decision 3: Gate by `input_type` only, not by nesting depth
+
+The template includes itself recursively for sub-questions (`{% include "editor/partials/question_list_item.html" with question=subq %}`). Sub-questions are never geo-typed — the product intentionally does not allow point/line/polygon as a sub-question type, and the form layer (Decision 4) now enforces that constraint — so the recursive include never reaches a card that would re-render the new button. We therefore gate the button on `input_type in (point, line, polygon)` alone, without an extra "is top-level" check. This keeps the template branching minimal and matches the gate the old `fa-sitemap` button used.
+
+### Decision 4: Enforce the "no geo sub-questions" rule in `QuestionForm`, not in the view
+
+Until now the rule "a sub-question cannot itself be a geo question" lived only in product convention — neither the form nor the view rejected `input_type=point` on a sub-question POST. The new prominent entry point makes the create flow much more visible, so the rule needs an explicit enforcement layer.
+
+We chose `QuestionForm` as that layer: the form gains an `is_subquestion: bool` keyword argument; when true, the `input_type` field's `choices` are filtered to exclude the constants in `SUBQUESTION_DISALLOWED_INPUT_TYPES = ('point', 'line', 'polygon')`. Django's built-in choice validation then rejects any POST that submits a filtered value, with the standard "Select a valid choice" error. The view layer wires the kwarg from the two callsites where sub-question context is known: `editor_subquestion_create` (always `True`) and `editor_question_edit` (passes `bool(question.parent_question_id_id)`).
+
+**Alternatives considered:**
+- *Reject in the view with an explicit 400.* Rejected — duplicates Django's choice validation and forces a custom error path that the modal would not render naturally.
+- *Filter the choices in the template only.* Rejected — UI-only enforcement is bypassable by any crafted POST and would silently allow inconsistent data through.
+- *Add a model-level `clean()` constraint.* Rejected for this change — the rule is editor-flow-specific, the model is shared with imports / admin / fixtures where applying the same constraint could break legitimate paths. If we later decide the rule must hold at the data layer, the form's constant becomes the single source of truth and a model `clean()` can call into it.
+
+## Risks / Trade-offs
+
+- **Vertical space** → Always rendering an "Add Sub-question" button on every geo question card adds ~36px of vertical space per card, even on cards the user has no intention of nesting. **Mitigation:** the smaller `--sub` modifier keeps the addition compact; the visible affordance is the explicit goal.
+- **Visual noise on surveys with many geo questions** → A large section with five point-type questions now shows five "+ Add Sub-question" buttons. **Mitigation:** matches the existing pattern at the section level (one "+ New Question" per section) so the visual idiom is consistent. We accept this as the cost of discoverability.
+- **HTMX preview iframe refresh** → The new button uses the same `hx-target="#questionModalBody"` + modal form pattern as the icon button, so the existing `htmx:afterSettle` listener already re-initialises Sortable on `.subquestion-list` and the iframe refresh continues to work without changes.
+
+## Migration Plan
+
+Single-step deploy: ship the template + CSS change. No data migration, no URL changes, no feature flag needed. Any user mid-session with the old template will pick up the new one on next page load.
+
+## Open Questions
+
+None — the issue (#17) fully specifies placement, style, scope, removal, and read-only behaviour.

--- a/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+In the WYSIWYG survey editor, the entry point for adding sub-questions to geo questions (point/line/polygon) is a small `fa-sitemap` icon tucked into the q-actions row of each question card. The icon reads as a generic "tree" affordance, has no label, and is structurally inconsistent with how top-level questions are added (the prominent "+ New Question" button below the section list). Power users have used the feature heavily (one user has 34 sub-questions), but only ~4 of ~50 active editor users have ever discovered it — the discoverability gap is substantial enough to be tracked as a backlog item (`openspec/backlog/idea-subquestion-discoverability-testing.md`).
+
+## What Changes
+
+- Add a "+ Add Sub-question" button **inside** every geo-question card (point/line/polygon), rendered below the sub-question list and always visible — even when the list is empty.
+- Style the button to match the existing `add-question-btn` (full-width, dashed-border, subdued, `fa-plus` icon), with a small modifier to right-size it for the nested context.
+- Wire the button to the existing `editor_subquestion_create` endpoint via the same HTMX modal pattern used by all editor question/edit affordances.
+- Honour the existing read-only state: when the survey is published/closed, the button is `disabled` and shows the same "Create a draft to edit" tooltip as siblings.
+- **REMOVED**: the `fa-sitemap` icon button in the q-actions row of geo-question cards. The new button replaces it as the single entry point — no two equivalent affordances for the same action.
+- Restrict the `input_type` choices in `QuestionForm` to non-geo options (excluding `point`, `line`, `polygon`) when the form is used for sub-question creation or for editing an existing sub-question. This codifies an existing product rule (a sub-question cannot itself be a geo question) at the form layer, so the new prominent entry point cannot be used to create a malformed sub-question type.
+
+## Capabilities
+
+### New Capabilities
+- _None._
+
+### Modified Capabilities
+- `survey-editor`: The `Sub-question management for geo questions` requirement changes its UI affordance — the entry point moves from an icon button in the q-actions row to a prominent, always-visible button rendered below the sub-question list. Behaviour (creating a sub-question with `parent_question_id` set to the geo question) and the gating rule (only on point/line/polygon) are unchanged.
+
+## Impact
+
+- Templates: `survey/templates/editor/partials/question_list_item.html` (move entry point), `survey/templates/editor/editor_base.html` (small CSS modifier for the nested button).
+- Forms: `survey/editor_forms.py` — `QuestionForm` gains an `is_subquestion` kwarg that filters geo input types out of the `input_type` field's choices (constant `SUBQUESTION_DISALLOWED_INPUT_TYPES = ('point', 'line', 'polygon')`).
+- Views: `survey/editor_views.py` — `editor_subquestion_create` instantiates `QuestionForm(is_subquestion=True)`; `editor_question_edit` instantiates `QuestionForm(is_subquestion=bool(question.parent_question_id_id))` so the same restriction applies when editing an existing sub-question.
+- Tests: extend `EditorSubquestionTest` in `survey/tests.py` to cover the new button (visible/absent/disabled, sitemap removed) and the input-type filter (form excludes geo on create+edit, server rejects geo POSTs, top-level edit still allows geo).
+- Backwards compatibility: existing sub-questions are unaffected (no data migration). Top-level question creation/edit is unchanged. The icon-button is removed in the same change. No URL or API surface changes.

--- a/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/specs/survey-editor/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/specs/survey-editor/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Sub-question management for geo questions
+The system SHALL allow adding, editing, and deleting sub-questions for geo-type questions (point, line, polygon). Sub-questions SHALL have `parent_question_id` set to the geo question. The sub-question form SHALL support the same fields as regular questions.
+
+The entry point for adding a sub-question SHALL be a prominent, full-width button labelled "+ Add Sub-question" with a `fa-plus` icon, rendered **inside** every geo-type question card directly **below** the sub-question list. The button SHALL always be visible on geo-type cards — including when the sub-question list is empty. The button SHALL match the visual style of the section-level "+ New Question" button (dashed-border, subdued, accent-on-hover), sized for the nested context.
+
+When the survey is in a read-only state (status `published` or `closed`), the button SHALL be rendered as `disabled` and SHALL show the tooltip "Create a draft to edit", consistent with all other editor structural-edit affordances. There SHALL NOT be a separate icon-button affordance for adding sub-questions.
+
+A sub-question SHALL NOT be a geo-type question itself. The sub-question form (used for both creation and for editing an existing sub-question) SHALL exclude `point`, `line`, and `polygon` from the `input_type` field's available choices. A POST that attempts to create or update a sub-question with `input_type` in `{point, line, polygon}` SHALL be rejected by form validation and SHALL NOT mutate the database. The same `input_type` field SHALL continue to offer all geo and non-geo options when the form is used to create or edit a top-level question.
+
+#### Scenario: Add sub-question to a point question
+- **WHEN** the user clicks "+ Add Sub-question" on a point-type question card and creates a choice sub-question
+- **THEN** a Question is created with `parent_question_id` set to the point question, and it appears nested under the parent in the question list
+
+#### Scenario: Sub-question button only on geo questions
+- **WHEN** the question list shows a `text` question and a `point` question
+- **THEN** only the `point` question card renders an "+ Add Sub-question" button; the `text` question card renders no such button
+
+#### Scenario: Button visible when no sub-questions exist
+- **WHEN** a `polygon` question has zero sub-questions
+- **THEN** the "+ Add Sub-question" button is still rendered below the (empty) sub-question area of that question card
+
+#### Scenario: Button visible below an existing sub-question list
+- **WHEN** a `line` question already has two sub-questions
+- **THEN** the "+ Add Sub-question" button is rendered below the sub-question list, in addition to the listed sub-questions
+
+#### Scenario: Button disabled in read-only state
+- **WHEN** the survey status is `published` and the editor renders a geo question card
+- **THEN** the "+ Add Sub-question" button is rendered with the `disabled` attribute and the tooltip "Create a draft to edit"
+
+#### Scenario: Legacy icon-button entry point removed
+- **WHEN** the editor renders any geo question card
+- **THEN** the q-actions row contains only the edit and delete icon buttons; no `fa-sitemap` icon button is present
+
+#### Scenario: Sub-question creation form excludes geo input types
+- **WHEN** the user opens the "New Sub-question" modal for a geo question
+- **THEN** the `input_type` select offers no `point`, `line`, or `polygon` options (and continues to offer non-geo options such as `text`, `choice`, `number`, `image`)
+
+#### Scenario: Sub-question creation rejects geo input types server-side
+- **WHEN** a POST is sent to `editor_subquestion_create` with `input_type=point` (e.g. by a stale or crafted request)
+- **THEN** no Question is created and the response re-renders the form with a validation error on `input_type`
+
+#### Scenario: Sub-question edit form excludes geo input types
+- **WHEN** the user opens the edit modal for an existing sub-question (a Question with `parent_question_id` set)
+- **THEN** the `input_type` select offers no `point`, `line`, or `polygon` options
+
+#### Scenario: Top-level question form keeps geo input types
+- **WHEN** the user opens the create modal for a section, or the edit modal for a top-level question
+- **THEN** the `input_type` select still offers `point`, `line`, and `polygon` alongside the non-geo options

--- a/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-prominent-add-subquestion-button/tasks.md
@@ -1,0 +1,36 @@
+## 1. Template
+
+- [x] 1.1 In `survey/templates/editor/partials/question_list_item.html`, remove the `fa-sitemap` icon button block from the `.q-actions` row (the conditional block currently rendered for `point`/`line`/`polygon` questions, between the edit and delete buttons).
+- [x] 1.2 In the same template, after the existing `{% if sub_questions %}<ul class="subquestion-list">…</ul>{% endif %}` block, add a `{% if question.input_type == 'point' or … 'line' or … 'polygon' %}` block that renders a `<div class="add-subquestion-wrap">` containing a `<button class="add-question-btn add-question-btn--sub">…</button>`.
+- [x] 1.3 Wire the button: `hx-get="{% url 'editor_subquestion_create' survey.uuid question.id %}"`, `hx-target="#questionModalBody"`, `hx-swap="innerHTML"`, `data-toggle="modal" data-target="#questionModal"`, plus the read-only branch (`{% if not is_read_only %}…{% else %}disabled{% endif %}`) and the `title="{% if is_read_only %}Create a draft to edit{% else %}Add Sub-question{% endif %}"` tooltip.
+- [x] 1.4 Button content: `<i class="fas fa-plus"></i> Add Sub-question`.
+
+## 2. CSS
+
+- [x] 2.1 In `survey/templates/editor/editor_base.html`, add a `.add-subquestion-wrap` rule with `padding: 0.5rem 0.75rem 0.5rem 2.5rem;` (matches the `.subquestion-list` left-indent so the button aligns with sub-question rows).
+- [x] 2.2 Add `.question-item-row + .add-subquestion-wrap { border-top: 1px dashed var(--border-color); }` so the empty-list case still has a visual separator (when a sub-question list is rendered above, its own `border-top` already provides one).
+- [x] 2.3 Add `.add-question-btn--sub { padding: 0.5rem 0.75rem; font-size: 0.8rem; border-width: 1px; }` to right-size the button for the nested context while keeping the dashed-border / accent-on-hover / disabled rules from `.add-question-btn`.
+
+## 3. Sub-question type filter (form layer)
+
+- [x] 3.1 In `survey/editor_forms.py`, declare `SUBQUESTION_DISALLOWED_INPUT_TYPES = ('point', 'line', 'polygon')` at module scope so the constant has a single source of truth.
+- [x] 3.2 In `QuestionForm.__init__`, accept `is_subquestion: bool = False` (keyword-only). When true, replace `self.fields['input_type'].choices` with the same list filtered to drop entries whose value is in `SUBQUESTION_DISALLOWED_INPUT_TYPES`. Django's built-in `ChoiceField` validation then rejects POSTs that submit a filtered value.
+- [x] 3.3 In `survey/editor_views.py::editor_subquestion_create`, instantiate `QuestionForm(..., is_subquestion=True)` for both the GET (modal render) and POST (validation) branches.
+- [x] 3.4 In `survey/editor_views.py::editor_question_edit`, compute `is_subquestion = question.parent_question_id_id is not None` once after fetching the question, and pass it to both the GET and POST `QuestionForm` instantiations. Top-level question edits keep all geo options.
+
+## 4. Tests
+
+- [x] 4.1 Extend `EditorSubquestionTest` with `test_add_subquestion_button_visible_on_geo_question`: GIVEN a draft survey with a `point` question; WHEN the editor section detail is fetched; THEN the response HTML contains "Add Sub-question" and an `hx-get` URL pointing at `editor_subquestion_create` for that question.
+- [x] 4.2 Add `test_add_subquestion_button_absent_on_non_geo_question`: GIVEN a draft survey with a `text` question; WHEN the editor section detail is fetched; THEN the response HTML does NOT contain the corresponding `editor_subquestion_create` URL for that text question.
+- [x] 4.3 Add `test_add_subquestion_button_disabled_in_readonly`: GIVEN a published survey with a `point` question; WHEN the editor section detail is fetched; THEN the "Add Sub-question" button is rendered with the `disabled` attribute and the "Create a draft to edit" tooltip, and carries no `hx-get` URL.
+- [x] 4.4 Add `test_legacy_sitemap_icon_removed`: GIVEN any geo question card; WHEN rendered; THEN the response HTML does NOT contain `fa-sitemap`.
+- [x] 4.5 Add `test_subquestion_create_form_excludes_geo_input_types`: GIVEN a geo question; WHEN the new sub-question modal is opened; THEN the rendered `<select name="input_type">` contains no `value="point"`, `value="line"`, `value="polygon"` options (and still contains `value="text"`, `value="choice"`).
+- [x] 4.6 Add `test_subquestion_create_rejects_geo_input_types`: GIVEN a geo question; WHEN a POST submits `input_type=point` to `editor_subquestion_create`; THEN no Question is created (count unchanged) and the form modal is re-rendered (status 200).
+- [x] 4.7 Add `test_subquestion_edit_form_excludes_geo_input_types`: GIVEN an existing non-geo sub-question; WHEN its edit modal is fetched; THEN the input_type select offers no geo options.
+- [x] 4.8 Add `test_top_level_question_edit_form_keeps_geo_input_types`: GIVEN a top-level geo question; WHEN its edit modal is fetched; THEN the input_type select still offers `point`, `line`, `polygon` so top-level editing is unchanged.
+
+## 5. Verification
+
+- [x] 5.1 Run `./run_tests.sh survey.tests.EditorSubquestionTest -v2` and confirm all 9 tests pass.
+- [x] 5.2 Run the full editor regression suite (`EditorAuthTest`, `EditorSurveyCreateTest`, `EditorSectionCRUDTest`, `EditorSectionReorderTest`, `EditorQuestionCRUDTest`, `EditorQuestionReorderTest`, `EditorSubquestionTest`, `EditorPermissionTest`, `EditorTransitionTest`, `EditorVersioningEndpointsTest`) and confirm all 49 tests pass.
+- [x] 5.3 Run `openspec validate add-prominent-add-subquestion-button` and confirm no validation errors.

--- a/openspec/specs/survey-editor/spec.md
+++ b/openspec/specs/survey-editor/spec.md
@@ -1,5 +1,7 @@
-## ADDED Requirements
+## Purpose
 
+WYSIWYG survey editor at `/editor/surveys/<uuid>/` — the in-app authoring surface for creating, configuring, and managing surveys (sections, questions, sub-questions, choices, translations, map positions, lifecycle transitions). Replaces the Django admin as the primary survey-construction tool for end users.
+## Requirements
 ### Requirement: Survey creation
 The system SHALL provide a form at `/editor/surveys/new/` that allows authenticated users to create a new survey. The form SHALL include fields for survey name, organization, available languages, visibility, redirect URL, and thanks HTML. On successful creation, the system SHALL create a SurveyHeader (with auto-generated UUID) and one default section (marked `is_head=True`), then redirect to the survey editor using the UUID.
 
@@ -111,13 +113,51 @@ The system SHALL display a dynamic choices editor when the question's input_type
 ### Requirement: Sub-question management for geo questions
 The system SHALL allow adding, editing, and deleting sub-questions for geo-type questions (point, line, polygon). Sub-questions SHALL have `parent_question_id` set to the geo question. The sub-question form SHALL support the same fields as regular questions.
 
+The entry point for adding a sub-question SHALL be a prominent, full-width button labelled "+ Add Sub-question" with a `fa-plus` icon, rendered **inside** every geo-type question card directly **below** the sub-question list. The button SHALL always be visible on geo-type cards — including when the sub-question list is empty. The button SHALL match the visual style of the section-level "+ New Question" button (dashed-border, subdued, accent-on-hover), sized for the nested context.
+
+When the survey is in a read-only state (status `published` or `closed`), the button SHALL be rendered as `disabled` and SHALL show the tooltip "Create a draft to edit", consistent with all other editor structural-edit affordances. There SHALL NOT be a separate icon-button affordance for adding sub-questions.
+
+A sub-question SHALL NOT be a geo-type question itself. The sub-question form (used for both creation and for editing an existing sub-question) SHALL exclude `point`, `line`, and `polygon` from the `input_type` field's available choices. A POST that attempts to create or update a sub-question with `input_type` in `{point, line, polygon}` SHALL be rejected by form validation and SHALL NOT mutate the database. The same `input_type` field SHALL continue to offer all geo and non-geo options when the form is used to create or edit a top-level question.
+
 #### Scenario: Add sub-question to a point question
-- **WHEN** the user clicks "Add Sub-question" on a point-type question and creates a choice sub-question
-- **THEN** a Question is created with parent_question_id set to the point question, and it appears nested under the parent in the question list
+- **WHEN** the user clicks "+ Add Sub-question" on a point-type question card and creates a choice sub-question
+- **THEN** a Question is created with `parent_question_id` set to the point question, and it appears nested under the parent in the question list
 
 #### Scenario: Sub-question button only on geo questions
-- **WHEN** the question list shows a "text" question and a "point" question
-- **THEN** only the "point" question has an "Add Sub-question" button
+- **WHEN** the question list shows a `text` question and a `point` question
+- **THEN** only the `point` question card renders an "+ Add Sub-question" button; the `text` question card renders no such button
+
+#### Scenario: Button visible when no sub-questions exist
+- **WHEN** a `polygon` question has zero sub-questions
+- **THEN** the "+ Add Sub-question" button is still rendered below the (empty) sub-question area of that question card
+
+#### Scenario: Button visible below an existing sub-question list
+- **WHEN** a `line` question already has two sub-questions
+- **THEN** the "+ Add Sub-question" button is rendered below the sub-question list, in addition to the listed sub-questions
+
+#### Scenario: Button disabled in read-only state
+- **WHEN** the survey status is `published` and the editor renders a geo question card
+- **THEN** the "+ Add Sub-question" button is rendered with the `disabled` attribute and the tooltip "Create a draft to edit"
+
+#### Scenario: Legacy icon-button entry point removed
+- **WHEN** the editor renders any geo question card
+- **THEN** the q-actions row contains only the edit and delete icon buttons; no `fa-sitemap` icon button is present
+
+#### Scenario: Sub-question creation form excludes geo input types
+- **WHEN** the user opens the "New Sub-question" modal for a geo question
+- **THEN** the `input_type` select offers no `point`, `line`, or `polygon` options (and continues to offer non-geo options such as `text`, `choice`, `number`, `image`)
+
+#### Scenario: Sub-question creation rejects geo input types server-side
+- **WHEN** a POST is sent to `editor_subquestion_create` with `input_type=point` (e.g. by a stale or crafted request)
+- **THEN** no Question is created and the response re-renders the form with a validation error on `input_type`
+
+#### Scenario: Sub-question edit form excludes geo input types
+- **WHEN** the user opens the edit modal for an existing sub-question (a Question with `parent_question_id` set)
+- **THEN** the `input_type` select offers no `point`, `line`, or `polygon` options
+
+#### Scenario: Top-level question form keeps geo input types
+- **WHEN** the user opens the create modal for a section, or the edit modal for a top-level question
+- **THEN** the `input_type` select still offers `point`, `line`, and `polygon` alongside the non-geo options
 
 ### Requirement: Section map position picker
 The system SHALL provide a Leaflet map picker for setting a section's start_map_position and start_map_zoom. The picker SHALL open in a modal, display a map centered at the section's current position, and allow the user to click to set a new position and adjust zoom.
@@ -162,3 +202,4 @@ The system SHALL wire the "New Survey" button in `/editor/` to navigate to `/edi
 #### Scenario: Edit link navigates to editor
 - **WHEN** the user clicks "Edit" for a survey on the dashboard
 - **THEN** the browser navigates to `/editor/surveys/<uuid>/`
+

--- a/survey/editor_forms.py
+++ b/survey/editor_forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from .models import SurveyHeader, SurveySection, Question, Organization, BASEMAP_CHOICES
 
+SUBQUESTION_DISALLOWED_INPUT_TYPES = ('point', 'line', 'polygon')
+
 
 class SurveyHeaderForm(forms.ModelForm):
     class Meta:
@@ -74,3 +76,12 @@ class QuestionForm(forms.ModelForm):
         help_texts = {
             'icon_class': '<a href="https://fontawesome.com/v5/search" target="_blank" rel="noopener">Font Awesome</a> class',
         }
+
+    def __init__(self, *args, is_subquestion=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if is_subquestion:
+            field = self.fields['input_type']
+            field.choices = [
+                (value, label) for value, label in field.choices
+                if value not in SUBQUESTION_DISALLOWED_INPUT_TYPES
+            ]

--- a/survey/editor_views.py
+++ b/survey/editor_views.py
@@ -406,9 +406,10 @@ def editor_question_edit(request, survey_uuid, question_id):
     if blocked:
         return blocked
     question = get_object_or_404(Question, id=question_id, survey_section__survey_header=survey)
+    is_subquestion = question.parent_question_id_id is not None
 
     if request.method == 'POST':
-        form = QuestionForm(request.POST, request.FILES, instance=question)
+        form = QuestionForm(request.POST, request.FILES, instance=question, is_subquestion=is_subquestion)
         if form.is_valid():
             q = form.save(commit=False)
             choices_json = request.POST.get('choices_json', '').strip()
@@ -451,7 +452,7 @@ def editor_question_edit(request, survey_uuid, question_id):
             'question': question,
         })
     else:
-        form = QuestionForm(instance=question)
+        form = QuestionForm(instance=question, is_subquestion=is_subquestion)
     return render(request, 'editor/partials/question_form_modal.html', {
         'form': form,
         'survey': survey,
@@ -559,7 +560,7 @@ def editor_subquestion_create(request, survey_uuid, parent_id):
     parent = get_object_or_404(Question, id=parent_id, survey_section__survey_header=survey)
 
     if request.method == 'POST':
-        form = QuestionForm(request.POST, request.FILES)
+        form = QuestionForm(request.POST, request.FILES, is_subquestion=True)
         if form.is_valid():
             question = form.save(commit=False)
             question.survey_section = parent.survey_section
@@ -582,7 +583,7 @@ def editor_subquestion_create(request, survey_uuid, parent_id):
             response['HX-Trigger'] = 'questionSaved'
             return response
     else:
-        form = QuestionForm()
+        form = QuestionForm(is_subquestion=True)
     return render(request, 'editor/partials/question_form_modal.html', {
         'form': form,
         'survey': survey,

--- a/survey/templates/editor/editor_base.html
+++ b/survey/templates/editor/editor_base.html
@@ -200,6 +200,10 @@
         .question-item .q-actions button:disabled { opacity: 0.3; cursor: not-allowed; }
         .question-item .q-actions button:disabled:hover { background: none; color: #9ca3af; }
 
+        .add-subquestion-wrap { padding: 0.5rem 0.75rem 0.5rem 2.5rem; }
+        .question-item-row + .add-subquestion-wrap { border-top: 1px dashed var(--border-color); }
+        .add-question-btn--sub { padding: 0.5rem 0.75rem; font-size: 0.8rem; border-width: 1px; }
+
         /* Preview panel */
         .editor-preview {
             width: var(--preview-width);

--- a/survey/templates/editor/partials/question_list_item.html
+++ b/survey/templates/editor/partials/question_list_item.html
@@ -14,17 +14,6 @@
                     {% else %}disabled{% endif %}>
                 <i class="fas fa-pen"></i>
             </button>
-            {% if question.input_type == 'point' or question.input_type == 'line' or question.input_type == 'polygon' %}
-            <button title="{% if is_read_only %}Create a draft to edit{% else %}Add Sub-question{% endif %}"
-                    {% if not is_read_only %}
-                    hx-get="{% url 'editor_subquestion_create' survey.uuid question.id %}"
-                    hx-target="#questionModalBody"
-                    hx-swap="innerHTML"
-                    data-toggle="modal" data-target="#questionModal"
-                    {% else %}disabled{% endif %}>
-                <i class="fas fa-sitemap"></i>
-            </button>
-            {% endif %}
             <button title="{% if is_read_only %}Create a draft to edit{% else %}Delete{% endif %}" class="text-danger"
                     {% if not is_read_only %}
                     hx-post="{% url 'editor_question_delete' survey.uuid question.id %}"
@@ -46,4 +35,18 @@
     </ul>
     {% endif %}
     {% endwith %}
+    {% if question.input_type == 'point' or question.input_type == 'line' or question.input_type == 'polygon' %}
+    <div class="add-subquestion-wrap">
+        <button class="add-question-btn add-question-btn--sub"
+                title="{% if is_read_only %}Create a draft to edit{% else %}Add Sub-question{% endif %}"
+                {% if not is_read_only %}
+                hx-get="{% url 'editor_subquestion_create' survey.uuid question.id %}"
+                hx-target="#questionModalBody"
+                hx-swap="innerHTML"
+                data-toggle="modal" data-target="#questionModal"
+                {% else %}disabled{% endif %}>
+            <i class="fas fa-plus"></i> Add Sub-question
+        </button>
+    </div>
+    {% endif %}
 </li>

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -5185,6 +5185,139 @@ class EditorSubquestionTest(TestCase):
         sub = Question.objects.get(name='Rate this place')
         self.assertEqual(sub.parent_question_id_id, self.geo_question.id)
 
+    def test_add_subquestion_button_visible_on_geo_question(self):
+        """
+        GIVEN a draft survey with a geo (point) question
+        WHEN the editor section detail is fetched
+        THEN the response renders an "Add Sub-question" button wired to editor_subquestion_create for that question
+        """
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/sections/{self.section.id}/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Add Sub-question')
+        self.assertContains(
+            response,
+            f'/editor/surveys/{self.survey.uuid}/questions/{self.geo_question.id}/subquestions/new/',
+        )
+        self.assertContains(response, 'add-question-btn--sub')
+
+    def test_add_subquestion_button_absent_on_non_geo_question(self):
+        """
+        GIVEN a draft survey with a non-geo (text) question alongside a geo question
+        WHEN the editor section detail is fetched
+        THEN no Add Sub-question entry point is rendered for the text question
+        """
+        text_question = Question.objects.create(
+            survey_section=self.section, name='Comment', input_type='text',
+        )
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/sections/{self.section.id}/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            f'/editor/surveys/{self.survey.uuid}/questions/{text_question.id}/subquestions/new/',
+        )
+
+    def test_add_subquestion_button_disabled_in_readonly(self):
+        """
+        GIVEN a published survey with a geo question
+        WHEN the editor section detail is fetched
+        THEN the Add Sub-question button is rendered disabled with the read-only tooltip
+        """
+        self.survey.status = 'published'
+        self.survey.save(update_fields=['status'])
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/sections/{self.section.id}/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Add Sub-question')
+        self.assertContains(response, 'Create a draft to edit')
+        # In read-only state the button must NOT carry the hx-get URL — the disabled
+        # branch of the template skips it entirely.
+        self.assertNotContains(
+            response,
+            f'hx-get="/editor/surveys/{self.survey.uuid}/questions/{self.geo_question.id}/subquestions/new/"',
+        )
+
+    def test_legacy_sitemap_icon_removed(self):
+        """
+        GIVEN a draft survey with a geo question
+        WHEN the editor section detail is fetched
+        THEN the legacy fa-sitemap icon button is no longer present
+        """
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/sections/{self.section.id}/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'fa-sitemap')
+
+    def test_subquestion_create_form_excludes_geo_input_types(self):
+        """
+        GIVEN a geo question
+        WHEN the new sub-question modal is opened
+        THEN the input_type select offers no point/line/polygon options
+        """
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/questions/{self.geo_question.id}/subquestions/new/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'value="point"')
+        self.assertNotContains(response, 'value="line"')
+        self.assertNotContains(response, 'value="polygon"')
+        self.assertContains(response, 'value="text"')
+        self.assertContains(response, 'value="choice"')
+
+    def test_subquestion_create_rejects_geo_input_types(self):
+        """
+        GIVEN a geo question
+        WHEN a POST attempts to create a sub-question with input_type="point"
+        THEN no Question is created and the form is re-rendered with errors
+        """
+        before = Question.objects.filter(parent_question_id=self.geo_question).count()
+        response = self.client.post(
+            f'/editor/surveys/{self.survey.uuid}/questions/{self.geo_question.id}/subquestions/new/',
+            {'name': 'Nested point', 'input_type': 'point', 'color': '#000000'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            Question.objects.filter(parent_question_id=self.geo_question).count(),
+            before,
+        )
+
+    def test_subquestion_edit_form_excludes_geo_input_types(self):
+        """
+        GIVEN an existing sub-question (non-geo)
+        WHEN its edit modal is opened
+        THEN the input_type select offers no point/line/polygon options
+        """
+        sub = Question.objects.create(
+            survey_section=self.section,
+            parent_question_id=self.geo_question,
+            name='Comment', input_type='text',
+        )
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/questions/{sub.id}/edit/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'value="point"')
+        self.assertNotContains(response, 'value="polygon"')
+
+    def test_top_level_question_edit_form_keeps_geo_input_types(self):
+        """
+        GIVEN a top-level (non-sub) question
+        WHEN its edit modal is opened
+        THEN the input_type select still offers point/line/polygon options
+        """
+        response = self.client.get(
+            f'/editor/surveys/{self.survey.uuid}/questions/{self.geo_question.id}/edit/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="point"')
+        self.assertContains(response, 'value="line"')
+        self.assertContains(response, 'value="polygon"')
+
 
 class UUIDSurveyIdentificationTest(TestCase):
     """Tests for UUID-based survey identification and dual-lookup behavior."""


### PR DESCRIPTION
## Summary
- Replaces the `fa-sitemap` icon button (q-actions row) with a prominent full-width "+ Add Sub-question" button below each geo question's sub-question list — always visible on point/line/polygon cards, including when the list is empty. Matches the section-level "+ New Question" affordance, sized for the nested context via a new `--sub` modifier.
- Restricts `QuestionForm.input_type` choices to non-geo options when the form is used for sub-question creation or editing — codifying at the form layer the product rule that a sub-question cannot itself be a geo question. Top-level question creation/edit is unchanged.
- Archived OpenSpec change: `2026-04-29-add-prominent-add-subquestion-button` (proposal, design, modified delta for `survey-editor`, tasks; main spec updated, change moved to archive).

## Test plan
- [x] `EditorSubquestionTest` — 9/9 (4 button-presence/state tests, 4 type-filter tests, 1 existing creation test)
- [x] Full editor regression — 49/49 across `EditorAuth/Survey/Section/Question/Reorder/Subquestion/Permission/Transition/VersioningEndpoints` test classes
- [x] `openspec validate add-prominent-add-subquestion-button` — passes

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)