### PR TITLE
feat: /alternatives/maptionnaire/ comparison page (H4)

### DIFF
--- a/openspec/changes/maptionnaire-alternative-page/.openspec.yaml
+++ b/openspec/changes/maptionnaire-alternative-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/maptionnaire-alternative-page/proposal.md
+++ b/openspec/changes/maptionnaire-alternative-page/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+"Maptionnaire alternative" is the one validated commercial-intent query for Mapsurvey — Jaakko
+Huttunen found us searching exactly this. Today's SERP: Mapsurvey is absent and aggregators
+(Capterra, SaaSHub, Slashdot) own the page. A dedicated, honest comparison page targets that
+intent directly and is the strongest SEO asset we can ship end-to-end (H4).
+
+## What Changes
+
+- New public page **`/alternatives/maptionnaire/`** — "A free, open-source Maptionnaire
+  alternative": positioning, a verified 8-row comparison table, an honest "when Maptionnaire may
+  fit better" section, CTAs tagged `utm_source=comparison&utm_medium=maptionnaire_alt`.
+- **SEO**: alternative-intent title/meta/keywords/canonical/OG; added to `sitemap.xml`; `/alternatives/`
+  allowed in `robots.txt`; footer internal link.
+- **Attribution**: CTAs UTM-tagged + first-touch source capture (Phase-1) → comparison signups land
+  in the funnel dashboard.
+- All competitor claims verified 2026-07-05 (web) or from our own code; balanced tone by design.
+
+## Capabilities
+
+### New Capabilities
+- `comparison-pages`: Public, SEO-optimized competitor-comparison landing page(s) with verified
+  claims, UTM attribution, and sitemap/robots discoverability.
+
+## Impact
+
+- Views/URLs: `maptionnaire_alternative` view + `alternatives/maptionnaire/` route; added to
+  `sitemap_xml` / `robots_txt`; footer link.
+- Template `maptionnaire_alternative.html` (extends `base_landing.html`).
+- Source content: `docs/marketing/comparisons/maptionnaire/`.
+- Depends on Phase-1 attribution (shipped). Future: `/vs/maptionnaire/` detailed page (fast follow).

--- a/openspec/changes/maptionnaire-alternative-page/specs/comparison-pages/spec.md
+++ b/openspec/changes/maptionnaire-alternative-page/specs/comparison-pages/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Maptionnaire alternative comparison page
+The system SHALL serve a public page at `/alternatives/maptionnaire/` presenting Mapsurvey as a
+free, open-source alternative to Maptionnaire, with a comparison table and a balanced
+"when Maptionnaire may fit better" section. Competitor claims SHALL be factual.
+
+#### Scenario: Page renders
+- **WHEN** an anonymous visitor requests `/alternatives/maptionnaire/`
+- **THEN** it returns HTTP 200 with the comparison content
+
+### Requirement: Alternative-intent SEO
+The page SHALL set an alternative-intent title, meta description, canonical URL and Open Graph tags,
+and SHALL be listed in `sitemap.xml` and allowed in `robots.txt`.
+
+#### Scenario: SEO + discoverability
+- **WHEN** the page, sitemap.xml, and robots.txt are fetched
+- **THEN** the page carries a canonical `/alternatives/maptionnaire/`, and both sitemap and robots reference it
+
+### Requirement: Attribution on comparison CTAs
+Registration CTAs SHALL carry `utm_source=comparison`, and the page SHALL capture first-touch source.
+
+#### Scenario: Comparison UTM present
+- **WHEN** the page renders
+- **THEN** its registration link includes `utm_source=comparison`

