### PR TITLE
feat: /for-government/ — open-source community engagement platform page

### DIFF
--- a/openspec/changes/for-government-engagement-page/.openspec.yaml
+++ b/openspec/changes/for-government-engagement-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/for-government-engagement-page/proposal.md
+++ b/openspec/changes/for-government-engagement-page/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Adds the local-government audience and makes the play for the "community engagement platform"
+keyword cluster (C6) — a competitive head term owned by Maptionnaire/Esri/Go Vocal. One focused page
+(rather than a separate audience page + a separate keyword page, which would read as doorway/duplicate
+content) both serves government buyers and carries the engagement-platform positioning.
+
+## What Changes
+
+- New public page **/for-government/** — "The open-source community engagement platform" for councils
+  and public agencies: map-based public consultation, data ownership/self-hosting, no lock-in, honest
+  "vs a proprietary suite" framing linking to the Maptionnaire comparison.
+- UTM CTAs (`utm_source=government`) + first-touch source capture; a "talk to us" mailto (branded).
+- Added to Solutions dropdown ("For Local Government"), footer, sitemap.xml, robots.txt.
+- SEO targets: community engagement platform / public consultation software / public engagement.
+
+## Capabilities
+
+### Modified Capabilities
+- `audience-pages`: adds the government/community-engagement page to the audience-page family.
+
+## Impact
+
+- Views/URLs: `for_government` + route; sitemap/robots; nav + footer.
+- Template `for_government.html` (extends `base_landing.html`).
+- Realistic note: the head term is competitive; the page works mainly as a conversion/credibility
+  surface + long-tail capture, not a guaranteed #1.

--- a/openspec/changes/for-government-engagement-page/specs/audience-pages/spec.md
+++ b/openspec/changes/for-government-engagement-page/specs/audience-pages/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Local-government / community-engagement page
+The system SHALL serve a public page at `/for-government/` positioning Mapsurvey as an open-source
+community engagement platform for local government, with engagement-intent SEO, a UTM-tagged CTA, and
+an honest comparison pointer.
+
+#### Scenario: Page renders with engagement positioning
+- **WHEN** `/for-government/` is requested
+- **THEN** it returns HTTP 200, presents the "community engagement platform" positioning, and its
+  registration CTA carries `utm_source=government`
+
+#### Scenario: Discoverable and navigable
+- **WHEN** the site is crawled and rendered
+- **THEN** `/for-government/` appears in sitemap.xml, robots.txt, the Solutions dropdown, and the footer

--- a/openspec/changes/for-government-engagement-page/tasks.md
+++ b/openspec/changes/for-government-engagement-page/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — for-government-engagement-page
+
+## 1. Page
+- [x] 1.1 `for_government` view (renders template, first-touch source capture)
+- [x] 1.2 Route `for-government/`
+- [x] 1.3 Template extending `base_landing.html`: engagement-platform hero, why-councils cards, use cases, honest comparison pointer, UTM CTAs + branded "talk to us" mailto
+
+## 2. SEO / discoverability
+- [x] 2.1 Engagement-intent title/meta/keywords/canonical/OG
+- [x] 2.2 Add to `sitemap_xml`, `robots_txt`, Solutions dropdown, footer
+
+## 3. Tests
+- [x] 3.1 `ForGovernmentLandingTest`: renders + positioning + UTM; in sitemap + robots
+
+## 4. Follow-ups
+- [ ] 4.1 NGO / community-organisation audience if demand shows
+- [ ] 4.2 A consented council case study to anchor credibility on this page

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -77,6 +77,7 @@
                 {# One audience page today; every future "for …" page goes in this list. #}
                 <ul class="landing-nav__dd-menu">
                     <li><a href="{% url 'for_planners' %}">{% trans "For Urban Planners" %}</a></li>
+                    <li><a href="{% url 'for_government' %}">{% trans "For Local Government" %}</a></li>
                     <li><a href="{% url 'for_researchers' %}">{% trans "For Researchers" %}</a></li>
                     <li><a href="{% url 'for_educators' %}">{% trans "For Educators" %}</a></li>
                 </ul>
@@ -129,6 +130,7 @@
                     <li><a href="/#features">{% trans "Features" %}</a></li>
                     <li><a href="/#demo">{% trans "Demo" %}</a></li>
                     <li><a href="{% url 'for_planners' %}">{% trans "For Urban Planners" %}</a></li>
+                    <li><a href="{% url 'for_government' %}">{% trans "For Local Government" %}</a></li>
                     <li><a href="{% url 'for_researchers' %}">{% trans "For Researchers" %}</a></li>
                     <li><a href="{% url 'for_educators' %}">{% trans "For Educators" %}</a></li>
                     <li><a href="{% url 'maptionnaire_alternative' %}">{% trans "Maptionnaire alternative" %}</a></li>

--- a/survey/templates/for_government.html
+++ b/survey/templates/for_government.html
@@ -1,0 +1,93 @@
+{% extends "base_landing.html" %}
+{% load static i18n %}
+
+{% block title %}{% trans "Open-Source Community Engagement Platform for Local Government | Mapsurvey" %}{% endblock %}
+{% block meta_description %}{% trans "A free, open-source community engagement platform for councils and public agencies. Run map-based public consultation — residents pin, draw, and outline their input — and keep full ownership of the data (self-hostable, GDPR)." %}{% endblock %}
+{% block meta_keywords %}{% trans "community engagement platform, public engagement software, public consultation software, citizen engagement platform, participatory planning, open source engagement platform, local government, GDPR" %}{% endblock %}
+{% block canonical_url %}https://mapsurvey.org/for-government/{% endblock %}
+{% block og_url %}https://mapsurvey.org/for-government/{% endblock %}
+{% block og_title %}{% trans "The open-source community engagement platform for local government" %}{% endblock %}
+
+{% block extra_head %}
+<style>
+  .aud-lead { max-width: 720px; margin: 0 auto; }
+  .aud-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 18px; margin-top: 26px; }
+  .aud-card { background: #fff; border: 1px solid #e6eaef; border-radius: 12px; padding: 20px 22px; text-align: left; }
+  .aud-card h3 { font-size: 17px; margin: 0 0 6px; }
+  .aud-card p { font-size: 14px; color: #556; margin: 0; line-height: 1.5; }
+  .aud-ideas { list-style: none; padding: 0; margin: 22px auto 0; max-width: 720px; text-align: left; }
+  .aud-ideas li { padding: 9px 0 9px 30px; border-bottom: 1px solid #eef1f4; position: relative; font-size: 15px; }
+  .aud-ideas li::before { content: "◆"; color: #2f6fb0; position: absolute; left: 6px; }
+  .aud-fair { background: #f7f8fa; border: 1px solid #e6eaef; border-radius: 14px; padding: 22px 26px; max-width: 820px; margin: 24px auto 0; text-align: left; font-size: 14.5px; color: #556; line-height: 1.6; }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="hero" id="hero">
+  <div class="hero__content aud-lead">
+    <h1 class="hero__headline">{% trans "The open-source community engagement platform" %}</h1>
+    <p class="hero__description">
+      {% trans "Built for councils and public agencies that want map-based public consultation without enterprise lock-in. Residents pin the places, draw the routes, and outline the areas that matter to them — you get GIS-ready results and full ownership of the data. Free, open source, GDPR-friendly, and self-hostable on your own infrastructure." %}
+    </p>
+    <div class="hero__cta-group">
+      <a href="{% url 'django_registration_register' %}?utm_source=government&amp;utm_medium=for_government" class="btn-primary-landing">{% trans "Start free — run a consultation" %}</a>
+      {% if DEMO_SURVEY_URL %}
+      <a href="{{ DEMO_SURVEY_URL }}" class="btn-secondary-landing" target="_blank" rel="noopener">{% trans "Try a live demo survey" %}</a>
+      {% endif %}
+    </div>
+    <div class="hero__badges">
+      <span class="hero__badge">{% trans "Free & open source" %}</span>
+      <span class="hero__badge">{% trans "GDPR / EU-hosted" %}</span>
+      <span class="hero__badge">{% trans "Self-host on your infra" %}</span>
+      <span class="hero__badge">{% trans "No per-project fees" %}</span>
+    </div>
+  </div>
+</section>
+
+<section class="showcase">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "Why councils choose it" %}</p>
+    <h2 class="section-heading">{% trans "Public engagement on a map, without the lock-in" %}</h2>
+    <div class="aud-grid">
+      <div class="aud-card">
+        <h3>{% trans "Map-based public consultation" %}</h3>
+        <p>{% trans "Residents give location-specific input — exactly where the issue is — instead of vague text. Wider, more diverse reach than a meeting." %}</p>
+      </div>
+      <div class="aud-card">
+        <h3>{% trans "You own the data" %}</h3>
+        <p>{% trans "Self-host on your own infrastructure, or use the EU-hosted version. GDPR-friendly, with your data where your policies require." %}</p>
+      </div>
+      <div class="aud-card">
+        <h3>{% trans "No vendor lock-in" %}</h3>
+        <p>{% trans "Open source (AGPLv3) — auditable, adaptable, and procurement-friendly. Export everything as GeoJSON + CSV, anytime." %}</p>
+      </div>
+      <div class="aud-card">
+        <h3>{% trans "Fits a public budget" %}</h3>
+        <p>{% trans "Free to run — no per-project or per-response licensing that stretches a small council's engagement budget." %}</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="showcase">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "Engagement use cases" %}</p>
+    <h2 class="section-heading">{% trans "What agencies run on it" %}</h2>
+    <ul class="aud-ideas">
+      <li>{% trans "Statutory planning & local-plan consultation — comments pinned to the map." %}</li>
+      <li>{% trans "Participatory budgeting — where residents want investment." %}</li>
+      <li>{% trans "Mobility & active-travel plans — routes, barriers, and desire lines." %}</li>
+      <li>{% trans "Ward / neighbourhood engagement — what to keep, fix, or change." %}</li>
+      <li>{% trans "\"Report an issue\" mapping — a lightweight public feedback channel." %}</li>
+    </ul>
+    <div class="aud-fair">
+      {% trans "Comparing engagement platforms? Mapsurvey trades a big vendor's bundled services for open-source transparency, self-hosting, and no per-project fees. If you need a fully managed enterprise suite, a commercial platform may fit better — we keep that honest." %}
+      <a href="{% url 'maptionnaire_alternative' %}">{% trans "See how we compare to Maptionnaire →" %}</a>
+    </div>
+    <div class="hero__cta-group" style="margin-top:28px;justify-content:center;">
+      <a href="{% url 'django_registration_register' %}?utm_source=government&amp;utm_medium=for_government" class="btn-primary-landing">{% trans "Create your first consultation — free" %}</a>
+      <a href="mailto:konuchovartem@mapsurvey.org?subject=Mapsurvey%20for%20our%20council" class="btn-secondary-landing">{% trans "Talk to us about your council" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13737,3 +13737,24 @@ class AudienceLandingPagesTest(TestCase):
         rb = c.get("/robots.txt")
         self.assertContains(rb, "/for-planners/")
         self.assertContains(rb, "/for-researchers/")
+
+
+class ForGovernmentLandingTest(TestCase):
+    """Local-government page positioned as the open-source community engagement platform."""
+
+    def test_page_renders_with_engagement_positioning_and_utm(self):
+        """
+        GIVEN the for-government page
+        WHEN requested
+        THEN it renders with the community-engagement-platform positioning and a government-UTM CTA
+        """
+        resp = Client().get("/for-government/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "community engagement platform")
+        self.assertContains(resp, "for-government/")
+        self.assertContains(resp, "utm_source=government")
+
+    def test_in_sitemap_and_robots(self):
+        c = Client()
+        self.assertContains(c.get("/sitemap.xml"), "/for-government/")
+        self.assertContains(c.get("/robots.txt"), "/for-government/")

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -90,6 +90,7 @@ urlpatterns = [
     path('for-educators/', views.for_educators, name='for_educators'),
     path('for-planners/', views.for_planners, name='for_planners'),
     path('for-researchers/', views.for_researchers, name='for_researchers'),
+    path('for-government/', views.for_government, name='for_government'),
     path('alternatives/maptionnaire/', views.maptionnaire_alternative, name='maptionnaire_alternative'),
     path('robots.txt', views.robots_txt, name='robots_txt'),
     path('sitemap.xml', views.sitemap_xml, name='sitemap_xml'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -1213,6 +1213,14 @@ def for_researchers(request):
 	return render(request, 'for_researchers.html')
 
 
+def for_government(request):
+	"""Public landing page: the open-source community engagement platform for
+	local government. Audience page (councils / public agencies) that also owns
+	the "community engagement platform" positioning. utm_source=government."""
+	capture_signup_source(request)
+	return render(request, 'for_government.html')
+
+
 def robots_txt(request):
 	lines = [
 		"User-agent: *",
@@ -1221,6 +1229,7 @@ def robots_txt(request):
 		"Allow: /for-educators/",
 		"Allow: /for-planners/",
 		"Allow: /for-researchers/",
+		"Allow: /for-government/",
 		"Allow: /alternatives/",
 		"Disallow: /admin/",
 		"Disallow: /editor/",
@@ -1240,6 +1249,7 @@ def sitemap_xml(request):
 	urls.append(f"  <url><loc>{base}/for-educators/</loc></url>")
 	urls.append(f"  <url><loc>{base}/for-planners/</loc></url>")
 	urls.append(f"  <url><loc>{base}/for-researchers/</loc></url>")
+	urls.append(f"  <url><loc>{base}/for-government/</loc></url>")
 	urls.append(f"  <url><loc>{base}/alternatives/maptionnaire/</loc></url>")
 	urls.append(f"  <url><loc>{base}/trust/</loc></url>")
 	urls.append(f"  <url><loc>{base}/surveys/</loc></url>")


### PR DESCRIPTION
Adds the **local-government** audience and makes the play for the **"community engagement platform"** keyword cluster — in one focused page rather than a separate audience page + keyword page (two community-engagement pages would read as doorway/duplicate content to Google).

## What
- **/for-government/** — "The open-source community engagement platform" for councils and public agencies: map-based public consultation, **data ownership / self-hosting**, no vendor lock-in, and an **honest "vs a proprietary suite"** pointer to the Maptionnaire comparison.
- UTM CTAs (`utm_source=government`) + first-touch capture; a branded "talk to us" mailto (`konuchovartem@mapsurvey.org`).
- Added to the Solutions dropdown ("For Local Government"), footer, `sitemap.xml`, `robots.txt`.
- SEO targets: community engagement platform / public consultation software / public engagement.

## Honest note
This head term is competitive (Maptionnaire/Esri/Go Vocal own it). The page works mainly as a **conversion/credibility surface + long-tail capture**, not a guaranteed #1. Flagged in tasks: a consented council case study to anchor it.

Tests: `ForGovernmentLandingTest`. Visual: Render PR preview. OpenSpec: `for-government-engagement-page`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)