### PR TITLE
feat(seo): landing structured data (FAQ + breadcrumbs) + public stories index

### DIFF
--- a/openspec/changes/landing-seo-structured-data/.openspec.yaml
+++ b/openspec/changes/landing-seo-structured-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/landing-seo-structured-data/design.md
+++ b/openspec/changes/landing-seo-structured-data/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The SEO landing pages (`survey/templates/*.html` extending `base_landing.html`) already override `title`/`meta_description`/`meta_keywords`/`canonical_url`/`og_url` blocks per page. `base_landing.html` carries two site-wide JSON-LD blobs (`SoftwareApplication`, `Organization`). The sitemap and robots are plain function views (`survey/views.py::sitemap_xml`, `::robots_txt`) that hardcode the landing URL list; the same list also appears as route registrations in `survey/urls.py`. There is no page-level structured data, no FAQ content, and no shared landing registry.
+
+Constraints:
+- Django template inheritance + `{% trans %}` i18n is the existing idiom; no JS framework on landings.
+- JSON-LD must be valid JSON — user-facing FAQ answers contain quotes/apostrophes, so escaping matters.
+- Keep it DRY: the on-page FAQ and the `FAQPage` JSON-LD must come from one per-page source so they can't drift.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reusable FAQ section + `FAQPage` JSON-LD driven by a single per-page Q&A list.
+- `BreadcrumbList` JSON-LD on landings, correct for the two-level `alternatives/*` pages.
+- One source of truth for the SEO landing list, consumed by `sitemap_xml` and `robots_txt`, with `lastmod`/`changefreq`/`priority`.
+- Tests asserting presence + validity of structured data and full sitemap/robots coverage.
+
+**Non-Goals:**
+- No change to the root `/` landing page requirements (`landing-page` spec untouched).
+- No auto-generation of `urls.py` routes from the registry (routes stay explicit; only robots/sitemap derive from the registry).
+- No new content pages, no blog, no `/stories/` index (separate changes).
+- No new runtime dependencies.
+
+## Decisions
+
+**D1 — The registry is the per-page data hub; a shared render helper injects it.**
+The 13 landings are rendered by thin view functions (`render(request, 'x.html')`). Rather than hand-editing 13 views with bespoke Q&A/breadcrumb lists, the SEO landing **registry** (D2) holds each page's `faq` list and `breadcrumbs`, and a single helper `render_seo_landing(request, page_key)` looks the entry up and injects `faq_items` + `breadcrumbs` (as already-built JSON-LD strings) into the template context. Each view becomes `return render_seo_landing(request, 'civic_engagement')`. This makes the registry the one place that knows a page's path, crawl hints, breadcrumb, and FAQ — so a page can't have a route but miss its sitemap/FAQ, or vice-versa.
+- Two shared partials read that context: `partials/_faq_section.html` renders the visible `<section>` by looping `faq_items`; `partials/_landing_structured_data.html` emits the `FAQPage` + `BreadcrumbList` `<script type="application/ld+json">`. Both derive from the same registry entry, so they can't drift.
+- *Alternative considered*: define Q&A inside each template with `{% with %}`/inclusion tags — rejected because building valid JSON from template loops requires fragile manual escaping, and it re-scatters the source of truth the registry is meant to unify.
+- *Escaping*: JSON-LD is built with `json.dumps(...)` in Python and passed to the template as a pre-escaped safe string, guaranteeing valid JSON regardless of quotes/apostrophes in answers.
+
+**D2 — `survey/seo_landings.py` holds the registry + builders.** One module with: `SEO_LANDINGS` — an ordered registry (dataclass/dict per page: `key`, `path`, `url_name`, `changefreq`, `priority`, `lastmod`, `breadcrumbs`, `faq`), plus `build_faqpage_jsonld(faq)` and `build_breadcrumb_jsonld(request, crumbs)` returning `json.dumps` strings, and `render_seo_landing(request, key)`. Views and the sitemap/robots views import from here; tests get a direct unit surface.
+
+**D3 — `structured_data` block in `base_landing.html`.** Add `{% block structured_data %}{% endblock %}` right after the site-wide JSON-LD. Landing templates fill it by `{% include "partials/_landing_structured_data.html" %}`. Root/other pages that extend the base and don't set it are unaffected.
+
+**D4 — Registry drives robots + sitemap, not urls.py.** `SEO_LANDINGS` in `survey/seo_landings.py` is the single list of `(path, changefreq, priority)`. `robots_txt` builds its `Allow:` lines from it; `sitemap_xml` builds `<url>` entries with `<lastmod>` (deploy date or a static release date — see D5), `<changefreq>`, `<priority>`. `urls.py` keeps explicit `path()` calls (they need view callables), but a test asserts every registry path resolves and vice-versa, catching drift.
+
+**D5 — `lastmod` value.** Use a per-entry static `lastmod` date string in the registry (updated when a page's content materially changes), not `now()` — a sitemap that reports "modified today" on every crawl trains crawlers to distrust `lastmod`. Default to the change's ship date for all current entries.
+
+## Risks / Trade-offs
+
+- **[Invalid JSON-LD from unescaped quotes]** → generate JSON via `json.dumps`, never string concatenation; test parses the emitted `<script>` with `json.loads`.
+- **[FAQ/JSON-LD drift]** → both derive from the same `faq_items`; a test asserts each visible `<summary>`/question also appears in the `FAQPage` JSON.
+- **[Registry vs urls.py drift]** → test resolves every registry path and asserts every landing route is in the registry.
+- **[Google flags FAQ rich results as spammy if content is thin/duplicated]** → per-page Q&A must be genuinely page-specific (not the same 5 questions copy-pasted); enforced by review, and a test asserts distinct questions across pages.
+- **[`lastmod` staleness]** → accepted; static dates are safer than always-now. Document that editors bump the date on material change.
+
+## Migration Plan
+
+Pure additive, no DB. Deploy = template + view refactor. Rollback = revert commit; no data migration. After deploy, validate a sample of pages with Google Rich Results Test and resubmit the sitemap in Search Console (manual, tracked in the outreach checklist).
+
+## Open Questions
+
+- None blocking. FAQ copy per page will be drafted during implementation from each page's existing value props; competitor pages (`alternatives/*`) get comparison-specific Q&A.

--- a/openspec/changes/landing-seo-structured-data/proposal.md
+++ b/openspec/changes/landing-seo-structured-data/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The 12 SEO landing pages shipped in the recent wave have clean per-page `title`/`meta`/`canonical`, but no page-level structured data beyond the site-wide `SoftwareApplication` + `Organization` markup in `base_landing.html`. Two high-value, low-cost gaps remain: (1) no `FAQPage` markup or FAQ content, so we forgo FAQ rich results and leave long-tail intent ("is it free?", "can I self-host?", "do respondents need an account?") unanswered on-page; (2) no `BreadcrumbList`, so SERP entries — especially the two-level `alternatives/*` pages — show a bare URL instead of a breadcrumb trail. Separately, the landing-URL list is hardcoded in three places (`urls.py`, `robots_txt`, `sitemap_xml`), so adding a landing can silently miss the sitemap or robots allow-list, and sitemap entries carry no `lastmod`/`priority` hints.
+
+## What Changes
+
+- Add a reusable **FAQ section partial** and render it on each of the 12 SEO landing pages with 3–5 page-specific Q&A targeting long-tail intent (competitor-comparison specifics on `alternatives/*`).
+- Emit **`FAQPage` JSON-LD** built from the same per-page Q&A list, so the on-page FAQ and the structured data never drift.
+- Emit **`BreadcrumbList` JSON-LD** on landing pages (`Home › [Solutions|Alternatives] › Page`).
+- Introduce a **`{% block structured_data %}`** in `base_landing.html` so pages opt into per-page JSON-LD without touching the site-wide markup.
+- Establish a **single source of truth** for the SEO landing URLs (one Python list/registry) consumed by `urls.py` route registration is out of scope, but `robots_txt` and `sitemap_xml` SHALL both derive their landing list from it.
+- **Sitemap polish**: add `<lastmod>`, `<changefreq>`, `<priority>` to landing entries.
+- Add tests mirroring `SeoProductLandingPagesTest` / `OrganizationSchemaTest`: assert FAQ + `FAQPage` present and well-formed, `BreadcrumbList` present, and that the sitemap/robots contain every registered landing.
+
+No user-facing behavior changes beyond added on-page FAQ content; no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+- `seo-structured-data`: Page-level structured data for the SEO landing pages (FAQ section + `FAQPage` JSON-LD, `BreadcrumbList` JSON-LD, opt-in `structured_data` block) and a single-source-of-truth landing registry that drives `sitemap.xml` and `robots.txt` with `lastmod`/`changefreq`/`priority` hints.
+
+### Modified Capabilities
+<!-- None: the existing `landing-page` spec covers the root `/` page and its structure; this change adds a separate SEO-metadata capability layered over the marketing landings and does not alter root-page requirements. -->
+
+## Impact
+
+- **Templates**: `survey/templates/base_landing.html` (new `structured_data` block, FAQ include hook); new partials `survey/templates/partials/_faq_section.html` and `partials/_landing_structured_data.html`; the 12 landing templates opt in by supplying a Q&A list.
+- **Views / Python**: `survey/views.py` (`robots_txt`, `sitemap_xml` refactored to consume a shared landing registry; new registry module e.g. `survey/seo_landings.py`).
+- **Tests**: `survey/tests.py` (new test class for structured data + sitemap coverage).
+- **No** model/migration/DB impact; **no** new dependencies.

--- a/openspec/changes/landing-seo-structured-data/specs/seo-structured-data/spec.md
+++ b/openspec/changes/landing-seo-structured-data/specs/seo-structured-data/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: FAQ section on SEO landing pages
+Each SEO landing page SHALL render a visible FAQ section built from a per-page, ordered list of 3–5 question/answer pairs. Questions SHALL be specific to that page's intent; competitor-comparison pages (`alternatives/*`) SHALL include comparison-specific questions.
+
+#### Scenario: FAQ section rendered on a landing page
+- **WHEN** an anonymous visitor loads any SEO landing page (e.g. `/civic-engagement/`)
+- **THEN** the HTML SHALL contain an FAQ section with each question text and its answer text visible
+
+#### Scenario: Page-specific questions
+- **WHEN** two different landing pages are compared (e.g. `/participatory-budgeting/` and `/alternatives/maptionnaire/`)
+- **THEN** their FAQ question sets SHALL NOT be identical
+
+#### Scenario: FAQ is optional per page
+- **WHEN** a template extends `base_landing.html` without providing an FAQ list
+- **THEN** the page SHALL render with no FAQ section and no `FAQPage` JSON-LD, and SHALL NOT error
+
+### Requirement: FAQPage structured data
+Each SEO landing page that renders an FAQ section SHALL emit one `FAQPage` JSON-LD script whose questions and answers are derived from the same per-page list used for the visible FAQ, so the two cannot drift.
+
+#### Scenario: FAQPage JSON-LD present and valid
+- **WHEN** a landing page with an FAQ is loaded
+- **THEN** the HTML SHALL contain a `<script type="application/ld+json">` with `"@type": "FAQPage"`
+- **AND** the script content SHALL parse as valid JSON
+- **AND** each `mainEntity` question `name` SHALL match a question shown in the visible FAQ section
+
+#### Scenario: Answer text is JSON-safe
+- **WHEN** an FAQ answer contains quotes or apostrophes
+- **THEN** the emitted `FAQPage` JSON-LD SHALL still parse as valid JSON
+
+### Requirement: BreadcrumbList structured data
+Each SEO landing page SHALL emit a `BreadcrumbList` JSON-LD describing its position in the site hierarchy. Audience/keyword pages SHALL use `Home › <Page>`; competitor pages SHALL use `Home › Alternatives › <Page>`.
+
+#### Scenario: Breadcrumb on a single-level landing
+- **WHEN** `/for-planners/` is loaded
+- **THEN** the HTML SHALL contain a `<script type="application/ld+json">` with `"@type": "BreadcrumbList"` whose items are Home then the page, with absolute `item` URLs
+
+#### Scenario: Breadcrumb on a two-level alternatives page
+- **WHEN** `/alternatives/maptionnaire/` is loaded
+- **THEN** the `BreadcrumbList` SHALL contain three ordered items: Home, Alternatives, and the page, with `position` 1, 2, 3
+
+### Requirement: Opt-in structured-data block in base landing template
+`base_landing.html` SHALL expose a `structured_data` template block, rendered after the site-wide `SoftwareApplication` and `Organization` JSON-LD, into which landing pages inject their per-page structured data.
+
+#### Scenario: Site-wide markup preserved
+- **WHEN** any page extending `base_landing.html` is loaded
+- **THEN** the site-wide `SoftwareApplication` and `Organization` JSON-LD SHALL still be present regardless of whether the page supplies per-page structured data
+
+### Requirement: Single source of truth for SEO landing URLs
+The system SHALL define the set of SEO landing paths (with `changefreq`, `priority`, and `lastmod`) in one registry. `robots.txt` and `sitemap.xml` SHALL both derive their SEO-landing entries from that registry.
+
+#### Scenario: Sitemap lists every registered landing
+- **WHEN** `/sitemap.xml` is requested
+- **THEN** for every path in the registry there SHALL be a matching `<url><loc>` entry
+- **AND** each landing entry SHALL include `<lastmod>`, `<changefreq>`, and `<priority>`
+
+#### Scenario: Robots allows every registered landing
+- **WHEN** `/robots.txt` is requested
+- **THEN** every registry path SHALL be covered by an `Allow:` rule
+
+#### Scenario: Registry and routes stay in sync
+- **WHEN** the test suite runs
+- **THEN** every registered landing path SHALL resolve to a view
+- **AND** every SEO landing route SHALL be present in the registry

--- a/openspec/changes/landing-seo-structured-data/tasks.md
+++ b/openspec/changes/landing-seo-structured-data/tasks.md
@@ -1,0 +1,35 @@
+## 1. Landing registry + builders (`survey/seo_landings.py`)
+
+- [x] 1.1 Create `survey/seo_landings.py` with a `SeoLanding` dataclass (`key`, `path`, `url_name`, `changefreq`, `priority`, `lastmod`, `breadcrumbs`, `faq`) and an ordered `SEO_LANDINGS` registry covering all 12 pages (audience: planners/researchers/government/educators/consultants; keyword: community-engagement-platform, public-consultation-software, civic-engagement, participatory-budgeting; alternatives: maptionnaire, social-pinpoint, metroquest).
+- [x] 1.2 Author 3–5 page-specific Q&A per entry (long-tail intent: free / self-host / respondent account / data export / GDPR; comparison specifics for `alternatives/*`). Ensure question sets differ across pages.
+- [x] 1.3 Set `breadcrumbs` per entry — `Home › <Page>` for audience/keyword pages, `Home › Alternatives › <Page>` for `alternatives/*`.
+- [x] 1.4 Implement `build_faqpage_jsonld(faq)` and `build_breadcrumb_jsonld(request, crumbs)` returning `json.dumps` strings (valid JSON, absolute URLs from `request`).
+- [x] 1.5 Implement `render_seo_landing(request, key)` that looks up the entry, calls `capture_signup_source(request)`, and renders the page template with `faq_items`, `faqpage_jsonld`, `breadcrumb_jsonld` in context.
+
+## 2. Templates: block + partials
+
+- [x] 2.1 Add `{% block structured_data %}{% endblock %}` to `base_landing.html` immediately after the site-wide `SoftwareApplication` + `Organization` JSON-LD.
+- [x] 2.2 Create `survey/templates/partials/_faq_section.html` rendering a visible FAQ `<section>` from `faq_items` (accessible markup; render nothing if `faq_items` is empty).
+- [x] 2.3 Create `survey/templates/partials/_landing_structured_data.html` emitting the `FAQPage` and `BreadcrumbList` `<script type="application/ld+json">` from `faqpage_jsonld` / `breadcrumb_jsonld` (guard each so a page without FAQ omits `FAQPage` cleanly).
+- [x] 2.4 In each of the 12 landing templates, override `{% block structured_data %}` to `{% include "partials/_landing_structured_data.html" %}` and place `{% include "partials/_faq_section.html" %}` near the closing CTA.
+
+## 3. Wire views to the registry
+
+- [x] 3.1 Refactor the 12 landing view functions in `survey/views.py` to `return render_seo_landing(request, '<key>')`, removing per-view duplication while preserving existing docstrings/UTM behavior.
+
+## 4. Sitemap + robots single source of truth
+
+- [x] 4.1 Refactor `robots_txt` to build its SEO-landing `Allow:` lines from `SEO_LANDINGS` (keep the static `/surveys/`, `/stories/`, admin/editor disallows and the `Sitemap:` line).
+- [x] 4.2 Refactor `sitemap_xml` to emit each registry entry as `<url>` with `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` (keep root, `/trust/`, `/surveys/`, and per-survey entries).
+
+## 5. Tests (`survey/tests.py`)
+
+- [x] 5.1 `LandingStructuredDataTest`: for each landing, assert the FAQ section renders (a known question appears) and a `FAQPage` `<script>` is present, parses as valid JSON, and its question names match the visible FAQ.
+- [x] 5.2 Assert `BreadcrumbList` present and valid: 2 items for a single-level page, 3 ordered items (Home/Alternatives/page) for an `alternatives/*` page.
+- [x] 5.3 Assert site-wide `SoftwareApplication` + `Organization` JSON-LD still present on landings (no regression).
+- [x] 5.4 Assert FAQ question sets are not identical across two sample pages (page-specificity), and that an answer containing an apostrophe still yields valid `FAQPage` JSON.
+- [x] 5.5 `SeoLandingRegistryTest`: sitemap contains every registry path with lastmod/changefreq/priority; robots allows every registry path; every registry `url_name` resolves and every SEO landing route is represented in the registry.
+
+## 6. Verify
+
+- [x] 6.1 Run `./run_tests.sh survey` (PostGIS up); fix failures. Spot-check one page's JSON-LD against Google Rich Results Test expectations (valid FAQPage + BreadcrumbList).

--- a/openspec/changes/public-stories-index/.openspec.yaml
+++ b/openspec/changes/public-stories-index/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/public-stories-index/design.md
+++ b/openspec/changes/public-stories-index/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`Story` (`survey/models.py`) has `title`, `slug`, `body`, `cover_image`, `story_type` (map/open-data/results/article), optional `survey` FK, `is_published`, `published_date`. `story_detail` renders published stories at `stories/<slug>/`; the root view passes a `stories` queryset to `landing.html` but the current marketing `landing.html` no longer renders a stories section (pre-existing drift, out of scope). `base_landing.html` already provides `structured_data`, `canonical_url`, `meta_description` blocks (from the landing-seo-structured-data change) and a `build_breadcrumb_jsonld` helper in `survey/seo_landings.py`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A crawlable `/stories/` hub that lists published stories and links to each.
+- Reuse the existing breadcrumb helper and `structured_data` block for consistency with the SEO landings.
+- Make detail pages self-canonical and breadcrumbed; add hub + published stories to the sitemap.
+
+**Non-Goals:**
+- No editing UI (stories are managed in Django admin, unchanged).
+- No re-adding a stories section to the marketing homepage (separate concern).
+- No pagination (story volume is low; revisit if it grows).
+- No new model fields, no migration.
+
+## Decisions
+
+**D1 — Reuse `seo_landings.build_breadcrumb_jsonld`.** Rather than a second breadcrumb builder, import the existing helper and pass `Crumb` lists. The hub uses `[Home, Stories]`; a detail page uses `[Home, Stories, <title>]`. Keeps one JSON-LD code path and one escaping guarantee.
+
+**D2 — `CollectionPage` + `ItemList` for the hub.** Emit a `CollectionPage` JSON-LD whose `mainEntity` is an `ItemList` of the listed stories (position + url + name). This is the schema.org-correct shape for a listing page and mirrors the FAQPage/Breadcrumb approach: built in Python via `json.dumps`, passed to the template as a safe string. Add a small `build_story_collection_jsonld(request, stories)` helper next to the others in `seo_landings.py` (it is SEO structured-data, same module).
+
+**D3 — Story card as a partial.** `partials/_story_card.html` renders one card (cover image or a typed placeholder, title, `story_type` badge, date, link to detail). The index loops it. A card links to `stories/<slug>/`.
+
+**D4 — Sitemap: hub is static, stories are queried.** In `sitemap_xml`, add one `/stories/` entry and loop `Story.objects.filter(is_published=True)` emitting `stories/<slug>/` with `lastmod` from `published_date` when present. Story detail is not in the SEO-landing registry (different content type), so it is added directly in the view — consistent with how per-survey URLs are already appended there.
+
+**D5 — Detail-page SEO via context, not template literals.** `story_detail` computes `canonical`, `meta_description` (first ~155 chars of `body`, tags stripped, or the title as fallback), and `breadcrumb_jsonld`, passing them to the template which fills the base blocks. Keeps escaping/JSON in Python.
+
+**D6 — Empty state.** When no stories are published, `/stories/` still returns 200 with a short "no stories yet" message and a CTA back to the product — a valid hub page beats a 404 the robots file points at. The hub stays in the sitemap regardless; individual story URLs only appear when published.
+
+## Risks / Trade-offs
+
+- **[Thin/empty hub looks low-value to crawlers]** → acceptable: the page is a legitimate hub, and it only lists real content; if it stays empty long-term that is a content problem, not a code one. Documented in the outreach checklist.
+- **[Duplicate content between story body and meta_description]** → description is a truncated plain-text excerpt, standard practice; canonical points to self.
+- **[`body` may contain HTML]** → meta_description strips tags (`django.utils.html.strip_tags`) before truncation; detail body already renders with `|safe` as today (unchanged).
+- **[Breadcrumb name for long titles]** → schema allows full title; no truncation needed in JSON-LD (only the visible `<meta>` description is truncated).
+
+## Migration Plan
+
+Additive, no DB. Deploy = view/template/CSS; run `collectstatic`. Rollback = revert commit. After deploy, resubmit the sitemap in Search Console so the new hub + story URLs are discovered (manual, tracked in the outreach checklist).
+
+## Open Questions
+
+- None blocking. Pre-existing drift (landing.html no longer shows a stories section though the public-stories spec still requires it) is noted but left for a separate cleanup.

--- a/openspec/changes/public-stories-index/proposal.md
+++ b/openspec/changes/public-stories-index/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`robots.txt` allows `/stories/` and the sitemap work assumes a stories hub, but no index page exists — only `stories/<slug>/` detail pages. `/stories/` currently 404s, so the allow-rule points at nothing, individual stories are undiscoverable (no internal link path, not in the sitemap), and the "public results showcase gallery + SEO" growth item (organic acquisition via indexable results/story pages) has no landing surface. This change adds the missing hub and makes stories crawlable.
+
+## What Changes
+
+- Add a **stories index** at `/stories/` (`stories_index` view + template) listing all published stories as a card grid, newest first, with a tasteful empty state.
+- Add a reusable **story-card partial** and card CSS, so the index and any future placement share one card.
+- **SEO for the hub**: per-page `title`/`meta_description`/`canonical`, a `BreadcrumbList` (`Home › Stories`), and a `CollectionPage`/`ItemList` JSON-LD of the listed stories.
+- **SEO for detail pages**: give `story_detail.html` a `canonical`, a `meta_description` (derived from the story), and a `BreadcrumbList` (`Home › Stories › <title>`) — currently it has none.
+- **Discoverability**: include `/stories/` and every published story URL in `sitemap.xml`; add a "Stories" link to the landing footer.
+- Add tests: index renders published (not draft) stories, empty state, `/stories/` returns 200, breadcrumb/collection JSON-LD valid, sitemap contains the hub and published stories, detail-page canonical/breadcrumb present.
+
+No model or migration changes; no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+<!-- None new; this extends the existing public-stories capability. -->
+
+### Modified Capabilities
+- `public-stories`: ADD a stories index page at `/stories/`, story-detail SEO metadata (canonical, meta description, breadcrumb), and sitemap inclusion of the hub and published story pages. Existing story model / detail-view / admin requirements are unchanged.
+
+## Impact
+
+- **Views / Python**: `survey/views.py` — new `stories_index`; `sitemap_xml` gains `/stories/` + published story URLs; `story_detail` context gains SEO fields (canonical/description/breadcrumb).
+- **URLs**: `survey/urls.py` — new `path('stories/', ...)` (the `stories/<slug>/` route is unaffected; `stories/` cannot match a slug route).
+- **Templates**: new `survey/templates/stories_index.html` + `partials/_story_card.html`; `story_detail.html` gains SEO blocks + breadcrumb; `base_landing.html` footer gains a Stories link.
+- **CSS**: `survey/assets/css/landing.css` — `.story-card` grid styles (run `collectstatic`).
+- **Tests**: `survey/tests.py` — new index/SEO test class.
+- **No** model/migration/DB impact; **no** new dependencies.

--- a/openspec/changes/public-stories-index/specs/public-stories/spec.md
+++ b/openspec/changes/public-stories-index/specs/public-stories/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Stories index page
+The system SHALL serve a public stories index at `/stories/` that lists all published stories as a card grid, ordered by `published_date` descending (unpublished stories excluded). The page SHALL return HTTP 200 even when no stories are published.
+
+#### Scenario: Index lists published stories
+- **WHEN** an anonymous visitor requests `/stories/` and published stories exist
+- **THEN** the response status SHALL be 200
+- **AND** each published story's title SHALL appear with a link to its `stories/<slug>/` detail page
+
+#### Scenario: Draft stories excluded
+- **WHEN** `/stories/` is requested and a story has `is_published=False`
+- **THEN** that story's title and slug SHALL NOT appear in the response
+
+#### Scenario: Empty state
+- **WHEN** `/stories/` is requested and no stories are published
+- **THEN** the response status SHALL be 200
+- **AND** the page SHALL show an empty-state message rather than an error
+
+### Requirement: Stories index structured data
+The stories index SHALL emit a `BreadcrumbList` JSON-LD (`Home › Stories`) and a `CollectionPage` JSON-LD whose `mainEntity` is an `ItemList` of the listed stories.
+
+#### Scenario: Breadcrumb and collection present and valid
+- **WHEN** `/stories/` is requested with at least one published story
+- **THEN** the HTML SHALL contain a `<script type="application/ld+json">` with `"@type": "BreadcrumbList"` (Home then Stories)
+- **AND** a `<script type="application/ld+json">` with `"@type": "CollectionPage"` whose `ItemList` has one entry per listed story
+- **AND** every JSON-LD script SHALL parse as valid JSON
+
+### Requirement: Story detail SEO metadata
+Each published story detail page SHALL provide a self-referencing `canonical` URL, a `meta_description` derived from the story, and a `BreadcrumbList` JSON-LD (`Home › Stories › <title>`).
+
+#### Scenario: Detail page canonical and breadcrumb
+- **WHEN** a published story at `stories/<slug>/` is requested
+- **THEN** the HTML SHALL contain a `<link rel="canonical">` whose href ends with `/stories/<slug>/`
+- **AND** a `BreadcrumbList` JSON-LD with three ordered items: Home, Stories, and the story title
+- **AND** a non-empty `<meta name="description">`
+
+### Requirement: Stories in sitemap
+`sitemap.xml` SHALL include the `/stories/` hub and one entry per published story. Unpublished stories SHALL NOT appear.
+
+#### Scenario: Hub and published stories listed
+- **WHEN** `/sitemap.xml` is requested and a published story exists
+- **THEN** the sitemap SHALL contain a `<loc>` for `/stories/`
+- **AND** a `<loc>` for that story's `stories/<slug>/` URL
+
+#### Scenario: Draft story not in sitemap
+- **WHEN** `/sitemap.xml` is requested and a story is unpublished
+- **THEN** the sitemap SHALL NOT contain that story's `stories/<slug>/` URL
+
+### Requirement: Stories link in landing footer
+The landing footer SHALL link to the stories index at `/stories/`.
+
+#### Scenario: Footer links to stories
+- **WHEN** any page extending `base_landing.html` is rendered
+- **THEN** the footer SHALL contain a link with href `/stories/`

--- a/openspec/changes/public-stories-index/tasks.md
+++ b/openspec/changes/public-stories-index/tasks.md
@@ -1,0 +1,35 @@
+## 1. Structured-data helper
+
+- [x] 1.1 Add `build_story_collection_jsonld(request, stories)` to `survey/seo_landings.py` returning a `CollectionPage` with an `ItemList` `mainEntity` (position/url/name per story), as a `json.dumps` string. Reuse `build_breadcrumb_jsonld` for breadcrumbs.
+
+## 2. Stories index view + template
+
+- [x] 2.1 Add `stories_index(request)` view in `survey/views.py`: query `Story.objects.filter(is_published=True).order_by('-published_date')`, build breadcrumb (`Home › Stories`) + collection JSON-LD, render `stories_index.html`.
+- [x] 2.2 Add `path('stories/', views.stories_index, name='stories_index')` to `survey/urls.py` (above or below the `stories/<slug>/` route — both resolve unambiguously).
+- [x] 2.3 Create `survey/templates/partials/_story_card.html` — one card (cover image or typed placeholder, `story_type` badge, title, date, link to `stories/<slug>/`).
+- [x] 2.4 Create `survey/templates/stories_index.html` extending `base_landing.html`: SEO blocks (`title`, `meta_description`, `canonical_url`, `og_url`), `structured_data` block including breadcrumb + collection JSON-LD, a card grid looping `_story_card.html`, and an empty state.
+
+## 3. Story detail SEO
+
+- [x] 3.1 In `story_detail`, compute `canonical`, `meta_description` (`strip_tags(body)` truncated ~155 chars, title fallback), and breadcrumb JSON-LD (`Home › Stories › <title>`); pass to context.
+- [x] 3.2 Update `story_detail.html` to fill `meta_description`/`canonical_url`/`og_url` blocks and add the `structured_data` block with the breadcrumb.
+
+## 4. Sitemap + footer
+
+- [x] 4.1 In `sitemap_xml`, append a `/stories/` entry and loop published stories emitting `stories/<slug>/` with `<lastmod>` from `published_date` when set.
+- [x] 4.2 Add a "Stories" link (`href="/stories/"`) to the `base_landing.html` footer (Product column).
+
+## 5. CSS
+
+- [x] 5.1 Add `.story-card` grid + card styles to `survey/assets/css/landing.css` (reuse existing tokens; typed-placeholder for cards without a cover image); run `collectstatic`.
+
+## 6. Tests (`survey/tests.py`)
+
+- [x] 6.1 `StoriesIndexViewTest`: `/stories/` returns 200 and lists published (not draft) stories with detail links; empty state returns 200.
+- [x] 6.2 Assert index `BreadcrumbList` + `CollectionPage`/`ItemList` JSON-LD present, valid, and item count matches published stories.
+- [x] 6.3 Assert detail page has self-canonical, non-empty meta description, and a 3-item `Home › Stories › <title>` breadcrumb.
+- [x] 6.4 Assert sitemap contains `/stories/` and a published story URL, and excludes a draft story's URL; footer on a landing links to `/stories/`.
+
+## 7. Verify
+
+- [x] 7.1 Run `./run_tests.sh survey`; fix failures. Spot-check `/stories/` JSON-LD validity.

--- a/survey/assets/css/landing.css
+++ b/survey/assets/css/landing.css
@@ -1545,3 +1545,71 @@ a:hover { color: var(--color-accent-hover); }
     padding: 0 0 1.2rem;
     max-width: 68ch;
 }