--- a/openspec/changes/maptionnaire-alternative-page/tasks.md
+++ b/openspec/changes/maptionnaire-alternative-page/tasks.md
@@ -1,0 +1,21 @@
+# Tasks — maptionnaire-alternative-page
+
+## 1. Page
+- [x] 1.1 `maptionnaire_alternative` view (renders template, captures first-touch source)
+- [x] 1.2 Route `alternatives/maptionnaire/`
+- [x] 1.3 Template extending `base_landing.html`: hero, why-switch cards, verified comparison table, fair section, UTM CTAs
+
+## 2. SEO / discoverability
+- [x] 2.1 Alternative-intent title/meta/keywords/canonical/OG
+- [x] 2.2 Add to `sitemap_xml`; allow `/alternatives/` in `robots_txt`; footer internal link
+
+## 3. Facts
+- [x] 3.1 Competitor claims verified (web 2026-07-05: no free tier, SaaS-only, Collect €150/mo min) + our own from code (AGPLv3, Docker, GeoJSON/CSV)
+
+## 4. Tests
+- [x] 4.1 `MaptionnaireAlternativeTest`: renders + SEO + UTM; in sitemap + robots
+
+## 5. Follow-ups
+- [ ] 5.1 `/vs/maptionnaire/` detailed comparison page (content drafted in docs/marketing/comparisons)
+- [ ] 5.2 Claim Mapsurvey listings on the aggregators that own this SERP (Capterra, SaaSHub, AlternativeTo, Slashdot) — no code
+- [ ] 5.3 Screenshots (editor + analytics) once assets are ready

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -126,6 +126,7 @@
                     <li><a href="/#features">{% trans "Features" %}</a></li>
                     <li><a href="/#demo">{% trans "Demo" %}</a></li>
                     <li><a href="{% url 'for_educators' %}">{% trans "For Educators" %}</a></li>
+                    <li><a href="{% url 'maptionnaire_alternative' %}">{% trans "Maptionnaire alternative" %}</a></li>
                 </ul>
             </div>
             {% if GITHUB_REPO_URL %}

