### PR TITLE
feat: top-10 active surveys + fix stale post-Phase-1 labels

### DIFF
--- a/openspec/changes/funnel-monitoring/specs/creator-funnel-dashboard/spec.md
+++ b/openspec/changes/funnel-monitoring/specs/creator-funnel-dashboard/spec.md
@@ -93,6 +93,19 @@ first response.
 - **WHEN** the dashboard loads
 - **THEN** it shows three median-days figures (or a dash when a stage has no data)
 
+### Requirement: Top active surveys
+The dashboard SHALL list the top surveys by response volume in the last 30 days (the currently
+active ones), showing survey name, owner, status, and recent response count, with a deep link to
+the survey in the admin.
+
+#### Scenario: Ranked by recent responses
+- **WHEN** several surveys have collected responses in the last 30 days
+- **THEN** they are listed most-active first, and a survey with only older responses is excluded
+
+#### Scenario: Bounded list
+- **WHEN** more than ten surveys are active
+- **THEN** at most ten are shown
+
 ### Requirement: Action lists
 The dashboard SHALL show two actionable lists with deep links into the admin: institutional-domain
 registrants who never created a survey (outreach candidates), and surveys collecting responses

--- a/openspec/changes/funnel-monitoring/tasks.md
+++ b/openspec/changes/funnel-monitoring/tasks.md
@@ -60,6 +60,13 @@ Phase 1 (groups 4–5) adds attribution and can follow in a second PR.
 - [x] 5.2 Idempotency test: persist twice → one row, no error (fail-open posture)
 - [x] 5.3 Dashboard test: `signups_by_source` groups by source; `available` False before any attribution; unattributed users fall under `unknown`
 
+## 3e. Follow-up: top active surveys + post-Phase-1 label fixes
+
+- [x] 3e.1 `top_active_surveys()` — top 10 surveys by responses in the last 30 days (name/owner/status/count + admin link); rendered in section ④
+- [x] 3e.2 Attribution-coverage goal card now computes real coverage (attributed recent signups / recent signups) instead of a hardcoded 0% / "ships Phase 1"
+- [x] 3e.3 Source-panel placeholder note reworded — Phase 1 is shipped; "no attributed signups yet, capture runs from deploy (no backfill)"
+- [x] 3e.4 Tests: `TopActiveSurveysTest`, `AttributionCoverageGoalTest` (25 funnel tests green)
+
 ## 6. Wrap-up
 
 - [ ] 6.1 Run `./run_tests.sh survey` green (PostGIS container up)

--- a/survey/funnel.py
+++ b/survey/funnel.py
@@ -238,6 +238,26 @@ class CreatorFunnelService:
             for r in rows
         ]
 