+
+/* ── Stories index (public showcase) ───────────────────────────────────── */
+.hero--compact { padding-bottom: 1.5rem; }
+.story-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+.story-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+.story-card:hover { border-color: var(--color-accent); transform: translateY(-2px); }
+.story-card__media {
+    aspect-ratio: 16 / 9;
+    background: var(--color-bg-warm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+.story-card__media img { width: 100%; height: 100%; object-fit: cover; }
+.story-card__media--map { background: var(--color-map-bg); }
+.story-card__media--results { background: var(--color-accent-light); }
+.story-card__placeholder {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-tertiary);
+}
+.story-card__body { padding: 1.1rem 1.25rem 1.35rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.story-card__badge {
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    background: var(--color-accent-light);
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
+}
+.story-card__title {
+    font-family: var(--font-display);
+    font-size: 1.08rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+    line-height: 1.35;
+}
+.story-card__date { font-size: 0.82rem; color: var(--color-text-tertiary); }
+.story-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--color-text-secondary);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+}

--- a/survey/assets/css/landing.css
+++ b/survey/assets/css/landing.css
@@ -1497,3 +1497,51 @@ a:hover { color: var(--color-accent-hover); }
     .showcase-row--reverse .showcase-row__media { order: 0; }
     .showcase-row__text p { max-width: none; }
 }
