### PR TITLE
feat(survey): token-gated HTTP trigger for trash auto-purge

### DIFF
--- a/mapsurvey/settings.py
+++ b/mapsurvey/settings.py
@@ -42,6 +42,10 @@ CSRF_TRUSTED_ORIGINS = [f'https://{host}' for host in ALLOWED_HOSTS if host and 
 # Analytics: max client-side tracking events per survey session per hour
 TRACK_EVENT_RATE_LIMIT = int(os.environ.get("TRACK_EVENT_RATE_LIMIT", 120))
 
+# Shared secret for the /internal/purge-trash/ endpoint (curl-based cron).
+# Empty string disables the endpoint entirely.
+PURGE_TASK_TOKEN = os.environ.get("PURGE_TASK_TOKEN", "")
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/openspec/changes/survey-deletion-safety/specs/survey-trash/spec.md
+++ b/openspec/changes/survey-deletion-safety/specs/survey-trash/spec.md
@@ -45,6 +45,21 @@ Manual Delete-forever and auto-purge SHALL permanently delete the survey, its ar
 - **WHEN** a Delete-forever request targets a survey that is not trashed
 - **THEN** the system SHALL reject the request without deleting anything
 
+### Requirement: Auto-purge is triggerable via an internal HTTP endpoint
+The system SHALL expose `POST /internal/purge-trash/` that runs the auto-purge routine, authenticated by a shared secret token from the `PURGE_TASK_TOKEN` environment variable. Requests without a valid token MUST be rejected with 403. When the token is unset, the endpoint MUST be disabled (403 for all requests). The endpoint exists so a lightweight external scheduler (curl-based cron) can drive purging without a Django runtime.
+
+#### Scenario: Valid token triggers purge
+- **WHEN** a POST with the correct bearer token arrives and a survey was trashed 31 days ago
+- **THEN** that survey SHALL be purged and the response SHALL report the purge count
+
+#### Scenario: Missing or wrong token rejected
+- **WHEN** a POST arrives without a token or with an incorrect token
+- **THEN** the system SHALL respond 403 and purge nothing
+
+#### Scenario: Endpoint disabled without configured token
+- **WHEN** `PURGE_TASK_TOKEN` is empty and any request arrives
+- **THEN** the system SHALL respond 403
+
 ### Requirement: Trashed surveys are auto-purged after 30 days
 A scheduled job SHALL permanently purge surveys whose `deleted_at` is older than 30 days, using the same purge routine as manual Delete-forever, and SHALL write a `survey_auto_purge` audit record per survey.
 

--- a/openspec/changes/survey-deletion-safety/tasks.md
+++ b/openspec/changes/survey-deletion-safety/tasks.md
@@ -27,6 +27,9 @@
 ## 5. Auto-purge job
 
 - [x] 5.1 Management command `purge_trashed_surveys --days 30 --dry-run`: purge routine + `survey_auto_purge` audit entries (actor=None)
+- [x] 5.2 Extract shared `purge_expired_surveys()` core into trash.py; command becomes a thin wrapper
+- [x] 5.3 Internal endpoint `POST /internal/purge-trash/` gated by `PURGE_TASK_TOKEN` env (constant-time compare, 403 when unset), returns purge count JSON; tests for token auth + purge + disabled state
+- [ ] 5.4 Render Cron Job (native runtime, curl) hitting the endpoint daily; `PURGE_TASK_TOKEN` env var on the web service
 
 ## 6. Tests (GIVEN/WHEN/THEN docstrings)
 

--- a/survey/management/commands/purge_trashed_surveys.py
+++ b/survey/management/commands/purge_trashed_surveys.py
@@ -1,16 +1,13 @@
 """Permanently purge surveys whose trash retention window has expired.
 
-Intended to run daily (Render Cron Job). Uses the same purge routine as the
-manual Delete-forever action and writes a survey_auto_purge audit record per
-survey with no actor. See openspec/changes/survey-deletion-safety/design.md (D6).
+Thin wrapper around survey.trash.purge_expired_surveys — the same core
+drives the /internal/purge-trash/ endpoint used by the curl-based Render
+cron. See openspec/changes/survey-deletion-safety/design.md (D6).
 """
-from datetime import timedelta
-
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
-from survey.models import AuditLog, SurveyHeader
-from survey.trash import purge_survey
+from survey.models import SurveyHeader
+from survey.trash import purge_expired_surveys
 
 
 class Command(BaseCommand):
@@ -27,24 +24,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        cutoff = timezone.now() - timedelta(days=options['days'])
-        expired = SurveyHeader.objects.filter(deleted_at__lt=cutoff)
-
-        if not expired.exists():
+        count = purge_expired_surveys(
+            days=options['days'], dry_run=options['dry_run'], log=self.stdout.write,
+        )
+        if count == 0:
             self.stdout.write("Nothing to purge")
-            return
-
-        for survey in expired:
-            if options['dry_run']:
-                self.stdout.write(f"Would purge '{survey.name}' ({survey.uuid}), trashed {survey.deleted_at:%Y-%m-%d}")
-                continue
-
-            AuditLog.objects.create(
-                actor=None,
-                action='survey_auto_purge',
-                survey_uuid=survey.uuid,
-                survey_name=survey.name,
-                metadata={'trashed_at': survey.deleted_at.isoformat(), 'retention_days': options['days']},
-            )
-            purge_survey(survey)
-            self.stdout.write(f"Purged '{survey.name}' ({survey.uuid})")

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -2526,6 +2526,82 @@ class AutoPurgeCommandTest(TestCase):
         self.assertFalse(AuditLog.objects.filter(action='survey_auto_purge').exists())
 
 
+class InternalPurgeEndpointTest(TestCase):
+    """Tests for the token-gated /internal/purge-trash/ endpoint."""
+
+    def setUp(self):
+        """Set up an expired trashed survey."""
+        from datetime import timedelta
+        from django.utils import timezone
+        self.org = _make_org('PurgeApiOrg')
+        self.expired = SurveyHeader.objects.create(
+            name="api_expired_survey", organization=self.org,
+            deleted_at=timezone.now() - timedelta(days=31),
+        )
+
+    def test_valid_token_triggers_purge(self):
+        """
+        GIVEN PURGE_TASK_TOKEN is configured and a survey expired in trash
+        WHEN POST arrives with the correct bearer token
+        THEN the survey is purged and the count is returned
+        """
+        from django.test import override_settings
+        from .models import AuditLog
+
+        with override_settings(PURGE_TASK_TOKEN='testtoken123'):
+            response = self.client.post(
+                '/internal/purge-trash/', HTTP_AUTHORIZATION='Bearer testtoken123',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'purged': 1})
+        self.assertFalse(SurveyHeader.objects.filter(pk=self.expired.pk).exists())
+        self.assertTrue(AuditLog.objects.filter(action='survey_auto_purge', survey_uuid=self.expired.uuid).exists())
+
+    def test_wrong_or_missing_token_rejected(self):
+        """
+        GIVEN PURGE_TASK_TOKEN is configured
+        WHEN POST arrives with a wrong token or none at all
+        THEN 403 is returned and nothing is purged
+        """
+        from django.test import override_settings
+
+        with override_settings(PURGE_TASK_TOKEN='testtoken123'):
+            wrong = self.client.post('/internal/purge-trash/', HTTP_AUTHORIZATION='Bearer nope')
+            missing = self.client.post('/internal/purge-trash/')
+
+        self.assertEqual(wrong.status_code, 403)
+        self.assertEqual(missing.status_code, 403)
+        self.assertTrue(SurveyHeader.objects.filter(pk=self.expired.pk).exists())
+
+    def test_endpoint_disabled_without_token_setting(self):
+        """
+        GIVEN PURGE_TASK_TOKEN is empty
+        WHEN any POST arrives (even with an empty bearer)
+        THEN 403 is returned
+        """
+        from django.test import override_settings
+
+        with override_settings(PURGE_TASK_TOKEN=''):
+            response = self.client.post('/internal/purge-trash/', HTTP_AUTHORIZATION='Bearer ')
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(SurveyHeader.objects.filter(pk=self.expired.pk).exists())
+
+    def test_get_rejected(self):
+        """
+        GIVEN a configured token
+        WHEN a GET request arrives
+        THEN 405 is returned
+        """
+        from django.test import override_settings
+
+        with override_settings(PURGE_TASK_TOKEN='testtoken123'):
+            response = self.client.get('/internal/purge-trash/', HTTP_AUTHORIZATION='Bearer testtoken123')
+
+        self.assertEqual(response.status_code, 405)
+
+
 class AuditLogTest(TestCase):
     """Tests for the append-only audit trail of editor operations."""
 

