### PR TITLE
feat: Organization schema + sameAs (brand disambiguation)

### DIFF
--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -47,6 +47,24 @@
         "codeRepository": "{{ GITHUB_REPO_URL }}"
     }
     </script>
+    {# Organization entity — brand disambiguation (there are unrelated firms named
+       "MapSurvey"); sameAs ties mapsurvey.org to our canonical profiles so search
+       engines resolve us as a distinct entity. #}
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Mapsurvey",
+        "alternateName": "Mapsurvey.org",
+        "url": "https://mapsurvey.org/",
+        "logo": "https://mapsurvey.org{% static 'favicon-512x512.png' %}",
+        "description": "Open-source participatory-mapping platform: map-based surveys where participants mark places, draw routes, and outline areas.",
+        "sameAs": [
+            "{{ GITHUB_REPO_URL }}",
+            "https://participedia.net/method/mapsurvey-1"
+        ]
+    }
+    </script>
 
     {# Fonts #}
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13758,3 +13758,29 @@ class ForGovernmentLandingTest(TestCase):
         c = Client()
         self.assertContains(c.get("/sitemap.xml"), "/for-government/")
         self.assertContains(c.get("/robots.txt"), "/for-government/")
+
+
+class OrganizationSchemaTest(TestCase):
+    """Brand-entity Organization JSON-LD with sameAs on the landing pages."""
+
+    def test_homepage_has_organization_schema_with_sameas(self):
+        """
+        GIVEN the landing page
+        WHEN rendered
+        THEN it includes an Organization JSON-LD block with sameAs linking our profiles
+        """
+        import json, re
+        html = Client().get("/").content.decode()
+        blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.S)
+        types = []
+        org = None
+        for b in blocks:
+            d = json.loads(b)   # must be valid JSON
+            types.append(d.get("@type"))
+            if d.get("@type") == "Organization":
+                org = d
+        self.assertIn("Organization", types)
+        self.assertIn("SoftwareApplication", types)
+        self.assertEqual(org["name"], "Mapsurvey")
+        self.assertTrue(any("github.com" in s for s in org["sameAs"]))
+        self.assertTrue(any("participedia.net" in s for s in org["sameAs"]))


### PR DESCRIPTION
## Why
GSC shows we're only ~#2 for our own name "mapsurvey" (59 impressions, 0 clicks / 28d). The cause isn't an imposter outranking us — **the term is contested**: unrelated firms `mapsurvey.eu` (engineering, since 2015) and `map-survey.com`, plus the accounting "MAP survey" (AICPA/ICPAS). "Mapsurvey" is a semi-generic word, not a clean brand.

## What
Adds an **Organization** JSON-LD entity on the landing pages with **`sameAs`** → our GitHub repo and our Participedia method entry (verified to be ours). This helps search engines resolve `mapsurvey.org` as a distinct entity, separate from the same-named firms — the cheapest technical brand-disambiguation signal.

The compounding lever remains authority: directory listings, awesome-list, and a Product Hunt / Show HN launch each reinforce "Mapsurvey → mapsurvey.org".

## Tests
`OrganizationSchemaTest` — valid JSON-LD; Organization + SoftwareApplication present; sameAs includes GitHub + Participedia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)