+    def top_active_surveys(self, limit=10, days=30, now=None):
+        """The surveys collecting the most responses recently (the live ones).
+
+        Ranked by non-deleted sessions in the last `days`. Returns survey name,
+        owner, status, and the recent response count -- with an admin deep link
+        built in the template.
+        """
+        now = now or timezone.now()
+        rows = (SurveySession.objects
+                .filter(is_deleted=False, start_datetime__gte=now - timedelta(days=days))
+                .values("survey_id", "survey__name", "survey__status",
+                        "survey__created_by__username")
+                .annotate(n=Count("id"))
+                .order_by("-n")[:limit])
+        return [{"survey_id": r["survey_id"],
+                 "name": r["survey__name"] or "—",
+                 "status": r["survey__status"],
+                 "owner": r["survey__created_by__username"] or "—",
+                 "responses": r["n"]} for r in rows]
+
     def active_user_metrics(self, now=None):
         """"Living" creators: registered users who keep using the platform.
 
@@ -317,6 +337,13 @@ class CreatorFunnelService:
         has_resp = {uid for uid, n in resp.items() if n >= 1}
         pub_rate = round(100 * len(has_resp & published) / len(has_resp)) if has_resp else 0
 
+        # Real attribution coverage: share of recent signups with a known source.
+        # Rises from deploy onward (no backfill), so pre-deploy signups don't count.
+        from .models import SignupAttribution
+        attributed_30 = (SignupAttribution.objects.filter(user_id__in=recent_ids)
+                         .values("user_id").distinct().count())
+        coverage = round(100 * attributed_30 / regs_30) if regs_30 else 0
+
         def card(label, value_display, pct_to_target, target_display, note):
             pct = min(100, max(0, pct_to_target))
             return {"label": label, "value": value_display, "target": target_display,
@@ -333,8 +360,9 @@ class CreatorFunnelService:
             card("Publish rate", f"{pub_rate}%",
                  round(100 * pub_rate / t["publish_rate"]), f"{t['publish_rate']}%",
                  "of users with responses (H5)"),
-            card("Attribution coverage", "0%",
-                 0, f"{t['attribution']}%", "ships Phase 1 (SignupAttribution)"),
+            card("Attribution coverage", f"{coverage}%",
+                 round(100 * coverage / t["attribution"]), f"{t['attribution']}%",
+                 "new signups with a known source"),
         ]
 
     def cluster_radar(self, now=None):
@@ -535,6 +563,7 @@ def dashboard_context(weeks=None):
         "cohorts": s.cohort_funnel(),
         "totals": s.alltime_totals(),
         "active": s.active_user_metrics(),
+        "top_surveys": s.top_active_surveys(),
         "ttv": s.time_to_value(),
         "dormant_valuable": s.dormant_valuable(),
         "collecting_unpublished": s.collecting_unpublished(),

--- a/survey/templates/admin/funnel_dashboard.html
+++ b/survey/templates/admin/funnel_dashboard.html
@@ -85,7 +85,7 @@
         <tr><th>Source</th><th>Regs</th></tr>
         {% for r in sources.rows %}<tr><td>{{ r.source }}</td><td>{{ r.regs }}</td></tr>{% endfor %}
       </table>
-      {% if not sources.available %}<div class="subtle" style="margin-top:6px">Needs Phase 1 (referrer/UTM) — placeholder.</div>{% endif %}
+      {% if not sources.available %}<div class="subtle" style="margin-top:6px">No attributed signups yet — capture runs from deploy onward (no backfill), so pre-deploy signups show as “unknown”.</div>{% endif %}
     </div>
     <div class="panel">
       <h3>Cluster radar</h3>
@@ -174,6 +174,25 @@
       {% include "admin/_funnel_barchart.html" with chart=activity_chart color="#70bf7a" empty_label="No responses yet." %}
     </div>
   </div>
+
+  <h3 style="margin:20px 0 8px;font-size:13px">Top active surveys <span class="subtle">— most responses in the last 30 days</span></h3>
+  <table class="funnel">
+    <thead><tr><th>#</th><th>Survey</th><th>Owner</th><th>Status</th><th>Responses&nbsp;30d</th><th></th></tr></thead>
+    <tbody>
+      {% for s in top_surveys %}
+      <tr>
+        <td>{{ forloop.counter }}</td>
+        <td>{{ s.name }}</td>
+        <td class="subtle">{{ s.owner }}</td>
+        <td><span class="tag {% if s.status == 'published' %}act{% elif s.status == 'closed' or s.status == 'archived' %}warn{% else %}acq{% endif %}">{{ s.status }}</span></td>
+        <td>{{ s.responses }}</td>
+        <td><a class="rowlink" href="{% url 'admin:survey_surveyheader_change' s.survey_id %}">open →</a></td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="6" class="subtle">No responses collected in the last 30 days.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
 
   {# ⑤ ACTIONS #}
   <h2 id="actions"><span class="step">5</span>Action lists <span class="sub">— the dashboard as a campaign tool, not a display</span></h2>

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13358,7 +13358,7 @@ class DashboardContextSmokeTest(TestCase):
         """
         ctx = _dashboard_context()
         for key in ("goals", "sources", "clusters", "abuse", "cohorts", "totals",
-                    "active", "ttv", "dormant_valuable", "collecting_unpublished",
+                    "active", "top_surveys", "ttv", "dormant_valuable", "collecting_unpublished",
                     "signups_chart", "activity_chart"):
             self.assertIn(key, ctx)
         self.assertEqual(len(ctx["goals"]), 4)
