### PR TITLE
fix: emit section_view for HTMX-navigated sections (0 views → N submits)

### DIFF
--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13517,3 +13517,43 @@ class AttributionCoverageGoalTest(TestCase):
         cards = {c["label"]: c for c in CreatorFunnelService().goals()}
         cov = cards["Attribution coverage"]
         self.assertEqual(cov["value"], "50%")
+
+
+class SectionViewHtmxTrackingTest(TestCase):
+    """Regression: section_view must fire for HTMX-navigated sections, not only the head."""
+
+    def setUp(self):
+        self.org = _make_org("SecTrackOrg")
+        self.survey = SurveyHeader.objects.create(name="sec_track", organization=self.org,
+                                                  status="published")
+        self.s1 = SurveySection.objects.create(name="s1", survey_header=self.survey, is_head=True)
+        self.s2 = SurveySection.objects.create(name="s2", survey_header=self.survey)
+        self.s1.next_section = self.s2
+        self.s1.save()
+        self.s2.prev_section = self.s1
+        self.s2.save()
+        Question.objects.create(name="q1", survey_section=self.s1, input_type="text_line",
+                                order_number=1, required=False)
+        Question.objects.create(name="q2", survey_section=self.s2, input_type="text_line",
+                                order_number=1, required=False)
+
+    def test_htmx_forward_emits_section_view_for_next_section(self):
+        """
+        GIVEN a two-section survey
+        WHEN the head section is viewed then submitted via HTMX (forward)
+        THEN section_view is recorded for BOTH the head and the next section
+             (before the fix, the next section stayed at 0 views)
+        """
+        c = Client()
+        c.get(f"/surveys/{self.survey.name}/{self.s1.name}/")            # head via GET
+        resp = c.post(f"/surveys/{self.survey.name}/{self.s1.name}/",
+                      data={}, HTTP_HX_REQUEST="true")                    # submit head via HTMX
+        self.assertEqual(resp.status_code, 200)
+
+        viewed = set(SurveyEvent.objects.filter(event_type="section_view")
+                     .values_list("metadata__section_name", flat=True))
+        submitted = set(SurveyEvent.objects.filter(event_type="section_submit")
+                        .values_list("metadata__section_name", flat=True))
+        self.assertIn("s1", viewed)
+        self.assertIn("s2", viewed)          # the fix: next section now records a view
+        self.assertIn("s1", submitted)

--- a/survey/views.py
+++ b/survey/views.py
@@ -688,6 +688,11 @@ def survey_section(request, survey_slug, section_name):
 			if nav_direction == 'back' and section.prev_section:
 				prev_sec = section.prev_section
 				prev_current = section_current - 1
+				# HTMX swaps the partial without a GET, so emit the view here —
+				# otherwise only the head section (initial GET) ever records a view.
+				emit_event(survey_session, 'section_view', {
+					'section_name': prev_sec.name, 'section_index': prev_current,
+				})
 				prev_ctx = _build_section_context(request, survey, session_survey, prev_sec, selected_language, prev_current, section_total)
 				return render(request, 'partials/survey_section_partial.html', prev_ctx)
 
@@ -695,6 +700,11 @@ def survey_section(request, survey_slug, section_name):
 				next_sec = section.next_section
 				# Recompute progress for next section
 				next_current = section_current + 1
+				# HTMX swaps the partial without a GET — emit the view for the
+				# section actually shown, so downstream sections aren't stuck at 0 views.
+				emit_event(survey_session, 'section_view', {
+					'section_name': next_sec.name, 'section_index': next_current,
+				})
 				next_ctx = _build_section_context(request, survey, session_survey, next_sec, selected_language, next_current, section_total)
 				return render(request, 'partials/survey_section_partial.html', next_ctx)
 			else:


### PR DESCRIPTION
## Bug: "0 views → N submits" in the Performance section funnel

The survey flow navigates between sections via **HTMX partial swaps** — after a section is submitted, `survey/views.py` renders the next (or previous) section's partial directly, without a GET round-trip. But `section_view` was only emitted in the **GET** branch, so only the **head** section (loaded by the initial full-page GET) ever recorded a view.

Result on `demo_city_feedback` (and every multi-section survey): the head section showed `357 views → 90 submits`, while every downstream section showed `0 views → N submits` — nonsensical, and it makes per-section drop-off (exactly the geo-friction signal we care about) **unmeasurable**.

Confirmed from prod event counts: `section_view` = 357 ≈ session count, while `section_submit` = 320 spread correctly across all four sections.

## Fix

Emit `section_view` for the section actually rendered in both HTMX branches (forward and back), mirroring the GET branch. `emit_event` is fail-open, so this cannot affect the submission flow.

## Test

`SectionViewHtmxTrackingTest` — views the head, submits it via HTMX, and asserts `section_view` is now recorded for the next section (it was missing before the fix). Smoke / EmitEvent / EventIntegration / AnswerPrepopulation suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
