### PR TITLE
feat: env-driven Google site-verification meta tag

### DIFF
--- a/mapsurvey/settings.py
+++ b/mapsurvey/settings.py
@@ -248,6 +248,8 @@ DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@mapsurvey.org
 
 # Plausible Analytics
 PLAUSIBLE_SCRIPT_URL = os.environ.get('PLAUSIBLE_SCRIPT_URL', '')
+# Google Search Console verification token (meta-tag method); empty = tag not rendered.
+GOOGLE_SITE_VERIFICATION = os.environ.get('GOOGLE_SITE_VERIFICATION', '')
 
 # Landing page
 CONTACT_EMAIL = os.environ.get('CONTACT_EMAIL', 'konuchovartem@mapsurvey.org')

--- a/openspec/changes/google-site-verification/.openspec.yaml
+++ b/openspec/changes/google-site-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/google-site-verification/proposal.md
+++ b/openspec/changes/google-site-verification/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Google Search Console is the measurement prerequisite for the SEO track (educators page shipped,
+comparison page next): without a verified property we have no impressions/position/query data.
+Domain (DNS) verification is preferred, but an env-driven meta-tag makes URL-prefix verification a
+zero-DNS, redeploy-only operation — and works for future verifications (e.g. Bing).
+
+## What Changes
+
+- `GOOGLE_SITE_VERIFICATION` setting (env var, default empty) exposed via the analytics context
+  processor; when set, `<meta name="google-site-verification" content="…">` renders in the head of
+  both base templates (`base_landing.html`, `base.html`). Empty ⇒ no tag, zero output change.
+
+## Capabilities
+
+### New Capabilities
+- `site-verification`: Env-configurable Google site-verification meta tag on all pages.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+settings.py, survey/context_processors.py, base templates; test `GoogleSiteVerificationTest`.
+Owner follow-up (not code): create the GSC property, verify (DNS TXT or this tag), submit sitemap.

--- a/openspec/changes/google-site-verification/specs/site-verification/spec.md
+++ b/openspec/changes/google-site-verification/specs/site-verification/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Configurable site-verification meta tag
+The system SHALL render `<meta name="google-site-verification">` with the configured token on all
+pages when `GOOGLE_SITE_VERIFICATION` is set, and SHALL render nothing when it is empty.
+
+#### Scenario: Tag rendered when configured
+- **WHEN** `GOOGLE_SITE_VERIFICATION` is set and a page is rendered
+- **THEN** the head contains the meta tag with that token
+
+#### Scenario: No tag by default
+- **WHEN** the setting is empty
+- **THEN** no google-site-verification meta tag is emitted

--- a/openspec/changes/google-site-verification/tasks.md
+++ b/openspec/changes/google-site-verification/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — google-site-verification
+
+## 1. Implementation
+- [x] 1.1 `GOOGLE_SITE_VERIFICATION` setting (env, default '') + analytics context processor
+- [x] 1.2 Meta tag in `base_landing.html` and `base.html` (guarded, empty ⇒ absent)
+- [x] 1.3 Tests: absent by default; rendered when configured
+
+## 2. Owner follow-up (no code)
+- [ ] 2.1 Create GSC property for mapsurvey.org and verify (DNS TXT preferred, or set the env var on Render and redeploy)
+- [ ] 2.2 Submit https://mapsurvey.org/sitemap.xml; request indexing for /for-educators/

--- a/survey/context_processors.py
+++ b/survey/context_processors.py
@@ -23,6 +23,9 @@ def contact(request):
 def analytics(request):
     return {
         'PLAUSIBLE_SCRIPT_URL': getattr(settings, 'PLAUSIBLE_SCRIPT_URL', ''),
+        # Google Search Console URL-prefix verification (meta-tag method).
+        # Empty (default) renders nothing; set the env var to the token GSC shows.
+        'GOOGLE_SITE_VERIFICATION': getattr(settings, 'GOOGLE_SITE_VERIFICATION', ''),
     }
 
 

--- a/survey/templates/base.html
+++ b/survey/templates/base.html
@@ -10,6 +10,7 @@
         <link rel="manifest" href="{% static 'manifest.json' %}">
         <meta name="theme-color" content="#3aafa9">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% if GOOGLE_SITE_VERIFICATION %}<meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">{% endif %}
 
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -12,6 +12,7 @@
     <link rel="manifest" href="{% static 'manifest.json' %}">
 
     {# SEO Meta #}
+    {% if GOOGLE_SITE_VERIFICATION %}<meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">{% endif %}
     <meta name="theme-color" content="#0FA58E">
     <meta name="description" content="{% block meta_description %}{% trans "Create map-based surveys where people mark places, draw routes, and outline areas. Free to start, open source, self-hostable. The open-source alternative to Maptionnaire." %}{% endblock %}">
     <meta name="keywords" content="{% block meta_keywords %}PPGIS, participatory mapping, open source GIS, map survey, spatial data collection, urban planning tool, community engagement, Maptionnaire alternative{% endblock %}">

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13646,3 +13646,26 @@ class ForEducatorsLandingTest(TestCase):
         c = Client()
         self.assertContains(c.get("/sitemap.xml"), "/for-educators/")
         self.assertContains(c.get("/robots.txt"), "/for-educators/")
+
+
+class GoogleSiteVerificationTest(TestCase):
+    """GSC meta-tag verification: rendered only when the token is configured."""
+
+    def test_tag_absent_by_default(self):
+        """
+        GIVEN no GOOGLE_SITE_VERIFICATION configured (default '')
+        WHEN the landing page renders
+        THEN no google-site-verification meta tag is emitted
+        """
+        resp = Client().get("/")
+        self.assertNotContains(resp, "google-site-verification")
+
+    def test_tag_rendered_when_configured(self):
+        """
+        GIVEN GOOGLE_SITE_VERIFICATION is set to a token
+        WHEN the landing page renders
+        THEN the meta tag with that token is emitted
+        """
+        with self.settings(GOOGLE_SITE_VERIFICATION="tok123abc"):
+            resp = Client().get("/")
+            self.assertContains(resp, '<meta name="google-site-verification" content="tok123abc">')


### PR DESCRIPTION
Measurement prerequisite for the SEO track: `GOOGLE_SITE_VERIFICATION` env var renders `<meta name="google-site-verification">` in both base templates (empty default = no output change). Makes GSC URL-prefix verification a redeploy-only operation; DNS TXT remains the preferred path.

Tests: `GoogleSiteVerificationTest` (absent by default / rendered when set). OpenSpec: `google-site-verification`.

Owner follow-up after merge: create the GSC property, verify, submit `sitemap.xml`, request indexing of `/for-educators/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)