--- a/survey/trash.py
+++ b/survey/trash.py
@@ -6,6 +6,8 @@ hard-delete cascade plus media cleanup and also covers satellites the old
 code missed (live draft copies). See
 openspec/changes/survey-deletion-safety/design.md (D3, D7).
 """
+from datetime import timedelta
+
 from django.utils import timezone
 
 from .models import SurveyHeader, SurveySession, Question
@@ -49,3 +51,35 @@ def purge_survey(survey):
         SurveySession.objects.filter(survey=header).delete()
     for header in reversed(headers):
         header.delete()
+
+
+def purge_expired_surveys(days=None, dry_run=False, log=lambda msg: None):
+    """Purge all surveys whose trash retention window has expired.
+
+    Shared core behind the purge_trashed_surveys management command and the
+    /internal/purge-trash/ endpoint. Writes a survey_auto_purge audit row
+    per survey (no actor). Returns the number of surveys purged (or that
+    would be purged, when dry_run).
+    """
+    from .models import AuditLog
+
+    if days is None:
+        days = SurveyHeader.TRASH_RETENTION_DAYS
+    cutoff = timezone.now() - timedelta(days=days)
+    expired = list(SurveyHeader.objects.filter(deleted_at__lt=cutoff))
+
+    for survey in expired:
+        if dry_run:
+            log(f"Would purge '{survey.name}' ({survey.uuid}), trashed {survey.deleted_at:%Y-%m-%d}")
+            continue
+        AuditLog.objects.create(
+            actor=None,
+            action='survey_auto_purge',
+            survey_uuid=survey.uuid,
+            survey_name=survey.name,
+            metadata={'trashed_at': survey.deleted_at.isoformat(), 'retention_days': days},
+        )
+        purge_survey(survey)
+        log(f"Purged '{survey.name}' ({survey.uuid})")
+
+    return len(expired)

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('editor/delete/<uuid:survey_uuid>/', views.delete_survey, name='delete_survey'),
     path('editor/restore/<uuid:survey_uuid>/', views.restore_survey_view, name='restore_survey'),
     path('editor/purge/<uuid:survey_uuid>/', views.purge_survey_view, name='purge_survey'),
+    path('internal/purge-trash/', views.internal_purge_trash, name='internal_purge_trash'),
 
     # Organization management
     path('org/new/', org_views.org_create, name='org_create'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -39,7 +39,11 @@ import pandas as pd
 
 from .access_control import check_survey_access
 from .audit import audit
-from .trash import trash_survey, restore_survey, purge_survey
+from .trash import trash_survey, restore_survey, purge_survey, purge_expired_surveys
+import hmac
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from .serialization import (
     export_survey_to_zip,
     import_survey_from_zip,
@@ -1148,6 +1152,25 @@ def restore_survey_view(request, survey_uuid):
 	messages.success(request, f"Survey '{survey.name}' restored")
 
 	return redirect('editor')
+
+
+@csrf_exempt
+@require_POST
+def internal_purge_trash(request):
+	"""Run auto-purge of expired trashed surveys; driven by an external cron.
+
+	Authenticated with the PURGE_TASK_TOKEN shared secret (empty token
+	disables the endpoint). See survey-deletion-safety spec, survey-trash.
+	"""
+	token = conf_settings.PURGE_TASK_TOKEN
+	provided = request.headers.get('Authorization', '')
+	if provided.startswith('Bearer '):
+		provided = provided[len('Bearer '):]
+	if not token or not hmac.compare_digest(provided, token):
+		return HttpResponseForbidden()
+
+	purged = purge_expired_surveys()
+	return JsonResponse({'purged': purged})
 
 
 @survey_permission_required('owner', allow_trashed=True)


### PR DESCRIPTION
## Why

The daily trash auto-purge (shipped in #36) needs a scheduler. A Docker-based Render Cron Job is heavyweight for this (full image build per run; the Render MCP can't create Docker crons, and GeoDjango needs GDAL so native runtimes can't run `manage.py`). A dumb curl cron hitting an internal endpoint is simpler and cheaper.

## What

- `POST /internal/purge-trash/` — runs `purge_expired_surveys()`, returns `{"purged": N}`.
- Auth: `Authorization: Bearer <PURGE_TASK_TOKEN>` shared secret from env, compared with `hmac.compare_digest`. Empty/unset token disables the endpoint entirely (403 for everything). GET → 405.
- Purge core extracted from the management command into `survey/trash.py::purge_expired_surveys(days, dry_run, log)`; `manage.py purge_trashed_surveys` stays as a thin wrapper for manual ops.
- OpenSpec: `survey-trash` spec extended with the HTTP-trigger requirement (change `survey-deletion-safety`, tasks 5.2–5.3).

## Tests

Full suite **709/709 green**. New `InternalPurgeEndpointTest`: valid token purges + audit row, wrong/missing token 403, disabled-without-token 403, GET 405.

## Post-merge

1. Set `PURGE_TASK_TOKEN` env var on the `mapsurvey` web service (triggers redeploy).
2. Create the lightweight Render Cron Job: native runtime, daily `0 3 * * *`, command `curl -fsS -X POST -H "Authorization: Bearer $PURGE_TOKEN" https://mapsurvey.org/internal/purge-trash/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)