@@ -13453,3 +13453,67 @@ class SignupsBySourceTest(TestCase):
         by = {r["source"]: r["regs"] for r in res["rows"]}
         self.assertEqual(by.get("edu"), 2)
         self.assertEqual(by.get("unknown"), 1)
+
+
+class TopActiveSurveysTest(TestCase):
+    """Top active surveys ranked by recent response volume."""
+
+    def setUp(self):
+        self.org = _make_org("TopOrg")
+        self.now = timezone.now()
+        self.owner = _u("top_owner", self.now)
+
+    def _survey_with_sessions(self, name, recent, old=0):
+        s = SurveyHeader.objects.create(name=name, organization=self.org,
+                                        created_by=self.owner, status="published")
+        for _ in range(recent):
+            SurveySession.objects.create(survey=s, start_datetime=self.now - _timedelta(days=2))
+        for _ in range(old):
+            SurveySession.objects.create(survey=s, start_datetime=self.now - _timedelta(days=60))
+        return s
+
+    def test_ranked_by_recent_responses_and_excludes_old(self):
+        """
+        GIVEN surveys with different recent response counts (and one with only old ones)
+        WHEN top_active_surveys runs
+        THEN it ranks by last-30d responses, descending, excluding out-of-window sessions
+        """
+        self._survey_with_sessions("busy", recent=8)
+        self._survey_with_sessions("medium", recent=3)
+        self._survey_with_sessions("stale", recent=0, old=20)   # only old -> not active
+
+        rows = CreatorFunnelService().top_active_surveys()
+        names = [r["name"] for r in rows]
+        self.assertEqual(names[:2], ["busy", "medium"])
+        self.assertNotIn("stale", names)
+        self.assertEqual(rows[0]["responses"], 8)
+
+    def test_limit_respected(self):
+        """
+        GIVEN more surveys than the limit
+        WHEN top_active_surveys runs with limit=2
+        THEN at most 2 rows are returned
+        """
+        for i in range(4):
+            self._survey_with_sessions(f"s{i}", recent=i + 1)
+        self.assertEqual(len(CreatorFunnelService().top_active_surveys(limit=2)), 2)
+
+
+class AttributionCoverageGoalTest(TestCase):
+    """The attribution-coverage goal card computes real coverage (not hardcoded)."""
+
+    def test_coverage_reflects_attributed_recent_signups(self):
+        """
+        GIVEN four recent signups, two of which have a SignupAttribution row
+        WHEN goals() computes the attribution-coverage card
+        THEN it reports 50% (not a hardcoded 0%)
+        """
+        for i in range(2):
+            u = User.objects.create_user(f"att_{i}", password="x")
+            SignupAttribution.objects.create(user=u, utm_source="edu")
+        for i in range(2):
+            User.objects.create_user(f"noatt_{i}", password="x")
+
+        cards = {c["label"]: c for c in CreatorFunnelService().goals()}
+        cov = cards["Attribution coverage"]
+        self.assertEqual(cov["value"], "50%")


### PR DESCRIPTION
Follow-up to #22 (growth funnel dashboard).

## What

- **Top 10 active surveys** — new table in section ④ ranking surveys by responses collected in the last 30 days (the currently live ones): survey name, owner, status, recent response count, with an admin deep link.

## Fixes (stale labels left over from before Phase 1 shipped)

- **Attribution-coverage goal card** was hardcoded to `0% · ships Phase 1`. Phase 1 (SignupAttribution) is now merged, so the card **computes real coverage** = attributed recent signups ÷ recent signups. It reads 0% today only because attribution captures from the deploy forward (no backfill) and there are no post-deploy signups yet — it climbs as new signups arrive.
- **Source-panel empty state** said "Needs Phase 1 — placeholder", which was misleading post-merge. Reworded to explain that capture runs from deploy onward and pre-deploy signups show as "unknown".

These addressed live-dashboard confusion: after #22 deployed, the dashboard still implied Phase 1 wasn't shipped.

## Tests

25 funnel tests green, including `TopActiveSurveysTest` and `AttributionCoverageGoalTest`, plus the page-render access test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