+
+/* ── FAQ section (SEO landings) ─────────────────────────────────────────── */
+.faq-list {
+    max-width: 780px;
+    margin: 2rem auto 0;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.faq-item {
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    padding: 0 1.25rem;
+    transition: border-color var(--transition-fast);
+}
+.faq-item[open] { border-color: var(--color-accent); }
+.faq-item__q {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 1.02rem;
+    color: var(--color-text);
+    cursor: pointer;
+    list-style: none;
+    padding: 1.1rem 2rem 1.1rem 0;
+    position: relative;
+}
+.faq-item__q::-webkit-details-marker { display: none; }
+.faq-item__q::after {
+    content: "+";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 1.4rem;
+    line-height: 1;
+    color: var(--color-accent);
+    transition: transform var(--transition-fast);
+}
+.faq-item[open] .faq-item__q::after { content: "\2013"; }
+.faq-item__a {
+    color: var(--color-text-secondary);
+    font-size: 0.97rem;
+    line-height: 1.6;
+    padding: 0 0 1.2rem;
+    max-width: 68ch;
+}

--- a/survey/seo_landings.py
+++ b/survey/seo_landings.py
@@ -333,6 +333,33 @@ def build_breadcrumb_jsonld(crumbs) -> str:
     return json.dumps(data, ensure_ascii=False)
 
 
+def build_story_collection_jsonld(request, stories) -> str:
+    """Return a ``CollectionPage`` JSON-LD for the stories index.
+
+    ``stories`` is an iterable of Story instances; each becomes an ``ItemList``
+    entry with an absolute detail URL. Built with ``json.dumps`` for safe escaping.
+    """
+    data = {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "Mapsurvey Stories",
+        "url": _abs("/stories/"),
+        "mainEntity": {
+            "@type": "ItemList",
+            "itemListElement": [
+                {
+                    "@type": "ListItem",
+                    "position": i + 1,
+                    "url": _abs(f"/stories/{story.slug}/"),
+                    "name": story.title,
+                }
+                for i, story in enumerate(stories)
+            ],
+        },
+    }
+    return json.dumps(data, ensure_ascii=False)
+
+
 def render_seo_landing(request, key: str):
     """Render an SEO landing, injecting its FAQ + structured data from the registry."""
     from .events import capture_signup_source  # local import: events is import-light

--- a/survey/seo_landings.py
+++ b/survey/seo_landings.py
@@ -1,0 +1,347 @@
+"""Single source of truth for the SEO landing pages.
+
+Each :class:`SeoLanding` entry owns everything a marketing landing needs beyond
+its template body: the public path, its sitemap crawl hints, its breadcrumb
+trail, and its FAQ. The FAQ drives *both* the visible FAQ section and the
+``FAQPage`` JSON-LD, so the two can't drift.
+
+``robots.txt`` and ``sitemap.xml`` derive their landing entries from
+``SEO_LANDINGS``, so a page can't have a route yet silently miss the sitemap,
+the robots allow-list, or its structured data.
+
+Landings are English-only today (the RU switcher is disabled until translations
+land — see ``base_landing.html``), so copy here is plain English rather than
+``gettext``-wrapped.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from django.shortcuts import render
+
+# Canonical production origin — matches the hardcoded canonical/og URLs in
+# base_landing.html so breadcrumb `item` URLs are the indexable absolute URLs
+# (and deterministic in tests, independent of the request host).
+SITE_ORIGIN = "https://mapsurvey.org"
+
+# Ship date of the current content wave. Bump an entry's ``lastmod`` when its
+# content materially changes. Do NOT use "now": an always-fresh lastmod trains
+# crawlers to distrust it.
+LASTMOD_DEFAULT = "2026-07-21"
+
+
+@dataclass(frozen=True)
+class Crumb:
+    name: str
+    path: str  # absolute path, e.g. "/" or "/alternatives/"
+
+
+@dataclass(frozen=True)
+class QA:
+    q: str
+    a: str
+
+
+@dataclass(frozen=True)
+class SeoLanding:
+    key: str
+    path: str
+    url_name: str
+    template: str
+    breadcrumbs: tuple  # tuple[Crumb, ...]
+    faq: tuple          # tuple[QA, ...]
+    changefreq: str = "monthly"
+    priority: str = "0.8"
+    lastmod: str = LASTMOD_DEFAULT
+
+
+HOME = Crumb("Home", "/")
+ALTERNATIVES = Crumb("Alternatives", "/alternatives/")
+
+# ---------------------------------------------------------------------------
+# Reusable answers (universal product facts shared across several pages). Keep
+# each page's *set* of questions distinct, but factual answers can be shared.
+# ---------------------------------------------------------------------------
+_A_FREE = (
+    "Yes. Mapsurvey is open source (AGPLv3) and free to start — you can create "
+    "and publish a map-based survey without paying, and self-host the whole "
+    "platform at no licence cost."
+)
+_A_SELFHOST = (
+    "Yes. Mapsurvey ships as a Docker stack you can run on your own "
+    "infrastructure, so response data stays on servers you control — useful for "
+    "GDPR and data-residency requirements."
+)
+_A_ACCOUNT = (
+    "No. Respondents open a public link and answer on the map — no sign-up or "
+    "login required. Only survey creators need an account."
+)
+_A_EXPORT = (
+    "Every response — including map geometry — exports as GeoJSON plus a CSV for "
+    "non-spatial answers, so results drop straight into QGIS, ArcGIS, or a "
+    "spreadsheet. You own the data."
+)
+_A_GEO = (
+    "Respondents can drop points, draw lines (routes), and outline polygons "
+    "(areas) directly on the map, alongside ordinary survey questions."
+)
+
+
+SEO_LANDINGS = (
+    SeoLanding(
+        key="for_planners",
+        path="/for-planners/",
+        url_name="for_planners",
+        template="for_planners.html",
+        breadcrumbs=(HOME, Crumb("For Urban Planners", "/for-planners/")),
+        faq=(
+            QA("Is Mapsurvey free for urban-planning teams?", _A_FREE),
+            QA("What can residents mark on the map?", _A_GEO),
+            QA("Can I export results into QGIS or ArcGIS?", _A_EXPORT),
+            QA("Do residents need to create an account to take part?", _A_ACCOUNT),
+            QA("Can we self-host it for data control?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="for_researchers",
+        path="/for-researchers/",
+        url_name="for_researchers",
+        template="for_researchers.html",
+        breadcrumbs=(HOME, Crumb("For Researchers", "/for-researchers/")),
+        faq=(
+            QA("Is Mapsurvey suitable for PPGIS and participatory research?",
+               "Yes — it is built for public-participation GIS: point, line, and "
+               "polygon input captured against your own questions, exported as "
+               "analysis-ready GeoJSON/CSV."),
+            QA("How do I get the raw spatial data for analysis?", _A_EXPORT),
+            QA("Do participants need an account?", _A_ACCOUNT),
+            QA("Can I self-host for ethics/data-governance requirements?", _A_SELFHOST),
+            QA("Is it really free to start?", _A_FREE),
+        ),
+    ),
+    SeoLanding(
+        key="for_government",
+        path="/for-government/",
+        url_name="for_government",
+        template="for_government.html",
+        breadcrumbs=(HOME, Crumb("For Local Government", "/for-government/")),
+        faq=(
+            QA("Is this a free community-engagement platform for local government?", _A_FREE),
+            QA("Can we host it on our own infrastructure?", _A_SELFHOST),
+            QA("Do residents need to register to respond?", _A_ACCOUNT),
+            QA("What map input can residents give?", _A_GEO),
+            QA("Can we export results for our GIS team?", _A_EXPORT),
+        ),
+    ),
+    SeoLanding(
+        key="for_educators",
+        path="/for-educators/",
+        url_name="for_educators",
+        template="for_educators.html",
+        breadcrumbs=(HOME, Crumb("For Educators", "/for-educators/")),
+        faq=(
+            QA("Is Mapsurvey free to use in the classroom?", _A_FREE),
+            QA("Do students need to install anything?",
+               "No. Students open a link in the browser and mark the map — no "
+               "install, and no account needed to respond."),
+            QA("Can students export the data for coursework?", _A_EXPORT),
+            QA("What kinds of map questions can students build?", _A_GEO),
+            QA("Can the university self-host it?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="for_consultants",
+        path="/for-consultants/",
+        url_name="for_consultants",
+        template="for_consultants.html",
+        breadcrumbs=(HOME, Crumb("For Consultants", "/for-consultants/")),
+        faq=(
+            QA("Are there per-project or per-survey fees?",
+               "No. The open-source path has no per-project or per-survey "
+               "licence fees — run as many engagements as you like and self-host "
+               "if you want full control."),
+            QA("Can I hand clients GIS-ready deliverables?", _A_EXPORT),
+            QA("Do respondents need accounts?", _A_ACCOUNT),
+            QA("Can I self-host for client data separation?", _A_SELFHOST),
+            QA("Is it free to start?", _A_FREE),
+        ),
+    ),
+    SeoLanding(
+        key="community_engagement_platform",
+        path="/community-engagement-platform/",
+        url_name="community_engagement_platform",
+        template="community_engagement_platform.html",
+        breadcrumbs=(HOME, Crumb("Community Engagement Platform", "/community-engagement-platform/")),
+        faq=(
+            QA("Is Mapsurvey a free, open-source community-engagement platform?", _A_FREE),
+            QA("Can we self-host it?", _A_SELFHOST),
+            QA("What map input can the community give?", _A_GEO),
+            QA("Do community members need an account to take part?", _A_ACCOUNT),
+            QA("Do we own the data we collect?", _A_EXPORT),
+        ),
+    ),
+    SeoLanding(
+        key="public_consultation_software",
+        path="/public-consultation-software/",
+        url_name="public_consultation_software",
+        template="public_consultation_software.html",
+        breadcrumbs=(HOME, Crumb("Public Consultation Software", "/public-consultation-software/")),
+        faq=(
+            QA("Is this free public-consultation software?", _A_FREE),
+            QA("Can residents comment on specific locations?", _A_GEO),
+            QA("Do respondents need to sign up to give feedback?", _A_ACCOUNT),
+            QA("Can we export consultation responses for the record?", _A_EXPORT),
+            QA("Can it be self-hosted for public-sector data rules?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="civic_engagement",
+        path="/civic-engagement/",
+        url_name="civic_engagement",
+        template="civic_engagement.html",
+        breadcrumbs=(HOME, Crumb("Civic Engagement", "/civic-engagement/")),
+        faq=(
+            QA("What is map-based civic engagement?",
+               "It lets residents show exactly where something matters — pinning "
+               "places, drawing routes, outlining areas — instead of leaving vague "
+               "free-text comments, giving officials location-specific evidence."),
+            QA("Is Mapsurvey free for civic-engagement projects?", _A_FREE),
+            QA("Do participants need an account?", _A_ACCOUNT),
+            QA("Can we export the results?", _A_EXPORT),
+            QA("Can we self-host it?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="participatory_budgeting",
+        path="/participatory-budgeting/",
+        url_name="participatory_budgeting",
+        template="participatory_budgeting.html",
+        breadcrumbs=(HOME, Crumb("Participatory Budgeting", "/participatory-budgeting/")),
+        faq=(
+            QA("Can Mapsurvey run the spatial side of participatory budgeting?",
+               "Yes — residents pin exactly where investment is needed "
+               "(playgrounds, crossings, lighting, greening). It captures the "
+               "location input for a PB programme; it is not a budget-allocation "
+               "or voting-ledger module."),
+            QA("Is it free to start?", _A_FREE),
+            QA("Do residents need an account to submit a location?", _A_ACCOUNT),
+            QA("Can we export the pinned proposals for scoring?", _A_EXPORT),
+            QA("Can we self-host it?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="maptionnaire_alternative",
+        path="/alternatives/maptionnaire/",
+        url_name="maptionnaire_alternative",
+        template="maptionnaire_alternative.html",
+        breadcrumbs=(HOME, ALTERNATIVES, Crumb("Maptionnaire Alternative", "/alternatives/maptionnaire/")),
+        faq=(
+            QA("Is Mapsurvey a free alternative to Maptionnaire?",
+               "Yes — Mapsurvey is a free, open-source alternative for map-based "
+               "surveys, with no per-survey fee and no free-tier gate on the "
+               "open-source path."),
+            QA("Does it support the same point, line, and polygon input?", _A_GEO),
+            QA("Can I export to GeoJSON like a GIS-first tool?", _A_EXPORT),
+            QA("Can I self-host or keep data in the EU?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="social_pinpoint_alternative",
+        path="/alternatives/social-pinpoint/",
+        url_name="social_pinpoint_alternative",
+        template="social_pinpoint_alternative.html",
+        breadcrumbs=(HOME, ALTERNATIVES, Crumb("Social Pinpoint Alternative", "/alternatives/social-pinpoint/")),
+        faq=(
+            QA("Is Mapsurvey an open-source alternative to Social Pinpoint?",
+               "Yes — it is an open-source, self-hostable alternative for "
+               "map-based engagement, with no per-project licence on the "
+               "open-source path."),
+            QA("Can respondents draw, not just drop markers?",
+               "Yes — respondents can drop points and also draw lines (routes) "
+               "and polygons (areas), then you export the geometry."),
+            QA("Can I export the raw spatial data?", _A_EXPORT),
+            QA("Can I self-host it?", _A_SELFHOST),
+        ),
+    ),
+    SeoLanding(
+        key="metroquest_alternative",
+        path="/alternatives/metroquest/",
+        url_name="metroquest_alternative",
+        template="metroquest_alternative.html",
+        breadcrumbs=(HOME, ALTERNATIVES, Crumb("MetroQuest Alternative", "/alternatives/metroquest/")),
+        faq=(
+            QA("Why look for a MetroQuest alternative?",
+               "MetroQuest has been folded into the Open Point suite. Mapsurvey "
+               "is a free, open-source option for map-based public input you can "
+               "self-host and fully export."),
+            QA("Does Mapsurvey support drawing on the map, not just markers?",
+               "Yes — points, lines, and polygons, alongside standard survey "
+               "questions."),
+            QA("Can I export the results?", _A_EXPORT),
+            QA("Is it free and self-hostable?", _A_SELFHOST),
+        ),
+    ),
+)
+
+_BY_KEY = {landing.key: landing for landing in SEO_LANDINGS}
+
+
+def get_landing(key: str) -> SeoLanding:
+    return _BY_KEY[key]
+
+
+def _abs(path: str) -> str:
+    return f"{SITE_ORIGIN}{path}"
+
+
+def build_faqpage_jsonld(faq) -> str:
+    """Return a valid ``FAQPage`` JSON-LD string built from a QA list.
+
+    Uses ``json.dumps`` so quotes/apostrophes in answers are always escaped.
+    """
+    data = {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": item.q,
+                "acceptedAnswer": {"@type": "Answer", "text": item.a},
+            }
+            for item in faq
+        ],
+    }
+    return json.dumps(data, ensure_ascii=False)
+
+
+def build_breadcrumb_jsonld(crumbs) -> str:
+    """Return a valid ``BreadcrumbList`` JSON-LD string with absolute item URLs."""
+    data = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {
+                "@type": "ListItem",
+                "position": i + 1,
+                "name": crumb.name,
+                "item": _abs(crumb.path),
+            }
+            for i, crumb in enumerate(crumbs)
+        ],
+    }
+    return json.dumps(data, ensure_ascii=False)
+
+
+def render_seo_landing(request, key: str):
+    """Render an SEO landing, injecting its FAQ + structured data from the registry."""
+    from .events import capture_signup_source  # local import: events is import-light
+
+    landing = _BY_KEY[key]
+    capture_signup_source(request)
+    context = {
+        "faq_items": landing.faq,
+        "faqpage_jsonld": build_faqpage_jsonld(landing.faq) if landing.faq else "",
+        "breadcrumb_jsonld": build_breadcrumb_jsonld(landing.breadcrumbs) if landing.breadcrumbs else "",
+    }
+    return render(request, landing.template, context)

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -153,6 +153,7 @@
                 <ul class="landing-footer__links">
                     <li><a href="/#features">{% trans "Features" %}</a></li>
                     <li><a href="/#demo">{% trans "Demo" %}</a></li>
+                    <li><a href="{% url 'stories_index' %}">{% trans "Stories" %}</a></li>
                     <li><a href="{% url 'for_planners' %}">{% trans "For Urban Planners" %}</a></li>
                     <li><a href="{% url 'for_government' %}">{% trans "For Local Government" %}</a></li>
                     <li><a href="{% url 'for_researchers' %}">{% trans "For Researchers" %}</a></li>

--- a/survey/templates/base_landing.html
+++ b/survey/templates/base_landing.html
@@ -68,6 +68,9 @@
     }
     </script>
 
+    {# Per-page structured data (FAQPage, BreadcrumbList) — opt-in via landing templates #}
+    {% block structured_data %}{% endblock %}
+
     {# Fonts #}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/survey/templates/civic_engagement.html
+++ b/survey/templates/civic_engagement.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/civic-engagement/{% endblock %}
 {% block og_url %}https://mapsurvey.org/civic-engagement/{% endblock %}
 {% block og_title %}{% trans "Civic engagement on a map — open-source tools" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -95,4 +96,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/community_engagement_platform.html
+++ b/survey/templates/community_engagement_platform.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/community-engagement-platform/{% endblock %}
 {% block og_url %}https://mapsurvey.org/community-engagement-platform/{% endblock %}
 {% block og_title %}{% trans "The open-source, map-based community engagement platform" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -95,4 +96,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/for_consultants.html
+++ b/survey/templates/for_consultants.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/for-consultants/{% endblock %}
 {% block og_url %}https://mapsurvey.org/for-consultants/{% endblock %}
 {% block og_title %}{% trans "Mapsurvey for engagement & planning consultants" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -92,4 +93,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/for_educators.html
+++ b/survey/templates/for_educators.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/for-educators/{% endblock %}
 {% block og_url %}https://mapsurvey.org/for-educators/{% endblock %}
 {% block og_title %}{% trans "Mapsurvey for Classrooms — Free Map Surveys for Student Fieldwork" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -112,4 +113,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/for_government.html
+++ b/survey/templates/for_government.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/for-government/{% endblock %}
 {% block og_url %}https://mapsurvey.org/for-government/{% endblock %}
 {% block og_title %}{% trans "The open-source community engagement platform for local government" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -90,4 +91,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/for_planners.html
+++ b/survey/templates/for_planners.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/for-planners/{% endblock %}
 {% block og_url %}https://mapsurvey.org/for-planners/{% endblock %}
 {% block og_title %}{% trans "Mapsurvey for Urban Planners — map-based public input, free" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -106,4 +107,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/for_researchers.html
+++ b/survey/templates/for_researchers.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/for-researchers/{% endblock %}
 {% block og_url %}https://mapsurvey.org/for-researchers/{% endblock %}
 {% block og_title %}{% trans "Mapsurvey for Researchers — participatory mapping & citizen science" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -87,4 +88,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/maptionnaire_alternative.html
+++ b/survey/templates/maptionnaire_alternative.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/alternatives/maptionnaire/{% endblock %}
 {% block og_url %}https://mapsurvey.org/alternatives/maptionnaire/{% endblock %}
 {% block og_title %}{% trans "A free, open-source Maptionnaire alternative — Mapsurvey" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -133,4 +134,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/metroquest_alternative.html
+++ b/survey/templates/metroquest_alternative.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/alternatives/metroquest/{% endblock %}
 {% block og_url %}https://mapsurvey.org/alternatives/metroquest/{% endblock %}
 {% block og_title %}{% trans "Looking for a MetroQuest alternative? — Mapsurvey" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -131,4 +132,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/partials/_faq_section.html
+++ b/survey/templates/partials/_faq_section.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{# Visible FAQ section for SEO landing pages. Renders nothing when no FAQ is
+   supplied. Questions/answers come from the seo_landings registry (context var
+   `faq_items`), the same source as the FAQPage JSON-LD, so they can't drift. #}
+{% if faq_items %}
+<section class="showcase showcase--center faq-section" id="faq">
+  <div class="landing-inner">
+    <p class="section-eyebrow">{% trans "FAQ" %}</p>
+    <h2 class="section-heading">{% trans "Frequently asked questions" %}</h2>
+    <div class="faq-list">
+      {% for item in faq_items %}
+      <details class="faq-item"{% if forloop.first %} open{% endif %}>
+        <summary class="faq-item__q">{{ item.q }}</summary>
+        <div class="faq-item__a">{{ item.a }}</div>
+      </details>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endif %}

--- a/survey/templates/partials/_landing_structured_data.html
+++ b/survey/templates/partials/_landing_structured_data.html
@@ -1,0 +1,9 @@
+{# Per-page structured data for SEO landings. FAQPage + BreadcrumbList are
+   pre-serialized valid JSON strings from the seo_landings registry, so they are
+   emitted with `safe` (never string-built in the template). #}
+{% if faqpage_jsonld %}
+<script type="application/ld+json">{{ faqpage_jsonld|safe }}</script>
+{% endif %}
+{% if breadcrumb_jsonld %}
+<script type="application/ld+json">{{ breadcrumb_jsonld|safe }}</script>
+{% endif %}

--- a/survey/templates/partials/_story_card.html
+++ b/survey/templates/partials/_story_card.html
@@ -1,0 +1,17 @@
+{# One story card for the stories index. Expects `story` in context. #}
+<a class="story-card" href="/stories/{{ story.slug }}/">
+  <div class="story-card__media story-card__media--{{ story.story_type }}">
+    {% if story.cover_image %}
+    <img src="{{ story.cover_image.url }}" alt="{{ story.title }}" loading="lazy">
+    {% else %}
+    <span class="story-card__placeholder">{{ story.get_story_type_display }}</span>
+    {% endif %}
+  </div>
+  <div class="story-card__body">
+    <span class="story-card__badge">{{ story.get_story_type_display }}</span>
+    <h3 class="story-card__title">{{ story.title }}</h3>
+    {% if story.published_date %}
+    <time class="story-card__date" datetime="{{ story.published_date|date:'Y-m-d' }}">{{ story.published_date|date:"j M Y" }}</time>
+    {% endif %}
+  </div>
+</a>

--- a/survey/templates/participatory_budgeting.html
+++ b/survey/templates/participatory_budgeting.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/participatory-budgeting/{% endblock %}
 {% block og_url %}https://mapsurvey.org/participatory-budgeting/{% endblock %}
 {% block og_title %}{% trans "Participatory budgeting on a map — open source" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -82,4 +83,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/public_consultation_software.html
+++ b/survey/templates/public_consultation_software.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/public-consultation-software/{% endblock %}
 {% block og_url %}https://mapsurvey.org/public-consultation-software/{% endblock %}
 {% block og_title %}{% trans "Open-source, map-based public consultation software" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -89,4 +90,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/social_pinpoint_alternative.html
+++ b/survey/templates/social_pinpoint_alternative.html
@@ -7,6 +7,7 @@
 {% block canonical_url %}https://mapsurvey.org/alternatives/social-pinpoint/{% endblock %}
 {% block og_url %}https://mapsurvey.org/alternatives/social-pinpoint/{% endblock %}
 {% block og_title %}{% trans "A free, open-source Social Pinpoint alternative — Mapsurvey" %}{% endblock %}
+{% block structured_data %}{% include "partials/_landing_structured_data.html" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -131,4 +132,7 @@
     </div>
   </div>
 </section>
+
+{% include "partials/_faq_section.html" %}
+
 {% endblock %}

--- a/survey/templates/stories_index.html
+++ b/survey/templates/stories_index.html
@@ -1,0 +1,41 @@
+{% extends "base_landing.html" %}
+{% load static i18n %}
+
+{% block title %}{% trans "Stories — participatory-mapping projects & results | Mapsurvey" %}{% endblock %}
+{% block meta_description %}{% trans "Real participatory-mapping projects built with Mapsurvey: community engagement, public consultation, and open-data stories with maps and results." %}{% endblock %}
+{% block canonical_url %}https://mapsurvey.org/stories/{% endblock %}
+{% block og_url %}https://mapsurvey.org/stories/{% endblock %}
+{% block og_title %}{% trans "Mapsurvey Stories" %}{% endblock %}
+
+{% block structured_data %}
+{% if breadcrumb_jsonld %}<script type="application/ld+json">{{ breadcrumb_jsonld|safe }}</script>{% endif %}
+{% if collection_jsonld %}<script type="application/ld+json">{{ collection_jsonld|safe }}</script>{% endif %}
+{% endblock %}
+
+{% block content %}
+<section class="hero hero--compact" id="hero">
+  <div class="hero__content">
+    <h1 class="hero__headline">{% trans "Stories" %}</h1>
+    <p class="hero__description">
+      {% trans "Participatory-mapping projects built with Mapsurvey — community engagement, public consultation, and the open data behind them." %}
+    </p>
+  </div>
+</section>
+
+<section class="showcase" id="stories">
+  <div class="landing-inner">
+    {% if stories %}
+    <div class="story-grid">
+      {% for story in stories %}
+      {% include "partials/_story_card.html" %}
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="story-empty">
+      <p>{% trans "No stories published yet — check back soon." %}</p>
+      <a href="{% url 'django_registration_register' %}" class="btn-primary-landing">{% trans "Start your own map survey" %}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/survey/templates/story_detail.html
+++ b/survey/templates/story_detail.html
@@ -1,6 +1,14 @@
 {% extends "base_landing.html" %}
 
 {% block title %}{{ story.title }} — Mapsurvey{% endblock %}
+{% block meta_description %}{{ meta_description }}{% endblock %}
+{% block canonical_url %}{{ canonical }}{% endblock %}
+{% block og_url %}{{ canonical }}{% endblock %}
+{% block og_title %}{{ story.title }}{% endblock %}
+
+{% block structured_data %}
+{% if breadcrumb_jsonld %}<script type="application/ld+json">{{ breadcrumb_jsonld|safe }}</script>{% endif %}
+{% endblock %}
 
 {% block content %}
 <article class="story-detail">

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -14070,3 +14070,96 @@ class SeoLandingRegistryTest(TestCase):
         from survey.seo_landings import SEO_LANDINGS
         for landing in SEO_LANDINGS:
             self.assertEqual(reverse(landing.url_name), landing.path)
+
+
+class StoriesIndexViewTest(TestCase):
+    """The public stories hub at /stories/: listing, empty state, SEO metadata."""
+
+    import re as _re
+    _LD_RE = _re.compile(r'<script type="application/ld\+json">(.*?)</script>', _re.S)
+
+    def _ld(self, html):
+        return [json.loads(b) for b in self._LD_RE.findall(html)]
+
+    def _story(self, title, slug, published=True):
+        from django.utils import timezone
+        return Story.objects.create(
+            title=title, slug=slug, story_type="results", body="<p>Body text about the project.</p>",
+            is_published=published, published_date=timezone.now() if published else None,
+        )
+
+    def test_index_lists_published_not_draft(self):
+        """
+        GIVEN a published and a draft story
+        WHEN /stories/ is requested
+        THEN it returns 200, lists the published story with a detail link, and hides the draft
+        """
+        self._story("Riverside Engagement", "riverside")
+        self._story("Secret Draft", "secret-draft", published=False)
+        resp = Client().get("/stories/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Riverside Engagement")
+        self.assertContains(resp, 'href="/stories/riverside/"')
+        self.assertNotContains(resp, "Secret Draft")
+
+    def test_empty_state_returns_200(self):
+        """
+        GIVEN no published stories
+        WHEN /stories/ is requested
+        THEN it returns 200 with an empty-state message (not a 404)
+        """
+        resp = Client().get("/stories/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "No stories published yet")
+
+    def test_index_structured_data(self):
+        """
+        GIVEN published stories
+        WHEN /stories/ is requested
+        THEN it emits a valid BreadcrumbList (Home > Stories) and a CollectionPage
+             whose ItemList has one entry per published story
+        """
+        self._story("Story A", "story-a")
+        self._story("Story B", "story-b")
+        blocks = self._ld(Client().get("/stories/").content.decode())
+        bc = next(b for b in blocks if b.get("@type") == "BreadcrumbList")
+        self.assertEqual([i["name"] for i in bc["itemListElement"]], ["Home", "Stories"])
+        coll = next(b for b in blocks if b.get("@type") == "CollectionPage")
+        self.assertEqual(len(coll["mainEntity"]["itemListElement"]), 2)
+
+    def test_detail_seo_metadata(self):
+        """
+        GIVEN a published story
+        WHEN its detail page is requested
+        THEN it has a self-canonical, a non-empty meta description, and a
+             3-item Home > Stories > <title> breadcrumb
+        """
+        self._story("Coastal Paths", "coastal-paths")
+        resp = Client().get("/stories/coastal-paths/")
+        html = resp.content.decode()
+        self.assertIn('<link rel="canonical" href="https://mapsurvey.org/stories/coastal-paths/">', html)
+        self.assertRegex(html, r'<meta name="description" content="[^"]+">')
+        bc = next(b for b in self._ld(html) if b.get("@type") == "BreadcrumbList")
+        self.assertEqual([i["name"] for i in bc["itemListElement"]], ["Home", "Stories", "Coastal Paths"])
+
+    def test_sitemap_includes_hub_and_published_excludes_draft(self):
+        """
+        GIVEN a published and a draft story
+        WHEN sitemap.xml is requested
+        THEN it lists /stories/ and the published story URL but not the draft's
+        """
+        self._story("Published Story", "pub-story")
+        self._story("Draft Story", "draft-story", published=False)
+        body = Client().get("/sitemap.xml").content.decode()
+        self.assertIn("/stories/</loc>", body)
+        self.assertIn("/stories/pub-story/</loc>", body)
+        self.assertNotIn("/stories/draft-story/", body)
+
+    def test_landing_footer_links_to_stories(self):
+        """
+        GIVEN the shared landing footer
+        WHEN a landing page is rendered
+        THEN the footer links to the stories hub
+        """
+        resp = Client().get("/for-planners/")
+        self.assertContains(resp, 'href="/stories/"')

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -13937,3 +13937,136 @@ class OrganizationSchemaTest(TestCase):
         self.assertEqual(org["name"], "Mapsurvey")
         self.assertTrue(any("github.com" in s for s in org["sameAs"]))
         self.assertTrue(any("participedia.net" in s for s in org["sameAs"]))
+
+
+class LandingStructuredDataTest(TestCase):
+    """Per-page structured data on the SEO landings: FAQ section + FAQPage /
+    BreadcrumbList JSON-LD driven by the seo_landings registry."""
+
+    import re as _re
+    _LD_RE = _re.compile(r'<script type="application/ld\+json">(.*?)</script>', _re.S)
+
+    def _ld_blocks(self, html):
+        """GIVEN rendered HTML WHEN scanning ld+json THEN return parsed JSON objects."""
+        return [json.loads(b) for b in self._LD_RE.findall(html)]
+
+    def test_every_landing_has_valid_faqpage_matching_visible_faq(self):
+        """
+        GIVEN each SEO landing page
+        WHEN rendered
+        THEN it emits a valid FAQPage JSON-LD whose question names each appear
+             in the visible FAQ section
+        """
+        from survey.seo_landings import SEO_LANDINGS
+        c = Client()
+        for landing in SEO_LANDINGS:
+            resp = c.get(landing.path)
+            self.assertEqual(resp.status_code, 200, landing.path)
+            html = resp.content.decode()
+            blocks = self._ld_blocks(html)  # all parse as valid JSON
+            faqpages = [b for b in blocks if b.get("@type") == "FAQPage"]
+            self.assertEqual(len(faqpages), 1, f"{landing.path}: expected one FAQPage")
+            names = {q["name"] for q in faqpages[0]["mainEntity"]}
+            self.assertEqual(names, {qa.q for qa in landing.faq}, landing.path)
+            # each question is also visible on the page
+            for qa in landing.faq:
+                self.assertIn(qa.q, html, f"{landing.path}: visible FAQ missing {qa.q!r}")
+
+    def test_breadcrumb_single_and_two_level(self):
+        """
+        GIVEN a single-level landing and a two-level alternatives landing
+        WHEN rendered
+        THEN BreadcrumbList JSON-LD has 2 vs 3 ordered items with absolute URLs
+        """
+        c = Client()
+        one = self._ld_blocks(c.get("/for-planners/").content.decode())
+        bc1 = next(b for b in one if b.get("@type") == "BreadcrumbList")
+        items1 = bc1["itemListElement"]
+        self.assertEqual([i["position"] for i in items1], [1, 2])
+        self.assertEqual(items1[0]["name"], "Home")
+        self.assertTrue(items1[-1]["item"].startswith("https://mapsurvey.org/for-planners/"))
+
+        two = self._ld_blocks(c.get("/alternatives/maptionnaire/").content.decode())
+        bc2 = next(b for b in two if b.get("@type") == "BreadcrumbList")
+        items2 = bc2["itemListElement"]
+        self.assertEqual([i["position"] for i in items2], [1, 2, 3])
+        self.assertEqual([i["name"] for i in items2], ["Home", "Alternatives", "Maptionnaire Alternative"])
+
+    def test_sitewide_schema_preserved_on_landing(self):
+        """
+        GIVEN a landing page with per-page structured data
+        WHEN rendered
+        THEN the site-wide SoftwareApplication + Organization JSON-LD are still present
+        """
+        blocks = self._ld_blocks(Client().get("/civic-engagement/").content.decode())
+        types = {b.get("@type") for b in blocks}
+        self.assertIn("SoftwareApplication", types)
+        self.assertIn("Organization", types)
+        self.assertIn("FAQPage", types)
+        self.assertIn("BreadcrumbList", types)
+
+    def test_faq_questions_are_page_specific(self):
+        """
+        GIVEN two different landing pages
+        WHEN their FAQ question sets are compared
+        THEN they are not identical (guards against thin duplicated FAQ markup)
+        """
+        from survey.seo_landings import get_landing
+        a = {qa.q for qa in get_landing("participatory_budgeting").faq}
+        b = {qa.q for qa in get_landing("maptionnaire_alternative").faq}
+        self.assertNotEqual(a, b)
+
+    def test_answer_with_apostrophe_is_json_safe(self):
+        """
+        GIVEN an FAQ answer containing an apostrophe
+        WHEN the FAQPage JSON-LD is built
+        THEN it still parses as valid JSON with the answer intact
+        """
+        from survey.seo_landings import build_faqpage_jsonld, QA
+        raw = build_faqpage_jsonld((QA("Q?", "You don't need an account — it's free."),))
+        data = json.loads(raw)  # must not raise
+        self.assertEqual(
+            data["mainEntity"][0]["acceptedAnswer"]["text"],
+            "You don't need an account — it's free.",
+        )
+
+
+class SeoLandingRegistryTest(TestCase):
+    """The seo_landings registry is the single source of truth for sitemap/robots."""
+
+    def test_sitemap_lists_every_landing_with_crawl_hints(self):
+        """
+        GIVEN the SEO landing registry
+        WHEN sitemap.xml is fetched
+        THEN every registry path is present with lastmod/changefreq/priority
+        """
+        from survey.seo_landings import SEO_LANDINGS
+        sm = Client().get("/sitemap.xml")
+        body = sm.content.decode()
+        for landing in SEO_LANDINGS:
+            self.assertIn(f"<loc>http://testserver{landing.path}</loc>", body)
+            self.assertIn(f"<lastmod>{landing.lastmod}</lastmod>", body)
+        self.assertIn("<changefreq>", body)
+        self.assertIn("<priority>", body)
+
+    def test_robots_allows_every_landing(self):
+        """
+        GIVEN the SEO landing registry
+        WHEN robots.txt is fetched
+        THEN every registry path has an Allow rule
+        """
+        from survey.seo_landings import SEO_LANDINGS
+        rb = Client().get("/robots.txt").content.decode()
+        for landing in SEO_LANDINGS:
+            self.assertIn(f"Allow: {landing.path}", rb)
+
+    def test_registry_url_names_resolve_and_match_paths(self):
+        """
+        GIVEN the SEO landing registry
+        WHEN each url_name is reversed
+        THEN it resolves to the registry path (registry and routes stay in sync)
+        """
+        from django.urls import reverse
+        from survey.seo_landings import SEO_LANDINGS
+        for landing in SEO_LANDINGS:
+            self.assertEqual(reverse(landing.url_name), landing.path)

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -86,6 +86,7 @@ urlpatterns = [
     path('surveys/<str:survey_slug>/thanks/', views.survey_thanks, name='survey_thanks'),
     path('surveys/<str:survey_slug>/<str:section_name>/', views.survey_section, name='section'),
     path('surveys/<str:survey_slug>/download', views.download_data, name='download_data'),
+    path('stories/', views.stories_index, name='stories_index'),
     path('stories/<slug:slug>/', views.story_detail, name='story_detail'),
     path('for-educators/', views.for_educators, name='for_educators'),
     path('for-planners/', views.for_planners, name='for_planners'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -22,6 +22,7 @@ from .events import (
     emit_event, build_session_start_metadata, store_utm_in_session,
     capture_signup_source, persist_signup_attribution,
 )
+from .seo_landings import SEO_LANDINGS, render_seo_landing
 from django.http import HttpResponseRedirect, Http404
 from django.urls import reverse
 from django.core.serializers import serialize
@@ -1179,8 +1180,7 @@ def for_educators(request):
 	First-touch source capture so a search/referral -> educators -> register flow is
 	attributed (Phase-1). The page's CTAs also carry utm_source=edu.
 	"""
-	capture_signup_source(request)
-	return render(request, 'for_educators.html')
+	return render_seo_landing(request, 'for_educators')
 
 
 def maptionnaire_alternative(request):
@@ -1189,8 +1189,7 @@ def maptionnaire_alternative(request):
 	Targets the validated "Maptionnaire alternative" search intent (how Jaakko
 	found us). First-touch source capture; CTAs carry utm_source=comparison.
 	"""
-	capture_signup_source(request)
-	return render(request, 'maptionnaire_alternative.html')
+	return render_seo_landing(request, 'maptionnaire_alternative')
 
 
 def for_planners(request):
@@ -1199,8 +1198,7 @@ def for_planners(request):
 	The core participatory-planning market (Maptionnaire's turf). First-touch
 	source capture; CTAs carry utm_source=planners.
 	"""
-	capture_signup_source(request)
-	return render(request, 'for_planners.html')
+	return render_seo_landing(request, 'for_planners')
 
 
 def for_researchers(request):
@@ -1209,16 +1207,14 @@ def for_researchers(request):
 	PPGIS / participatory research + citizen science. First-touch source capture;
 	CTAs carry utm_source=researchers.
 	"""
-	capture_signup_source(request)
-	return render(request, 'for_researchers.html')
+	return render_seo_landing(request, 'for_researchers')
 
 
 def for_government(request):
 	"""Public landing page: the open-source community engagement platform for
 	local government. Audience page (councils / public agencies) that also owns
 	the "community engagement platform" positioning. utm_source=government."""
-	capture_signup_source(request)
-	return render(request, 'for_government.html')
+	return render_seo_landing(request, 'for_government')
 
 
 def community_engagement_platform(request):
@@ -1228,8 +1224,7 @@ def community_engagement_platform(request):
 	transport agencies) — distinct from the audience page /for-government/, which scopes the
 	same term to local government. First-touch source capture; CTAs carry
 	utm_source=engagement_platform."""
-	capture_signup_source(request)
-	return render(request, 'community_engagement_platform.html')
+	return render_seo_landing(request, 'community_engagement_platform')
 
 
 def public_consultation_software(request):
@@ -1238,8 +1233,7 @@ def public_consultation_software(request):
 	Consultation-workflow framing (statutory consultation, planning applications,
 	infrastructure) — audience wider than government. First-touch source capture; CTAs carry
 	utm_source=consultation_software."""
-	capture_signup_source(request)
-	return render(request, 'public_consultation_software.html')
+	return render_seo_landing(request, 'public_consultation_software')
 
 
 def civic_engagement(request):
@@ -1248,8 +1242,7 @@ def civic_engagement(request):
 
 	Middle-funnel semantic anchor: explains map-based civic engagement and funnels down
 	to the product pages. CTAs carry utm_source=civic_engagement."""
-	capture_signup_source(request)
-	return render(request, 'civic_engagement.html')
+	return render_seo_landing(request, 'civic_engagement')
 
 
 def participatory_budgeting(request):
@@ -1257,8 +1250,7 @@ def participatory_budgeting(request):
 
 	Honest scope: location input for PB programmes (where residents want investment),
 	explicitly not a budget-allocation module. CTAs carry utm_source=participatory_budgeting."""
-	capture_signup_source(request)
-	return render(request, 'participatory_budgeting.html')
+	return render_seo_landing(request, 'participatory_budgeting')
 
 
 def for_consultants(request):
@@ -1266,8 +1258,7 @@ def for_consultants(request):
 
 	Leads with per-project economics (no per-project fees), GeoJSON deliverables, and
 	open-source self-hosting. CTAs carry utm_source=consultants."""
-	capture_signup_source(request)
-	return render(request, 'for_consultants.html')
+	return render_seo_landing(request, 'for_consultants')
 
 
 def social_pinpoint_alternative(request):
@@ -1275,8 +1266,7 @@ def social_pinpoint_alternative(request):
 
 	Claims restricted to the verified dossier (docs/marketing/competitors/openpoint.md).
 	CTAs carry utm_source=comparison / utm_medium=social_pinpoint_alt."""
-	capture_signup_source(request)
-	return render(request, 'social_pinpoint_alternative.html')
+	return render_seo_landing(request, 'social_pinpoint_alternative')
 
 
 def metroquest_alternative(request):
@@ -1284,8 +1274,7 @@ def metroquest_alternative(request):
 
 	Migration framing: metroquest.com now redirects into Open Point. CTAs carry
 	utm_source=comparison / utm_medium=metroquest_alt."""
-	capture_signup_source(request)
-	return render(request, 'metroquest_alternative.html')
+	return render_seo_landing(request, 'metroquest_alternative')
 
 
 def robots_txt(request):
@@ -1293,16 +1282,12 @@ def robots_txt(request):
 		"User-agent: *",
 		"Allow: /surveys/",
 		"Allow: /stories/",
-		"Allow: /for-educators/",
-		"Allow: /for-planners/",
-		"Allow: /for-researchers/",
-		"Allow: /for-government/",
-		"Allow: /community-engagement-platform/",
-		"Allow: /public-consultation-software/",
-		"Allow: /civic-engagement/",
-		"Allow: /participatory-budgeting/",
-		"Allow: /for-consultants/",
-		"Allow: /alternatives/",
+	]
+	# SEO landing pages — derived from the single-source registry
+	# (survey/seo_landings.py) so a new landing can't silently miss the allow-list.
+	for landing in SEO_LANDINGS:
+		lines.append(f"Allow: {landing.path}")
+	lines += [
 		"Disallow: /admin/",
 		"Disallow: /editor/",
 		"Disallow: /accounts/",
@@ -1318,18 +1303,14 @@ def sitemap_xml(request):
 		visibility__in=['public', 'demo'],
 	)
 	urls = [f"  <url><loc>{base}/</loc></url>"]