--- a/survey/templates/maptionnaire_alternative.html
+++ b/survey/templates/maptionnaire_alternative.html
@@ -27,6 +27,10 @@
   .cmp-fair { background: #f7f8fa; border: 1px solid #e6eaef; border-radius: 14px; padding: 24px 28px; max-width: 820px; margin: 26px auto 0; text-align: left; }
   .cmp-fair h3 { margin: 0 0 10px; font-size: 17px; }
   .cmp-fair ul { margin: 0; padding-left: 20px; color: #556; line-height: 1.6; font-size: 14.5px; }
+  .cmp-maker { max-width: 820px; margin: 26px auto 0; padding: 24px 28px; text-align: center;
+               background: linear-gradient(180deg,#f2f8f5,#eef4fb); border: 1px solid #d8e6df; border-radius: 14px; }
+  .cmp-maker h3 { margin: 0 0 8px; font-size: 18px; }
+  .cmp-maker p { margin: 0 auto 16px; max-width: 560px; color: #556; font-size: 14.5px; line-height: 1.55; }
 </style>
 {% endblock %}
 
@@ -114,6 +118,13 @@
       </ul>
     </div>
     <p class="cmp-note">{% trans "We keep this honest on purpose. If Mapsurvey isn't the right fit, we'd rather you know now — and the fastest way to tell is to build a survey and see." %}</p>
+
+    <div class="cmp-maker">
+      <h3>{% trans "Comparing tools? Talk to the person who builds it" %}</h3>
+      <p>{% trans "Mapsurvey is independent and founder-led — no sales team, no funnel. Email me directly with a migration, self-hosting, DPA, or \"does it do X?\" question, and I'll answer personally." %}</p>
+      <a href="mailto:konuchovartem@mapsurvey.org?subject=Mapsurvey%20question%20(from%20the%20Maptionnaire%20comparison)" class="btn-primary-landing">{% trans "Email me — I answer personally" %}</a>
+    </div>
+
     <div class="hero__cta-group" style="margin-top:26px;justify-content:center;">
       <a href="{% url 'django_registration_register' %}?utm_source=comparison&amp;utm_medium=maptionnaire_alt" class="btn-primary-landing">{% trans "Create your Mapsurvey — free" %}</a>
       {% if DEMO_SURVEY_URL %}

--- a/survey/templates/maptionnaire_alternative.html
+++ b/survey/templates/maptionnaire_alternative.html
@@ -1,0 +1,125 @@
+{% extends "base_landing.html" %}
+{% load static i18n %}
+
+{% block title %}{% trans "Free, Open-Source Maptionnaire Alternative — Mapsurvey" %}{% endblock %}
+{% block meta_description %}{% trans "Mapsurvey is a free, open-source alternative to Maptionnaire for map-based surveys — point, line, and polygon input, GeoJSON/CSV export, EU-hosted or self-hostable. No per-survey fees, no free-tier gate." %}{% endblock %}
+{% block meta_keywords %}{% trans "Maptionnaire alternative, open source Maptionnaire, free Maptionnaire alternative, Maptionnaire vs Mapsurvey, participatory mapping software, PPGIS tool" %}{% endblock %}
+{% block canonical_url %}https://mapsurvey.org/alternatives/maptionnaire/{% endblock %}
+{% block og_url %}https://mapsurvey.org/alternatives/maptionnaire/{% endblock %}
+{% block og_title %}{% trans "A free, open-source Maptionnaire alternative — Mapsurvey" %}{% endblock %}
+
+{% block extra_head %}
+<style>
+  .cmp-lead { max-width: 720px; margin: 0 auto; }
+  .cmp-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 18px; margin-top: 26px; }
+  .cmp-card { background: #fff; border: 1px solid #e6eaef; border-radius: 12px; padding: 20px 22px; text-align: left; }
+  .cmp-card h3 { font-size: 17px; margin: 0 0 6px; }
+  .cmp-card p { font-size: 14px; color: #556; margin: 0; line-height: 1.5; }
+  .cmp-table-wrap { max-width: 820px; margin: 26px auto 0; overflow-x: auto; }
+  table.cmp { width: 100%; border-collapse: collapse; font-size: 14.5px; background: #fff; border: 1px solid #e6eaef; border-radius: 12px; overflow: hidden; }
+  table.cmp th, table.cmp td { padding: 11px 16px; text-align: left; border-bottom: 1px solid #eef1f4; vertical-align: top; }
+  table.cmp thead th { background: #f4f8fb; font-size: 13px; }
+  table.cmp th:first-child { color: #667; font-weight: 500; }
+  table.cmp .ms { color: #1f7a4d; font-weight: 600; }
+  table.cmp .mt { color: #667; }
+  table.cmp tr:last-child td { border-bottom: 0; }
+  .cmp-note { max-width: 820px; margin: 14px auto 0; font-size: 13px; color: #889; text-align: left; }
+  .cmp-fair { background: #f7f8fa; border: 1px solid #e6eaef; border-radius: 14px; padding: 24px 28px; max-width: 820px; margin: 26px auto 0; text-align: left; }
+  .cmp-fair h3 { margin: 0 0 10px; font-size: 17px; }
+  .cmp-fair ul { margin: 0; padding-left: 20px; color: #556; line-height: 1.6; font-size: 14.5px; }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="hero" id="hero">
+  <div class="hero__content cmp-lead">
+    <h1 class="hero__headline">{% trans "A free, open-source Maptionnaire alternative" %}</h1>
+    <p class="hero__description">
+      {% trans "Mapsurvey does the same core job as Maptionnaire — map-based surveys where people mark places, draw routes, and outline areas — with different economics: free to use, open source (AGPLv3), EU-hosted, and self-hostable. No per-survey fees, no free-tier gate on your first real project." %}
+    </p>
+    <div class="hero__cta-group">
+      <a href="{% url 'django_registration_register' %}?utm_source=comparison&amp;utm_medium=maptionnaire_alt" class="btn-primary-landing">{% trans "Create your Mapsurvey — free" %}</a>
+      {% if DEMO_SURVEY_URL %}
+      <a href="{{ DEMO_SURVEY_URL }}" class="btn-secondary-landing" target="_blank" rel="noopener">{% trans "Try a live demo survey" %}</a>
+      {% endif %}
+    </div>
+    <div class="hero__badges">
+      <span class="hero__badge">{% trans "Free" %}</span>
+      <span class="hero__badge">{% trans "Open source (AGPLv3)" %}</span>
+      <span class="hero__badge">{% trans "Self-hostable" %}</span>
+      <span class="hero__badge">{% trans "EU-hosted" %}</span>
+    </div>
+  </div>
+</section>
+
+<section class="showcase">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "Why teams switch" %}</p>
+    <h2 class="section-heading">{% trans "Same participatory-mapping job, without the licensing" %}</h2>
+    <div class="cmp-grid">
+      <div class="cmp-card">
+        <h3>{% trans "Free to start" %}</h3>
+        <p>{% trans "No per-survey fees, no seat licensing, no tier that gates your first real project. Run one survey or many at the same cost: zero." %}</p>
+      </div>
+      <div class="cmp-card">
+        <h3>{% trans "Open source (AGPLv3)" %}</h3>
+        <p>{% trans "Read the code, fork it, or run it yourself. No proprietary lock-in — useful for audits and academic publication." %}</p>
+      </div>
+      <div class="cmp-card">
+        <h3>{% trans "Self-host or EU cloud" %}</h3>
+        <p>{% trans "Use the hosted version (EU, Frankfurt) or self-host with Docker on your own infrastructure for full data sovereignty." %}</p>
+      </div>
+      <div class="cmp-card">
+        <h3>{% trans "Standard data out" %}</h3>
+        <p>{% trans "GeoJSON + CSV export built in — open in QGIS, ArcGIS, R, or Python with no conversion." %}</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="showcase">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "Side by side" %}</p>
+    <h2 class="section-heading">{% trans "Mapsurvey vs Maptionnaire" %}</h2>
+    <div class="cmp-table-wrap">
+      <table class="cmp">
+        <thead>
+          <tr><th>&nbsp;</th><th>Mapsurvey</th><th>Maptionnaire</th></tr>
+        </thead>
+        <tbody>
+          <tr><th>{% trans "Free tier for real projects" %}</th><td class="ms">{% trans "Yes — unlimited, free" %}</td><td class="mt">{% trans "No free tier" %}</td></tr>
+          <tr><th>{% trans "Pricing model" %}</th><td class="ms">{% trans "Free hosted; free self-hosted" %}</td><td class="mt">{% trans "Subscription — Collect tier listed at €150/mo, 12-month minimum" %}</td></tr>
+          <tr><th>{% trans "Open source" %}</th><td class="ms">{% trans "Yes — AGPLv3, code on GitHub" %}</td><td class="mt">{% trans "No — proprietary" %}</td></tr>
+          <tr><th>{% trans "Self-hosting" %}</th><td class="ms">{% trans "Yes — Docker, your infrastructure" %}</td><td class="mt">{% trans "No — SaaS only" %}</td></tr>
+          <tr><th>{% trans "Map input (point / line / polygon)" %}</th><td class="ms">{% trans "Yes" %}</td><td class="mt">{% trans "Yes" %}</td></tr>
+          <tr><th>{% trans "Multilingual surveys" %}</th><td class="ms">{% trans "Yes — per-question translations" %}</td><td class="mt">{% trans "Yes" %}</td></tr>
+          <tr><th>{% trans "Data export" %}</th><td class="ms">{% trans "GeoJSON + CSV, built in" %}</td><td class="mt">{% trans "Yes" %}</td></tr>
+          <tr><th>{% trans "EU data residency" %}</th><td class="ms">{% trans "Frankfurt, or self-host anywhere" %}</td><td class="mt">{% trans "Finland" %}</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="cmp-note">{% trans "Maptionnaire details reflect their published product and pricing pages as of July 2026; verify current specifics on maptionnaire.com. Both platforms are GDPR-oriented and support point, line, and polygon input." %}</p>
+  </div>
+</section>
+
+<section class="showcase">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "Being fair" %}</p>
+    <h2 class="section-heading">{% trans "When Maptionnaire may be the better fit" %}</h2>
+    <div class="cmp-fair">
+      <ul>
+        <li>{% trans "You want a mature commercial vendor with a long track record in participatory planning and formal EU procurement." %}</li>
+        <li>{% trans "You need a feature that's on Mapsurvey's roadmap today (e.g. custom WMS/WFS basemaps, Shapefile export)." %}</li>
+        <li>{% trans "You're already running on Maptionnaire and the switching cost outweighs the savings." %}</li>
+      </ul>
+    </div>
+    <p class="cmp-note">{% trans "We keep this honest on purpose. If Mapsurvey isn't the right fit, we'd rather you know now — and the fastest way to tell is to build a survey and see." %}</p>
+    <div class="hero__cta-group" style="margin-top:26px;justify-content:center;">
+      <a href="{% url 'django_registration_register' %}?utm_source=comparison&amp;utm_medium=maptionnaire_alt" class="btn-primary-landing">{% trans "Create your Mapsurvey — free" %}</a>
+      {% if DEMO_SURVEY_URL %}
+      <a href="{{ DEMO_SURVEY_URL }}" class="btn-secondary-landing" target="_blank" rel="noopener">{% trans "Try a live demo survey" %}</a>
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13646,3 +13646,29 @@ class ForEducatorsLandingTest(TestCase):
         c = Client()
         self.assertContains(c.get("/sitemap.xml"), "/for-educators/")
         self.assertContains(c.get("/robots.txt"), "/for-educators/")
+
+
+class MaptionnaireAlternativeTest(TestCase):
+    """SEO comparison page targeting the validated "Maptionnaire alternative" query."""
+
+    def test_page_renders_with_seo_and_utm(self):
+        """
+        GIVEN the Maptionnaire alternative page
+        WHEN requested
+        THEN it renders with comparison content, education/alternative SEO, and a comparison-UTM CTA
+        """
+        resp = Client().get("/alternatives/maptionnaire/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Maptionnaire alternative")
+        self.assertContains(resp, "alternatives/maptionnaire/")     # canonical
+        self.assertContains(resp, "utm_source=comparison")
+
+    def test_discoverable_in_sitemap_and_robots(self):
+        """
+        GIVEN the page should be indexable
+        WHEN sitemap.xml and robots.txt are fetched
+        THEN both reference the page / its prefix
+        """
+        c = Client()
+        self.assertContains(c.get("/sitemap.xml"), "/alternatives/maptionnaire/")
+        self.assertContains(c.get("/robots.txt"), "/alternatives/")

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -88,6 +88,7 @@ urlpatterns = [
     path('surveys/<str:survey_slug>/download', views.download_data, name='download_data'),
     path('stories/<slug:slug>/', views.story_detail, name='story_detail'),
     path('for-educators/', views.for_educators, name='for_educators'),
+    path('alternatives/maptionnaire/', views.maptionnaire_alternative, name='maptionnaire_alternative'),
     path('robots.txt', views.robots_txt, name='robots_txt'),
     path('sitemap.xml', views.sitemap_xml, name='sitemap_xml'),
 ]

--- a/survey/views.py
+++ b/survey/views.py
@@ -1183,12 +1183,23 @@ def for_educators(request):
 	return render(request, 'for_educators.html')
 
 
+def maptionnaire_alternative(request):
+	"""Public "free, open-source Maptionnaire alternative" comparison page.
+
+	Targets the validated "Maptionnaire alternative" search intent (how Jaakko
+	found us). First-touch source capture; CTAs carry utm_source=comparison.
+	"""
+	capture_signup_source(request)
+	return render(request, 'maptionnaire_alternative.html')
+
+
 def robots_txt(request):
 	lines = [
 		"User-agent: *",
 		"Allow: /surveys/",
 		"Allow: /stories/",
 		"Allow: /for-educators/",
+		"Allow: /alternatives/",
 		"Disallow: /admin/",
 		"Disallow: /editor/",
 		"Disallow: /accounts/",
@@ -1205,6 +1216,7 @@ def sitemap_xml(request):
 	)
 	urls = [f"  <url><loc>{base}/</loc></url>"]
 	urls.append(f"  <url><loc>{base}/for-educators/</loc></url>")
+	urls.append(f"  <url><loc>{base}/alternatives/maptionnaire/</loc></url>")
 	urls.append(f"  <url><loc>{base}/trust/</loc></url>")
 	urls.append(f"  <url><loc>{base}/surveys/</loc></url>")
 	for survey in surveys:


### PR DESCRIPTION
Targets the one **validated commercial-intent query** for Mapsurvey — "Maptionnaire alternative" (how Jaakko Huttunen found us). Today's SERP: we're absent, aggregators own it. This is the strongest SEO asset shippable end-to-end.

## What
- New page `/alternatives/maptionnaire/`: positioning, a verified 8-row comparison table, and an honest **"when Maptionnaire may fit better"** section (balanced tone — Google rewards honesty, and it's true).
- SEO: alternative-intent title/meta/canonical/OG; added to `sitemap.xml`; `/alternatives/` in `robots.txt`; footer internal link (site-wide).
- Attribution: CTAs `utm_source=comparison&utm_medium=maptionnaire_alt` + first-touch capture → comparison signups show in the funnel dashboard.

## Facts checked (2026-07-05)
Competitor claims verified via web (no free tier; SaaS-only, not open source, no self-hosting; Collect tier listed at €150/mo, 12-mo min) and our own from code (AGPLv3, Docker self-host, GeoJSON+CSV export). Source drafts: `docs/marketing/comparisons/maptionnaire/`.

## Tests
`MaptionnaireAlternativeTest` (renders + SEO + UTM; sitemap + robots). Visual: Render PR preview.

Follow-ups (in tasks.md): `/vs/maptionnaire/` detailed page; claim aggregator listings (no code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)