-	urls.append(f"  <url><loc>{base}/for-educators/</loc></url>")
-	urls.append(f"  <url><loc>{base}/for-planners/</loc></url>")
-	urls.append(f"  <url><loc>{base}/for-researchers/</loc></url>")
-	urls.append(f"  <url><loc>{base}/for-government/</loc></url>")
-	urls.append(f"  <url><loc>{base}/community-engagement-platform/</loc></url>")
-	urls.append(f"  <url><loc>{base}/public-consultation-software/</loc></url>")
-	urls.append(f"  <url><loc>{base}/civic-engagement/</loc></url>")
-	urls.append(f"  <url><loc>{base}/participatory-budgeting/</loc></url>")
-	urls.append(f"  <url><loc>{base}/for-consultants/</loc></url>")
-	urls.append(f"  <url><loc>{base}/alternatives/maptionnaire/</loc></url>")
-	urls.append(f"  <url><loc>{base}/alternatives/social-pinpoint/</loc></url>")
-	urls.append(f"  <url><loc>{base}/alternatives/metroquest/</loc></url>")
+	# SEO landing pages with crawl hints — from the single-source registry.
+	for landing in SEO_LANDINGS:
+		urls.append(
+			f"  <url><loc>{base}{landing.path}</loc>"
+			f"<lastmod>{landing.lastmod}</lastmod>"
+			f"<changefreq>{landing.changefreq}</changefreq>"
+			f"<priority>{landing.priority}</priority></url>"
+		)
 	urls.append(f"  <url><loc>{base}/trust/</loc></url>")
 	urls.append(f"  <url><loc>{base}/surveys/</loc></url>")
 	for survey in surveys:

--- a/survey/views.py
+++ b/survey/views.py
@@ -22,7 +22,10 @@ from .events import (
     emit_event, build_session_start_metadata, store_utm_in_session,
     capture_signup_source, persist_signup_attribution,
 )
-from .seo_landings import SEO_LANDINGS, render_seo_landing
+from .seo_landings import (
+    SEO_LANDINGS, render_seo_landing, Crumb, HOME,
+    build_breadcrumb_jsonld, build_story_collection_jsonld,
+)
 from django.http import HttpResponseRedirect, Http404
 from django.urls import reverse
 from django.core.serializers import serialize
@@ -1068,12 +1071,37 @@ def import_survey(request):
 	return redirect('editor')
 
 
+STORIES_CRUMB = Crumb("Stories", "/stories/")
+
+
+def stories_index(request):
+	"""Public stories hub at /stories/ — card grid of published stories, newest first."""
+	stories = list(Story.objects.filter(is_published=True).order_by('-published_date'))
+	breadcrumbs = (HOME, STORIES_CRUMB)
+	context = {
+		'stories': stories,
+		'breadcrumb_jsonld': build_breadcrumb_jsonld(breadcrumbs),
+		'collection_jsonld': build_story_collection_jsonld(request, stories) if stories else "",
+	}
+	return render(request, 'stories_index.html', context)
+
+
 def story_detail(request, slug):
+	from django.utils.html import strip_tags
 	try:
 		story = Story.objects.select_related('survey').get(slug=slug, is_published=True)
 	except Story.DoesNotExist:
 		raise Http404
-	return render(request, 'story_detail.html', {'story': story})
+	excerpt = " ".join(strip_tags(story.body or "").split())
+	meta_description = (excerpt[:155].rstrip() + "…") if len(excerpt) > 155 else (excerpt or story.title)
+	breadcrumbs = (HOME, STORIES_CRUMB, Crumb(story.title, f"/stories/{story.slug}/"))
+	context = {
+		'story': story,
+		'canonical': f"https://mapsurvey.org/stories/{story.slug}/",
+		'meta_description': meta_description,
+		'breadcrumb_jsonld': build_breadcrumb_jsonld(breadcrumbs),
+	}
+	return render(request, 'story_detail.html', context)
 
 
 @survey_permission_required('owner')
@@ -1313,6 +1341,11 @@ def sitemap_xml(request):
 		)
 	urls.append(f"  <url><loc>{base}/trust/</loc></url>")
 	urls.append(f"  <url><loc>{base}/surveys/</loc></url>")
+	# Stories hub + published stories
+	urls.append(f"  <url><loc>{base}/stories/</loc></url>")
+	for story in Story.objects.filter(is_published=True).order_by('-published_date'):
+		lastmod = f"<lastmod>{story.published_date.date().isoformat()}</lastmod>" if story.published_date else ""
+		urls.append(f"  <url><loc>{base}/stories/{story.slug}/</loc>{lastmod}</url>")
 	for survey in surveys:
 		urls.append(f"  <url><loc>{base}/surveys/{survey.uuid}/</loc></url>")
 	xml = (


### PR DESCRIPTION
## What

On-page SEO follow-ups to the landing-page wave (PR #32). Two OpenSpec changes, two commits:

### 1. `landing-seo-structured-data` — FAQ + FAQPage/BreadcrumbList (`e1f943e`)
- FAQ section (4–5 page-specific Q&A) + **FAQPage JSON-LD** on all 12 SEO landings, both driven by one per-page list in `survey/seo_landings.py` so the visible FAQ and the structured data can't drift.
- **BreadcrumbList JSON-LD** (`Home › [Alternatives ›] Page`), correct for the two-level `alternatives/*` pages.
- Opt-in `{% block structured_data %}` in `base_landing.html` + reusable partials `_faq_section.html` / `_landing_structured_data.html`.
- **Single source of truth**: the `seo_landings` registry drives `robots.txt` and `sitemap.xml` (previously the landing URL list was duplicated in 3 places). Sitemap entries gain `lastmod`/`changefreq`/`priority`.
- 12 landing views collapse to `render_seo_landing(request, key)`.

### 2. `public-stories-index` — `/stories/` hub + story SEO (`7bcdba9`)
- New **stories index** at `/stories/` (card grid of published stories, newest first, empty state → 200 not 404). Closes the dangling `robots.txt` allow + the "public results showcase" backlog item.
- **CollectionPage/ItemList** + **BreadcrumbList** JSON-LD on the hub.
- Story detail pages gain a self-canonical, a meta description, and a `Home › Stories › <title>` breadcrumb (previously had none).
- `sitemap.xml` lists `/stories/` and every published story; footer links Stories.

## Test plan
- Full suite green: **685 tests** (`./run_tests.sh survey`).
- New classes: `LandingStructuredDataTest`, `SeoLandingRegistryTest`, `StoriesIndexViewTest` — assert JSON-LD present + valid JSON, breadcrumb depth, sitemap/robots coverage, draft-story exclusion.
- JSON-LD spot-checked (FAQPage + BreadcrumbList on `alternatives/maptionnaire/`, CollectionPage on `/stories/`).

## Post-merge (manual)
- Resubmit `sitemap.xml` in Google Search Console; request indexing for `/stories/` + landings.
- Validate a sample page in Google Rich Results Test (FAQPage + BreadcrumbList).

OpenSpec: `openspec/changes/landing-seo-structured-data`, `openspec/changes/public-stories-index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
