### PR TITLE
feat(auth): auto-login on activation, resend flow, funnel activation stages

### DIFF
--- a/mapsurvey/settings.py
+++ b/mapsurvey/settings.py
@@ -234,7 +234,7 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 LOGIN_REDIRECT_URL = '/editor/'
 
-ACCOUNT_ACTIVATION_DAYS = 1
+ACCOUNT_ACTIVATION_DAYS = int(os.environ.get('ACCOUNT_ACTIVATION_DAYS', 7))
 
 # Mapbox
 MAPBOX_URL = os.environ.get('MAPBOX_URL', 'https://api.mapbox.com/styles/v1/mapbox/streets-v12/tiles/256/{z}/{x}/{y}@2x?access_token={accessToken}')
@@ -306,6 +306,11 @@ TURNSTILE_SECRET_KEY = os.environ.get('TURNSTILE_SECRET_KEY', '')
 CLOUDFLARE_TRUSTED = os.environ.get('CLOUDFLARE_TRUSTED', 'False').lower() in ('true', '1')
 REGISTRATION_RATE_LIMIT_HOUR = int(os.environ.get('REGISTRATION_RATE_LIMIT_HOUR', 3))
 REGISTRATION_RATE_LIMIT_DAY = int(os.environ.get('REGISTRATION_RATE_LIMIT_DAY', 10))
+# Resend-activation endpoint. Tighter than registration: it emails an address
+# the sender does not have to control, so it is the more attractive bombing
+# vector of the two. Per-IP hourly + per-email daily.
+RESEND_ACTIVATION_RATE_LIMIT_HOUR = int(os.environ.get('RESEND_ACTIVATION_RATE_LIMIT_HOUR', 3))
+RESEND_ACTIVATION_RATE_LIMIT_DAY = int(os.environ.get('RESEND_ACTIVATION_RATE_LIMIT_DAY', 3))
 
 LOGGING = {
     # This LOGGING block configures only the `abuse.*` logger hierarchy used

--- a/mapsurvey/urls.py
+++ b/mapsurvey/urls.py
@@ -17,7 +17,13 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 
-from survey.views import AbuseProtectedRegistrationView, DirectActivationView
+from django.views.generic import TemplateView
+
+from survey.views import (
+    AbuseProtectedRegistrationView,
+    DirectActivationView,
+    ResendActivationView,
+)
 
 
 urlpatterns = [
@@ -25,6 +31,20 @@ urlpatterns = [
     path('i18n/', include('django.conf.urls.i18n')),
     path('admin/', admin.site.urls),
     path('accounts/register/', AbuseProtectedRegistrationView.as_view(), name='django_registration_register'),
+    # Resend routes must precede the activation include below, which owns the
+    # rest of /accounts/activate/.
+    path(
+        'accounts/activate/resend/',
+        ResendActivationView.as_view(),
+        name='django_registration_resend_activation',
+    ),
+    path(
+        'accounts/activate/resend/done/',
+        TemplateView.as_view(
+            template_name='django_registration/resend_activation_done.html'
+        ),
+        name='django_registration_resend_activation_done',
+    ),
     path('accounts/activate/', DirectActivationView.as_view(), name='django_registration_activate'),
     path('accounts/', include('django_registration.backends.activation.urls')),
     path('accounts/', include('django.contrib.auth.urls')),

--- a/openspec/changes/activation-funnel-autologin/.openspec.yaml
+++ b/openspec/changes/activation-funnel-autologin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/activation-funnel-autologin/design.md
+++ b/openspec/changes/activation-funnel-autologin/design.md
@@ -1,0 +1,83 @@
+# Design: activation-funnel-autologin
+
+## Context
+
+Registration uses `django_registration`'s two-step activation backend. `AbuseProtectedRegistrationView` creates the user inactive and emails an activation link; `DirectActivationView` (survey/views.py:198) activates on GET and redirects to `django_registration_activation_complete` — a static page whose only affordance is a "Sign In" button. `ACCOUNT_ACTIVATION_DAYS = 1`. The failed-activation page links to "Try registering again", which dead-ends because the inactive account still holds the username/email.
+
+Prod funnel (2026-07-27): 53 accounts never activated; 24 activated but never logged in (~11 distinct people, disproportionately institutional leads). The staff growth-funnel dashboard (`survey/funnel.py` + `admin/funnel_dashboard.html`) currently has no visibility into either stage: its cohort rows jump from `regs` straight to `created`.
+
+Constraints:
+
+- The platform was attacked via subscription-bombing in May 2026 (registration welcome emails to harvested addresses). Any new unauthenticated endpoint that sends email must be defended in the same way as `/accounts/register/` (rate limit via `django-ratelimit` patterns in `survey/abuse.py`, fail-open on Redis outage, no account-existence leak).
+- Single auth backend: `survey.backends.EmailOrUsernameBackend`.
+- Funnel dashboard derives all stages live from existing tables — no event log; new stages must follow the same pattern (`is_active`, `last_login` are already on `auth_user`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A user who clicks a valid activation link lands in `/editor/` already authenticated.
+- An activation link stays valid for 7 days.
+- A user with an expired/invalid key can request a fresh activation email without re-registering; the flow is not usable for email-bombing or account enumeration.
+- The staff funnel dashboard shows per-cohort and all-time counts for **activated** and **logged in**, positioned between registrations and created-survey.
+
+**Non-Goals:**
+
+- No email-verification-before-account restructuring (backlog: `feature-email-verification-before-account`).
+- No duplicate-account merging or same-email signup rerouting (backlog: `improvement-account-dedup-signup-ux`).
+- No changes to the registration endpoint or its defenses.
+- No historical backfill of "when did activation happen" — `auth_user` has no activation timestamp; cohort stages count current state, same as every other funnel stage.
+
+## Decisions
+
+### D1. Auto-login inside `DirectActivationView.get()`, not via `RegistrationView` signals
+
+After `self.activate(form)` returns the user, call `django.contrib.auth.login(request, user, backend='survey.backends.EmailOrUsernameBackend')` and redirect to `settings.LOGIN_REDIRECT_URL` (`/editor/`). The explicit `backend=` kwarg is required because `login()` otherwise expects `user.backend` set by `authenticate()`, which never ran.
+
+*Alternative considered*: listening to `django_registration`'s `user_activated` signal in an app hook. Rejected — the signal handler has no clean way to influence the view's redirect, and we already own the view subclass.
+
+*Kept*: the `activation_complete` template remains as a fallback (direct visits to the URL, e.g. from history), now with a line "you are signed in" only when relevant — in practice the redirect bypasses it entirely; the template's "Sign In" button stays for the anonymous case.
+
+### D2. `ACCOUNT_ACTIVATION_DAYS = 7`, env-overridable
+
+Match django-registration's default. Read from `os.environ` with default 7, consistent with how the abuse settings are configured. Keys signed with the old 1-day window automatically benefit (validity is checked against the setting at activation time, not at signing time).
+
+### D3. Resend flow: separate endpoint, silent success, signed-key regeneration
+
+- `GET /accounts/activate/resend/` renders a one-field form (email). `POST` always redirects to a "check your inbox" page regardless of whether the email matched anything (**no enumeration**).
+- Handler behaviour: look up `User` by email (case-insensitive). If found AND `is_active=False` → re-send the standard activation email using the same machinery as registration (`RegistrationView.get_activation_key(user)` + the existing `django_registration/activation_email*` templates, reusing `AbuseProtectedRegistrationView.email_html_template`). Found-and-active or not-found → do nothing, same redirect. Activation keys are stateless signed values (`TimestampSigner` over the username), so "regeneration" is just signing again — no DB writes.
+- **Rate limits**: reuse the `survey/abuse.py` pattern — per-IP `3/h` and per-email `3/d` (settings-backed like `REGISTRATION_RATE_LIMIT_*`), fail-open if Redis is down, over-limit logged to `AbuseEvent` with a new `event_type='resend_rate_limited'` (existing choices permitting; otherwise reuse the generic rate-limit type — resolve in implementation against the `AbuseEvent` model).
+- **Honeypot**: same hidden `website` field trick as registration; a filled honeypot silently fake-succeeds.
+- *Alternative considered*: auto-resend on expired-key detection in `DirectActivationView` (no form). Rejected — the activation URL with a stale key can be re-fetched by mail scanners and would trigger unsolicited email sends; an explicit user-facing form with rate limits is the safer shape.
+
+### D4. Failed-activation page routes to resend, not re-register
+
+`activation_failed.html` replaces "Try registering again" with a link to the resend form (email prefilled when derivable — it is not, from a signed key alone, so no prefill). Copy explains the link may have expired and a new one can be requested.
+
+### D5. Funnel stages: `activated` and `logged_in` from `auth_user` columns
+
+`survey/funnel.py`:
+
+- `_blank_row` gains `activated` and `logged_in` keys (after `regs`).
+- `cohort_funnel()` iterates `self._real_users().values_list("id", "date_joined", "is_active", "last_login")` and increments the two counters; `alltime_totals()` adds the keys to its sum list.
+- Dashboard template `admin/funnel_dashboard.html` gains two `<th>/<td>` columns between Regs and Created, in both cohort table and all-time header cards.
+
+Semantics are point-in-time (an account activated today counts in its signup cohort's `activated` immediately), identical to how `created`/`published` behave today. `last_login` is maintained by Django's `user_logged_in` signal, which `login()` fires — so the auto-login of D1 correctly marks users as logged-in.
+
+*Alternative considered*: tracking activation timestamps for time-boxed columns (activated-within-7d). Rejected — `auth_user` stores no activation time; adding a model/table for it is out of proportion for a staff dashboard.
+
+## Risks / Trade-offs
+
+- [Resend endpoint as spam vector] → honeypot + per-IP and per-email rate limits + silent no-op for active/unknown accounts; only ever emails an address that already registered, and at most 3/day.
+- [Auto-login on a GET link: mail scanners pre-fetching the link] → the scanner activates the account and receives a session cookie *in its own session*; the user's later click re-runs activation, which now raises `ActivationError(code="already_activated")` → previously a dead-end failure page. Mitigation: that code is treated as benign and redirects to login (`?activated=1`), or to `/editor/` if the session is already authenticated.
+  **Auto-login fires only on the genuine inactive→active transition, never on the already-activated replay.** This is deliberate: activation can only succeed once, so signing in there keeps the key single-use as a credential. Signing in on replay would instead turn the activation link into a bearer token valid for the whole `ACCOUNT_ACTIVATION_DAYS` window — anyone later obtaining the email (forward, shared inbox, browser-history sync) could sign in as that user. Given the user base includes government and child-services accounts, the small UX loss for the scanner-then-human sequence (one login form) is the correct trade.
+- [Fail-open rate limiting] → same accepted trade-off as registration (documented in `registration-abuse-defenses`); Redis outage briefly disables throttling rather than blocking real users.
+- [Cohort `activated`/`logged_in` are current-state, not as-of-cohort-age] → same caveat as every other stage in this dashboard; documented in the template legend.
+
+## Migration Plan
+
+Code + settings only; no migrations expected (unless `AbuseEvent.event_type` choices need a new value — that is a choices-only change, still no schema migration in Django for `choices`). Deploy normally on Render. Rollback = revert commit. Existing unexpired activation emails keep working; expired-key holders gain the resend path immediately.
+
+## Open Questions
+
+- Whether `AbuseEvent.event_type` has a reusable value for resend rate-limiting or needs a new choice — resolve against `survey/models.py` during implementation.

--- a/openspec/changes/activation-funnel-autologin/proposal.md
+++ b/openspec/changes/activation-funnel-autologin/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: activation-funnel-autologin
+
+## Why
+
+Production funnel data (2026-07-27): of 269 registered users, **53 never activated** their account and a further **24 activated but never logged in** (~11 distinct people after deduplication). The second cohort is disproportionately high-value institutional leads — DECYP Tasmania, Flagship Housing (both accounts), Riverside County, LichtBlick, SMU, Columbia — people who clicked the activation link and then abandoned at the "Sign In" screen. Three compounding causes:
+
+1. After successful activation, `DirectActivationView` redirects to a static "Account Activated" page that asks the user to **re-enter credentials they typed two minutes ago**. This is the observed drop-off point.
+2. `ACCOUNT_ACTIVATION_DAYS = 1`: the activation link dies after 24 hours (django-registration's own default is 7 days). Anyone who opens the email late is dead-ended.
+3. The "Activation Failed" page suggests "Try registering again" — which cannot succeed, because the inactive account still holds the username and email. There is no way to re-send an activation link.
+
+The duplicate-account pattern documented in `openspec/backlog/improvement-account-dedup-signup-ux.md` (same person registering 2–3 times: tcoombs/t.coombs, Fränze/fraenze, Echa/vnecha, Claire Cameron ×2) is a direct symptom of causes 2 and 3.
+
+## What Changes
+
+- **Auto-login after activation**: on successful activation, log the user in (via the configured `EmailOrUsernameBackend`) and redirect straight to `/editor/` instead of showing the "Account Activated → Sign In" page.
+- **Extend activation window**: `ACCOUNT_ACTIVATION_DAYS` 1 → 7.
+- **Resend activation link**: replace the "Try registering again" dead end on the failed/expired-key page with a resend flow — request a fresh activation email for a not-yet-activated account. Abuse-hardened: rate-limited per IP and per account, no account-existence leak (always fake-success response), no-op for already-active accounts.
+- **Funnel dashboard: activation stages**: the staff growth-funnel dashboard gains two stages between "registrations" and "created survey" — **activated** (`is_active=True`) and **logged in** (`last_login IS NOT NULL`) — in the monthly cohort table and the all-time totals, so this leak is visible per cohort and the effect of the fixes above is measurable.
+
+## Capabilities
+
+### New Capabilities
+
+- `account-activation`: the account activation flow — activation key lifecycle (validity window), post-activation auto-login and landing, expired/invalid-key handling, and the abuse-hardened resend-activation flow.
+
+### Modified Capabilities
+
+- `creator-funnel-dashboard`: the monthly cohort funnel and all-time totals gain two new stages — activated and logged-in — between registrations and created-survey.
+
+`registration-abuse-defenses` covers `/accounts/register/` and is unchanged; the resend endpoint adopts the same defense patterns (rate limit, fail-open on Redis outage, no-enumeration) but its requirements live in the new `account-activation` spec.
+
+## Impact
+
+- **Code**: `survey/views.py` (`DirectActivationView`, new resend view), `mapsurvey/settings.py` (`ACCOUNT_ACTIVATION_DAYS`), `mapsurvey/urls.py` (resend route), templates `django_registration/activation_failed.html` (+ new resend request/sent templates), reuse of helpers in `survey/abuse.py`; `survey/funnel.py` (cohort stages) and `survey/templates/admin/funnel_dashboard.html` (columns).
+- **No schema/migration changes** — no model changes anticipated.
+- **Security surface**: new unauthenticated endpoint that sends email → must not become an email-bombing vector (the platform was already attacked via the registration welcome-email path in May 2026); rate limiting and silent no-ops are requirements, not niceties.
+- **Interactions**: complements (does not replace) backlog items `feature-email-verification-before-account`, `improvement-account-dedup-signup-ux`, `feature-funnel-monitoring`.
+- **Sessions**: auto-login issues a session cookie on the activation GET — flow remains a top-level navigation, so `SESSION_COOKIE_SAMESITE=Lax` is unaffected.

--- a/openspec/changes/activation-funnel-autologin/specs/account-activation/spec.md
+++ b/openspec/changes/activation-funnel-autologin/specs/account-activation/spec.md
@@ -1,0 +1,69 @@
+# account-activation Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Auto-login after successful activation
+The system SHALL, upon successful account activation via a valid activation key, log the activated user in and redirect them to the editor dashboard (`LOGIN_REDIRECT_URL`) without requiring credential entry.
+
+#### Scenario: Valid key activates and signs in
+- **WHEN** an anonymous user opens the activation URL with a valid, unexpired activation key for an inactive account
+- **THEN** the account becomes active, the user's session is authenticated as that account, and the response redirects to `/editor/`
+
+#### Scenario: Login records last_login
+- **WHEN** a user is auto-logged-in through activation
+- **THEN** `last_login` is set on the account, as with any interactive login
+
+### Requirement: Already-active account with a valid key is not an error
+The system SHALL treat an activation request whose key is valid but whose account is already active as a benign repeat (e.g. a mail scanner pre-fetched the link before the user clicked it) and SHALL route the user onward rather than showing a failure page.
+
+#### Scenario: Second click on an already-consumed link
+- **WHEN** an activation URL with a valid key is opened for an account that is already active
+- **THEN** the user is redirected to the login page (or `/editor/` when their session is already authenticated), and no failure page is shown
+
+### Requirement: Activation key validity window
+The activation key SHALL remain valid for 7 days by default, configurable via the `ACCOUNT_ACTIVATION_DAYS` environment variable.
+
+#### Scenario: Click within the window
+- **WHEN** a user opens their activation link 6 days after registration
+- **THEN** activation succeeds
+
+#### Scenario: Click after the window
+- **WHEN** a user opens their activation link more than 7 days after registration
+- **THEN** activation fails and the failure page offers the resend-activation flow
+
+### Requirement: Resend activation email
+The system SHALL provide an unauthenticated form at a dedicated URL where a user can enter an email address and request a fresh activation email. For an email that matches a not-yet-activated account, the system SHALL send a new activation email using the standard activation template with a freshly signed key.
+
+#### Scenario: Expired-key holder requests a new link
+- **WHEN** a user whose activation key expired submits the resend form with their registered email
+- **THEN** a new activation email is sent, and the new link activates the account within the validity window
+
+#### Scenario: Failure page links to resend
+- **WHEN** activation fails for any reason (expired, invalid, or missing key)
+- **THEN** the failure page contains a link to the resend-activation form and does not suggest re-registering
+
+### Requirement: Resend flow does not leak account existence
+The resend endpoint SHALL respond identically — redirect to a neutral "check your inbox" page — whether the submitted email matches an inactive account, an active account, or no account at all. Email SHALL be sent only in the inactive-account case.
+
+#### Scenario: Unknown email
+- **WHEN** the resend form is submitted with an email that matches no account
+- **THEN** the response is the same neutral confirmation, and no email is sent
+
+#### Scenario: Already-active account
+- **WHEN** the resend form is submitted with the email of an already-active account
+- **THEN** the response is the same neutral confirmation, and no activation email is sent
+
+### Requirement: Resend flow is abuse-hardened
+The resend endpoint SHALL be protected by the same defense layers as registration: a hidden honeypot field that silently fake-succeeds when filled, and rate limits per client IP and per target email (settings-configurable, defaulting to 3/hour per IP and 3/day per email). Rate limiting SHALL fail open when the cache backend is unreachable. Over-limit attempts SHALL be recorded in the abuse audit log.
+
+#### Scenario: Honeypot filled
+- **WHEN** the resend form is submitted with the honeypot field non-empty
+- **THEN** the response is the neutral confirmation and no email is sent
+
+#### Scenario: Per-IP rate limit exceeded
+- **WHEN** a client IP exceeds the per-IP resend limit within the window
+- **THEN** subsequent submissions from that IP receive the neutral confirmation without sending email, and an abuse event is recorded
+
+#### Scenario: Cache backend down
+- **WHEN** the rate-limit cache backend is unreachable
+- **THEN** the resend request is processed as if under the limit (fail-open)

--- a/openspec/changes/activation-funnel-autologin/specs/creator-funnel-dashboard/spec.md
+++ b/openspec/changes/activation-funnel-autologin/specs/creator-funnel-dashboard/spec.md
@@ -1,0 +1,43 @@
+# creator-funnel-dashboard Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Monthly cohort activation funnel
+The dashboard SHALL show, for each registration-month cohort, the count of real registrations and
+the counts that reached each activation stage: **activated the account (`is_active=True`), logged
+in at least once (`last_login` set),** created a survey, added at least one question, published a
+survey, and collected at least 1 / 5 / 10 non-deleted responses. The activated and logged-in
+stages SHALL appear between registrations and created-survey, in both the cohort table and the
+all-time totals. Real registrations SHALL exclude staff and superuser accounts.
+
+#### Scenario: Cohort rows reflect existing data
+- **WHEN** the service aggregates registrations grouped by `date_trunc('month', date_joined)`
+- **THEN** each cohort row reports registrations and the per-stage counts derived from
+  `auth_user.is_active`, `auth_user.last_login`, `SurveyHeader`, its `Question` rows,
+  `SurveyHeader.status`, and non-deleted `SurveySession` counts
+
+#### Scenario: Activated stage counts active accounts
+- **WHEN** the cohort funnel is computed
+- **THEN** a user with `is_active=True` counts in their signup cohort's activated stage, and a
+  user with `is_active=False` does not
+
+#### Scenario: Logged-in stage counts users who ever signed in
+- **WHEN** the cohort funnel is computed
+- **THEN** a user with a non-null `last_login` counts in their signup cohort's logged-in stage,
+  and a user who never logged in does not
+
+#### Scenario: All-time totals include the new stages
+- **WHEN** the all-time totals row is computed
+- **THEN** it includes summed activated and logged-in counts alongside the existing stages
+
+#### Scenario: Staff and superusers are excluded
+- **WHEN** the registration population is computed
+- **THEN** users with `is_staff=True` or `is_superuser=True` are not counted in any cohort or stage
+
+#### Scenario: Published stage counts only published-or-later surveys
+- **WHEN** the published stage is computed
+- **THEN** only creators owning a survey with `status` in (`published`, `closed`, `archived`) are counted
+
+#### Scenario: Deleted sessions are not counted as responses
+- **WHEN** response-count stages (≥1/≥5/≥10) are computed
+- **THEN** `SurveySession` rows with `is_deleted=True` are excluded from the counts

--- a/openspec/changes/activation-funnel-autologin/tasks.md
+++ b/openspec/changes/activation-funnel-autologin/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: activation-funnel-autologin
+
+## 1. Auto-login + activation window
+
+- [x] 1.1 `mapsurvey/settings.py`: `ACCOUNT_ACTIVATION_DAYS` from env, default 7
+- [x] 1.2 `DirectActivationView`: on successful activation, `auth.login(request, user, backend='survey.backends.EmailOrUsernameBackend')` and redirect to `settings.LOGIN_REDIRECT_URL`
+- [x] 1.3 `DirectActivationView`: valid key + already-active account → redirect to login (or `/editor/` if session already authenticated) instead of the failure page (mail-scanner sequence). **Deliberately does NOT sign them in** — see 1.5
+- [x] 1.4 Tests (GIVEN/WHEN/THEN): valid key → active + authenticated session + redirect to `/editor/` + `last_login` set; expired key → failure page; valid key on already-active account → no failure page
+- [x] 1.5 **Scope correction made during implementation.** The design originally allowed auto-login on the already-activated replay. Rejected once implemented: activation keys stay valid for the whole `ACCOUNT_ACTIVATION_DAYS` window, so signing in on replay would turn the emailed link into a 7-day reusable login credential (forwarded or leaked mail → account takeover). Auto-login now fires only on the inactive→active transition, which can succeed exactly once. design.md Risks updated; `test_replayed_key_does_not_sign_anyone_in` locks it in
+
+## 2. Resend activation flow
+
+- [x] 2.1 Open question resolved: reuse the existing `AbuseEvent.defense` choices (`ratelimit`, `honeypot`) and distinguish this endpoint via `detail` (`resend_hour`, `resend_day`, `resend_filled`). No new choice, no migration
+- [x] 2.2 Settings: `RESEND_ACTIVATION_RATE_LIMIT_HOUR` (default 3, per IP), `RESEND_ACTIVATION_RATE_LIMIT_DAY` (default 3, per email), env-overridable
+- [x] 2.3 `ResendActivationView` + `ResendActivationForm` (email + honeypot); POST always redirects to the neutral "check your inbox" page; email sent only for existing inactive accounts (case-insensitive match), fresh key via `get_activation_key`, existing activation templates
+- [x] 2.4 Rate limiting per D3: per-IP (`ratelimit_key`) and per-email (`ratelimit_email_key`, new in `survey/abuse.py`), fail-open on cache outage, over-limit → `AbuseEvent` + neutral response (deliberately not 429 — a 429 would break the response uniformity that prevents enumeration)
+- [x] 2.5 URL routes `/accounts/activate/resend/` + `/resend/done/`, ordered before the activation include; two new templates
+- [x] 2.6 `activation_failed.html`: "Try registering again" replaced with a link to the resend form, copy mentions possible expiry
+- [x] 2.7 Tests (GIVEN/WHEN/THEN): inactive → mail + neutral redirect; unknown / already-active / malformed email → no mail, identical response; honeypot → no mail + `AbuseEvent`; per-IP and per-email limits → capped + `AbuseEvent`; cache down → fail-open
+
+## 3. Funnel dashboard stages
+
+- [x] 3.1 `survey/funnel.py`: `_blank_row` gains `activated`, `logged_in`; `cohort_funnel()` reads `is_active`/`last_login` via `values_list` and increments; `alltime_totals()` sums the new keys
+- [x] 3.2 `admin/funnel_dashboard.html`: Activated + Logged-in columns with percentages between Regs and Created; legend explains both gaps and their point-in-time semantics
+- [x] 3.3 Tests (GIVEN/WHEN/THEN): active-never-logged-in counts in `activated` only; logged-in counts in both; inactive in neither; totals row sums; dashboard renders the columns
+
+## 4. Verification
+
+- [x] 4.1 Test suite: baseline **711 tests / 2 errors** → after **734 tests / same 2 errors**. +23 tests, no new failures. Both errors are pre-existing in `LastActivityMiddlewareTest` (unrelated `UserActivity` middleware)
+- [x] 4.2 Flow coverage is automated rather than manual: the tests exercise real template rendering and redirects end to end (activation → `/editor/`; expired key → failure page carrying the resend link; resend → mail → key that activates; dashboard columns). **Not visually inspected in a browser** — worth a look before merge
+
+## Notes for review
+
+- Two test-harness details that were needed and are easy to regress:
+  - Rate-limit tests must pin `CACHES` to LocMemCache. The configured Redis backend runs with `IGNORE_EXCEPTIONS`, so without Redis every counter silently no-ops and limit tests pass vacuously.
+  - Activation mail is sent from a background thread (that is what keeps response time uniform and the endpoint non-enumerable), which makes `mail.outbox` assertions racy. `_InlineThread` runs the target synchronously in tests instead of removing the thread.

--- a/survey/abuse.py
+++ b/survey/abuse.py
@@ -59,6 +59,21 @@ def ratelimit_key(group, request):
     return client_ip(request)
 
 
+def ratelimit_email_key(group, request):
+    """Rate-limit key over the submitted email, for the resend endpoint.
+
+    The per-IP limit alone does not protect a *victim*: an attacker rotating
+    IPs could still hammer one inbox. Keying a second limit on the normalized
+    target address caps how many activation emails any single address can
+    receive per day, regardless of origin.
+
+    Falls back to the IP when no email was submitted, so a malformed POST
+    still consumes a bucket instead of bypassing the limit entirely.
+    """
+    email = (request.POST.get("email") or "").strip().lower()
+    return email or client_ip(request)
+
+
 def verify_turnstile(token, remote_ip=""):
     """Return True if `token` is accepted by Cloudflare's siteverify endpoint.
 
@@ -137,6 +152,33 @@ class RegistrationAbuseForm(RegistrationForm):
     Turnstile validation is also handled in the view — it needs `request`
     to read `cf-turnstile-response` (with dash, not Python-friendly).
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields[HONEYPOT_FIELD_NAME] = forms.CharField(
+            required=False,
+            widget=forms.TextInput(attrs={
+                "tabindex": "-1",
+                "autocomplete": "off",
+                "aria-hidden": "true",
+            }),
+            label="",
+        )
+
+
+class ResendActivationForm(forms.Form):
+    """Single email field plus the same hidden honeypot as registration.
+
+    As with RegistrationAbuseForm, the honeypot check itself lives in the
+    view (read from request.POST before validation) so a bot that fills the
+    honeypot AND submits a malformed email still gets the neutral response
+    rather than a form-error page that would fingerprint the defense.
+    """
+
+    email = forms.EmailField(
+        label="Email address",
+        widget=forms.EmailInput(attrs={"autocomplete": "email", "autofocus": True}),
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/survey/funnel.py
+++ b/survey/funnel.py
@@ -164,11 +164,20 @@ class CreatorFunnelService:
 
         cohorts = {}
         dates = {}
-        for uid, joined in self._real_users().values_list("id", "date_joined"):
+        for uid, joined, is_active, last_login in self._real_users().values_list(
+            "id", "date_joined", "is_active", "last_login"
+        ):
             key = joined.strftime("%Y-%m")
             row = cohorts.setdefault(key, self._blank_row(key))
             dates.setdefault(key, []).append(joined)
             row["regs"] += 1
+            # Two pre-product stages straight off auth_user. Both are
+            # point-in-time (an account activated today counts in its signup
+            # cohort immediately), like every other stage in this table.
+            if is_active:
+                row["activated"] += 1
+            if last_login is not None:
+                row["logged_in"] += 1
             if uid in created:
                 row["created"] += 1
             if uid in with_q:
@@ -196,7 +205,8 @@ class CreatorFunnelService:
     def alltime_totals(self):
         """Single funnel row across all real registrations (for header cards)."""
         total = self._blank_row("all-time")
-        keys = ("regs", "created", "added_question", "published", "pub_14d",
+        keys = ("regs", "activated", "logged_in", "created", "added_question",
+                "published", "pub_14d",
                 "got_1", "got_5", "got_10", "got5_30d")
         for r in self.cohort_funnel():
             for k in keys:
@@ -508,7 +518,9 @@ class CreatorFunnelService:
     @staticmethod
     def _blank_row(label):
         return {
-            "cohort": label, "regs": 0, "created": 0, "added_question": 0,
+            "cohort": label, "regs": 0,
+            "activated": 0, "logged_in": 0,
+            "created": 0, "added_question": 0,
             "published": 0, "pub_14d": 0,
             "got_1": 0, "got_5": 0, "got_10": 0, "got5_30d": 0,
         }

--- a/survey/templates/admin/funnel_dashboard.html
+++ b/survey/templates/admin/funnel_dashboard.html
@@ -117,7 +117,7 @@
   <table class="funnel">
     <thead>
       <tr>
-        <th>Cohort</th><th>Regs</th><th>Created</th><th>+Q</th><th>Published</th>
+        <th>Cohort</th><th>Regs</th><th>Activated</th><th>Logged&nbsp;in</th><th>Created</th><th>+Q</th><th>Published</th>
         <th class="win">Pub&nbsp;≤14d</th><th>≥1</th><th>≥5</th><th class="win">≥5&nbsp;≤30d</th>
         <th style="width:120px">Weekly regs</th>
       </tr>
@@ -127,6 +127,8 @@
       <tr>
         <td>{{ c.cohort }}</td>
         <td>{{ c.regs }}</td>
+        <td>{{ c.activated }} <span class="subtle">{% widthratio c.activated c.regs 100 %}%</span></td>
+        <td>{{ c.logged_in }} <span class="subtle">{% widthratio c.logged_in c.regs 100 %}%</span></td>
         <td>{{ c.created }} <span class="subtle">{% widthratio c.created c.regs 100 %}%</span></td>
         <td>{{ c.added_question }}</td>
         <td>{{ c.published }} <span class="subtle">{% widthratio c.published c.regs 100 %}%</span></td>
@@ -141,11 +143,12 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="10" class="subtle">No registrations yet.</td></tr>
+      <tr><td colspan="12" class="subtle">No registrations yet.</td></tr>
       {% endfor %}
     </tbody>
   </table>
   <div class="subtle">Highlighted columns are time-boxed (published within {{ 14 }} days of signup — approx: created-and-now-published; 5th response within 30 days). This is how H2 (templates/onboarding) is judged cohort-over-cohort without the “older cohort had more time” bias.</div>
+  <div class="subtle">Activated = clicked the emailed activation link. Logged in = signed in at least once afterwards. Regs→Activated measures email deliverability; Activated→Logged&nbsp;in was a pure UX leak until auto-login-on-activation shipped, so expect that gap to close from that cohort onward. Both are point-in-time, not as-of-cohort-age.</div>
 
   {# ④ LIVING USERS #}
   <h2 id="living"><span class="step">4</span>Living users &amp; trends

--- a/survey/templates/django_registration/activation_failed.html
+++ b/survey/templates/django_registration/activation_failed.html
@@ -9,9 +9,12 @@
 <div class="auth-card auth-message">
     <span class="auth-icon" style="color: #dc3545;">&#10007;</span>
     <h2>{% trans "Activation Failed" %}</h2>
-    <p>{{ activation_error.message }}</p>
+    {% if activation_error.message %}<p>{{ activation_error.message }}</p>{% endif %}
+    <p>{% trans "This activation link may have expired or been used already. You can request a new one." %}</p>
+    {# Deliberately NOT "try registering again": the inactive account still
+       holds this username and email, so re-registering can only fail. #}
     <div class="auth-links" style="margin-top:1.25rem;">
-        <a href="{% url 'django_registration_register' %}">{% trans "Try registering again" %}</a>
+        <a href="{% url 'django_registration_resend_activation' %}">{% trans "Send me a new activation link" %}</a>
     </div>
 </div>
 {% endblock %}

--- a/survey/templates/django_registration/resend_activation_done.html
+++ b/survey/templates/django_registration/resend_activation_done.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Check Your Inbox" %} — Mapsurvey{% endblock %}
+
+{% block content_wrapper_class %}auth-page{% endblock %}
+
+{% block content %}
+<div class="auth-card auth-message">
+    <span class="auth-icon">&#9993;</span>
+    <h2>{% trans "Check Your Inbox" %}</h2>
+    {# Deliberately non-committal: this same page is shown whether or not an
+       email was actually sent, so the flow never reveals which addresses have
+       accounts. Do not add a "we sent it to X" line here. #}
+    <p>{% trans "If that address belongs to an account that hasn't been activated yet, an activation link is on its way. It's valid for 7 days." %}</p>
+    <p style="font-size:.9rem;color:#888">{% trans "Nothing arrived? Check your spam folder, and make sure you used the address you signed up with." %}</p>
+    <div class="auth-links" style="margin-top:1.25rem;">
+        <a href="{% url 'login' %}">{% trans "Back to sign in" %}</a>
+    </div>
+</div>
+{% endblock %}

--- a/survey/templates/django_registration/resend_activation_form.html
+++ b/survey/templates/django_registration/resend_activation_form.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Resend Activation Email" %} — Mapsurvey{% endblock %}
+
+{% block content_wrapper_class %}auth-page{% endblock %}
+
+{% block content %}
+<div class="auth-card">
+    <h2>{% trans "Resend Activation Email" %}</h2>
+    <p class="auth-subtitle">{% trans "Enter the email address you signed up with and we'll send a fresh activation link." %}</p>
+
+    <form method="post" action="">
+        {% csrf_token %}
+        {% for field in form %}
+            {% if field.name == "website" %}
+                {# Honeypot — hidden from humans, present in DOM for naive bots. #}
+                <div style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden" aria-hidden="true">
+                    <label for="{{ field.id_for_label }}">Website</label>
+                    {{ field }}
+                </div>
+            {% else %}
+                <div class="form-group">
+                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    {{ field }}
+                </div>
+            {% endif %}
+        {% endfor %}
+
+        <button type="submit" class="btn-auth">{% trans "Send activation link" %}</button>
+    </form>
+
+    <div class="auth-links">
+        <a href="{% url 'login' %}">{% trans "Back to sign in" %}</a>
+    </div>
+</div>
+{% endblock %}

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -14664,3 +14664,437 @@ class StoriesIndexViewTest(TestCase):
         """
         resp = Client().get("/for-planners/")
         self.assertContains(resp, 'href="/stories/"')
+
+
+# ---------------------------------------------------------------------------
+# activation-funnel-autologin
+# ---------------------------------------------------------------------------
+
+from django.conf import settings
+from django.core import mail
+from django.test import override_settings
+
+
+def _activation_key(username):
+    """Sign an activation key exactly as django-registration does."""
+    from django.core import signing
+    from django_registration.backends.activation import REGISTRATION_SALT
+
+    return signing.dumps(obj=username, salt=REGISTRATION_SALT)
+
+
+# Rate limiting is counted in the cache. The configured backend is Redis with
+# IGNORE_EXCEPTIONS, so when Redis is absent every counter silently no-ops and
+# limits never fire. Pin an in-process cache for limit tests instead.
+_LOCMEM_CACHE = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "activation-funnel-test",
+    }
+}
+
+
+class _InlineThread:
+    """Stand-in for threading.Thread that runs its target synchronously.
+
+    Activation mail is dispatched from a background thread so the response
+    time is the same whether or not mail was sent — that uniformity is what
+    stops the resend endpoint leaking account existence through timing. The
+    side effect is that mail.outbox assertions race the thread. Running the
+    target inline makes them deterministic without altering the code path
+    under test.
+    """
+
+    def __init__(self, target=None, kwargs=None, daemon=None, **_ignored):
+        self._target = target
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(**self._kwargs)
+
+
+class ActivationAutoLoginTest(TestCase):
+    """GET /accounts/activate/ — activation, auto-login, and replay handling."""
+
+    def setUp(self):
+        from django.core.cache import cache
+        User.objects.all().delete()
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="newbie", email="newbie@example.com", password="x"
+        )
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+
+    def _activate(self, key):
+        return self.client.get("/accounts/activate/", {"activation_key": key})
+
+    def test_valid_key_activates_and_signs_user_in(self):
+        """
+        GIVEN an inactive account and a valid, unexpired activation key
+        WHEN the activation URL is opened
+        THEN the account becomes active, the session is authenticated as that
+             user, and the response redirects to LOGIN_REDIRECT_URL
+        """
+        resp = self._activate(_activation_key("newbie"))
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], settings.LOGIN_REDIRECT_URL)
+        self.assertEqual(int(self.client.session["_auth_user_id"]), self.user.pk)
+
+    def test_activation_records_last_login(self):
+        """
+        GIVEN an inactive account with last_login unset
+        WHEN it is activated through the activation URL
+        THEN last_login is populated, as it would be by any interactive login
+        """
+        self.assertIsNone(self.user.last_login)
+
+        self._activate(_activation_key("newbie"))
+
+        self.user.refresh_from_db()
+        self.assertIsNotNone(self.user.last_login)
+
+    def test_expired_key_shows_failure_page_with_resend_link(self):
+        """
+        GIVEN an activation key older than ACCOUNT_ACTIVATION_DAYS
+        WHEN the activation URL is opened
+        THEN the failure page renders and offers the resend flow instead of
+             suggesting re-registration
+        """
+        key = _activation_key("newbie")
+        with override_settings(ACCOUNT_ACTIVATION_DAYS=0):
+            resp = self._activate(key)
+
+        self.assertEqual(resp.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        self.assertContains(resp, "/accounts/activate/resend/")
+        self.assertNotContains(resp, "Try registering again")
+
+    def test_missing_key_shows_failure_page(self):
+        """
+        GIVEN no activation_key querystring parameter
+        WHEN the activation URL is opened
+        THEN the failure page renders rather than raising
+        """
+        resp = self.client.get("/accounts/activate/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Activation Failed")
+
+    def test_replayed_key_on_active_account_redirects_to_login(self):
+        """
+        GIVEN a valid key whose account is already active (mail scanner
+              pre-fetched the link before the human clicked it)
+        WHEN the activation URL is opened again by an anonymous visitor
+        THEN they are redirected to the login page, not the failure page
+        """
+        key = _activation_key("newbie")
+        self._activate(key)          # scanner consumes it
+        self.client.logout()
+
+        resp = self._activate(key)   # human clicks the same link
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(settings.LOGIN_URL, resp["Location"])
+
+    def test_replayed_key_does_not_sign_anyone_in(self):
+        """
+        GIVEN a valid key for an already-active account
+        WHEN an anonymous visitor opens the activation URL
+        THEN no session is created — the key must not work as a reusable
+             login credential for the rest of its validity window
+        """
+        key = _activation_key("newbie")
+        self._activate(key)
+        self.client.logout()
+
+        self._activate(key)
+
+        self.assertNotIn("_auth_user_id", self.client.session)
+
+    def test_replayed_key_while_signed_in_goes_to_editor(self):
+        """
+        GIVEN an already-active account whose owner is signed in
+        WHEN they re-open the activation link (e.g. from history)
+        THEN they land on the editor rather than a failure page
+        """
+        key = _activation_key("newbie")
+        self._activate(key)          # activates and signs in
+
+        resp = self._activate(key)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], settings.LOGIN_REDIRECT_URL)
+
+    def test_key_for_unknown_username_shows_failure_page(self):
+        """
+        GIVEN a correctly signed key naming an account that does not exist
+        WHEN the activation URL is opened
+        THEN the failure page renders and nobody is signed in
+        """
+        resp = self._activate(_activation_key("ghost"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("_auth_user_id", self.client.session)
+
+    def test_activation_window_default_is_seven_days(self):
+        """
+        GIVEN no ACCOUNT_ACTIVATION_DAYS override in the environment
+        WHEN settings are loaded
+        THEN the activation window is 7 days, not the previous 1
+        """
+        self.assertEqual(settings.ACCOUNT_ACTIVATION_DAYS, 7)
+
+
+class ResendActivationTest(TestCase):
+    """POST /accounts/activate/resend/ — re-issue an activation email."""
+
+    URL = "/accounts/activate/resend/"
+
+    def setUp(self):
+        from django.core.cache import cache
+        from .models import AbuseEvent
+        User.objects.all().delete()
+        AbuseEvent.objects.all().delete()
+        cache.clear()
+        mail.outbox = []
+        self.inactive = User.objects.create_user(
+            username="dormant", email="dormant@example.com", password="x"
+        )
+        self.inactive.is_active = False
+        self.inactive.save(update_fields=["is_active"])
+        User.objects.create_user(
+            username="live", email="live@example.com", password="x"
+        )
+
+    def _post(self, email, **overrides):
+        data = {"email": email, "website": ""}
+        data.update(overrides)
+        with mock.patch("threading.Thread", _InlineThread):
+            return self.client.post(self.URL, data)
+
+    def _assert_neutral(self, resp):
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], "/accounts/activate/resend/done/")
+
+    def test_form_renders(self):
+        """
+        GIVEN an anonymous visitor
+        WHEN they open the resend form
+        THEN it renders with an email field
+        """
+        resp = self.client.get(self.URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'name="email"')
+
+    def test_inactive_account_receives_working_activation_link(self):
+        """
+        GIVEN an account that never activated
+        WHEN its email is submitted to the resend form
+        THEN one activation email is sent and its key activates the account
+        """
+        resp = self._post("dormant@example.com")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 1)
+
+        key = _activation_key("dormant")
+        self.client.get("/accounts/activate/", {"activation_key": key})
+        self.inactive.refresh_from_db()
+        self.assertTrue(self.inactive.is_active)
+
+    def test_email_match_is_case_insensitive(self):
+        """
+        GIVEN a registered address stored in lowercase
+        WHEN the resend form is submitted with different casing
+        THEN the activation email is still sent
+        """
+        self._post("DORMANT@Example.COM")
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_unknown_email_sends_nothing_but_looks_identical(self):
+        """
+        GIVEN an email address matching no account
+        WHEN it is submitted to the resend form
+        THEN no mail is sent and the response is the same neutral redirect
+        """
+        resp = self._post("nobody@example.com")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_already_active_account_sends_nothing_but_looks_identical(self):
+        """
+        GIVEN an already-activated account
+        WHEN its email is submitted to the resend form
+        THEN no activation mail is sent and the response is the same neutral
+             redirect, so the flow cannot be used to probe account state
+        """
+        resp = self._post("live@example.com")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_malformed_email_looks_identical(self):
+        """
+        GIVEN an unparseable email address
+        WHEN it is submitted to the resend form
+        THEN the response is the same neutral redirect, not a form-error page
+        """
+        resp = self._post("not-an-email")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_filled_honeypot_sends_nothing_and_logs_event(self):
+        """
+        GIVEN a bot that fills the hidden honeypot field
+        WHEN it submits a real inactive address
+        THEN no mail is sent and one honeypot AbuseEvent is recorded
+        """
+        from .models import AbuseEvent
+
+        resp = self._post("dormant@example.com", website="bot-trap")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(
+            AbuseEvent.objects.filter(defense="honeypot", detail="resend_filled").count(), 1
+        )
+
+    def test_per_ip_rate_limit_stops_mail_and_logs_event(self):
+        """
+        GIVEN the per-IP hourly resend limit set to 1
+        WHEN a second request arrives from the same IP
+        THEN no further mail is sent, the response stays neutral, and a
+             ratelimit AbuseEvent is recorded
+        """
+        from .models import AbuseEvent
+
+        with override_settings(RESEND_ACTIVATION_RATE_LIMIT_HOUR=1,
+                               CACHES=_LOCMEM_CACHE):
+            self._post("dormant@example.com")
+            self.assertEqual(len(mail.outbox), 1)
+            resp = self._post("dormant@example.com")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            AbuseEvent.objects.filter(defense="ratelimit", detail="resend_hour").count(), 1
+        )
+
+    def test_per_email_rate_limit_caps_one_inbox(self):
+        """
+        GIVEN the per-email daily limit set to 1
+        WHEN a second request targets the same address from a different IP
+        THEN no second mail is sent — an attacker rotating IPs still cannot
+             bomb one inbox
+        """
+        from .models import AbuseEvent
+
+        with override_settings(RESEND_ACTIVATION_RATE_LIMIT_DAY=1,
+                               CACHES=_LOCMEM_CACHE), \
+                mock.patch("threading.Thread", _InlineThread):
+            self.client.post(
+                self.URL, {"email": "dormant@example.com", "website": ""},
+                REMOTE_ADDR="10.0.0.1",
+            )
+            self.assertEqual(len(mail.outbox), 1)
+            self.client.post(
+                self.URL, {"email": "dormant@example.com", "website": ""},
+                REMOTE_ADDR="10.0.0.2",
+            )
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            AbuseEvent.objects.filter(defense="ratelimit", detail="resend_day").count(), 1
+        )
+
+    def test_rate_limit_fails_open_when_cache_is_down(self):
+        """
+        GIVEN a cache backend that raises on every call
+        WHEN the resend form is submitted
+        THEN the request is still processed and the mail goes out (fail-open,
+             matching the registration endpoint's accepted trade-off)
+        """
+        with mock.patch(
+            "survey.views.is_ratelimited", side_effect=Exception("redis down")
+        ):
+            resp = self._post("dormant@example.com")
+
+        self._assert_neutral(resp)
+        self.assertEqual(len(mail.outbox), 1)
+
+
+class FunnelActivationStagesTest(TestCase):
+    """Activated / logged-in stages on the creator funnel."""
+
+    def setUp(self):
+        User.objects.all().delete()
+        now = timezone.now()
+        self.month = now.replace(year=2026, month=3, day=10, hour=12,
+                                 minute=0, second=0, microsecond=0)
+        self.key = self.month.strftime("%Y-%m")
+
+        # Never activated.
+        u = _user_at("never_activated", self.month)
+        u.is_active = False
+        u.save(update_fields=["is_active"])
+
+        # Activated but never logged in — the leak this change targets.
+        _user_at("activated_only", self.month)
+
+        # Activated and logged in.
+        signed_in = _user_at("signed_in", self.month)
+        signed_in.last_login = self.month
+        signed_in.save(update_fields=["last_login"])
+
+    def _row(self):
+        from .funnel import CreatorFunnelService
+        rows = CreatorFunnelService().cohort_funnel()
+        return next(r for r in rows if r["cohort"] == self.key)
+
+    def test_activated_counts_only_active_accounts(self):
+        """
+        GIVEN one inactive and two active registrations in a cohort
+        WHEN the cohort funnel is computed
+        THEN the activated stage counts the two active accounts
+        """
+        row = self._row()
+        self.assertEqual(row["regs"], 3)
+        self.assertEqual(row["activated"], 2)
+
+    def test_logged_in_counts_only_users_who_signed_in(self):
+        """
+        GIVEN an active account that never logged in and one that did
+        WHEN the cohort funnel is computed
+        THEN only the latter counts in the logged-in stage
+        """
+        self.assertEqual(self._row()["logged_in"], 1)
+
+    def test_alltime_totals_include_the_new_stages(self):
+        """
+        GIVEN cohorts carrying activated and logged-in counts
+        WHEN all-time totals are computed
+        THEN the totals row sums both new stages
+        """
+        from .funnel import CreatorFunnelService
+        totals = CreatorFunnelService().alltime_totals()
+        self.assertEqual(totals["activated"], 2)
+        self.assertEqual(totals["logged_in"], 1)
+
+    def test_dashboard_renders_the_new_columns(self):
+        """
+        GIVEN a staff user
+        WHEN they open the funnel dashboard
+        THEN the cohort table shows Activated and Logged in columns
+        """
+        User.objects.create_superuser("boss2", "boss2@example.com", "x")
+        c = Client()
+        c.login(username="boss2", password="x")
+        resp = c.get(reverse("admin:survey_funnelreport_changelist"))
+        self.assertContains(resp, "Activated")
+        self.assertContains(resp, "Logged")

--- a/survey/views.py
+++ b/survey/views.py
@@ -54,6 +54,7 @@ from .serialization import (
 from .abuse import (
     HONEYPOT_FIELD_NAME,
     RegistrationAbuseForm,
+    ResendActivationForm,
     client_ip,
     log_abuse_event,
     verify_turnstile,
@@ -198,26 +199,156 @@ class AbuseProtectedRegistrationView(AsyncEmailRegistrationView):
 class DirectActivationView(
     __import__('django_registration.backends.activation.views', fromlist=['ActivationView']).ActivationView
 ):
-    """Activate account directly on GET without showing a form."""
+    """Activate account directly on GET without showing a form.
+
+    On success the user is logged in and sent straight to the editor. Making
+    them re-enter credentials they typed two minutes earlier was the measured
+    drop-off point: 24 accounts were active but had never logged in. See
+    openspec/changes/activation-funnel-autologin/design.md (D1).
+    """
+
+    AUTH_BACKEND = "survey.backends.EmailOrUsernameBackend"
 
     def get(self, request, *args, **kwargs):
+        from django_registration.backends.activation.forms import ActivationForm
+        from django_registration.exceptions import ActivationError
+
         activation_key = request.GET.get("activation_key")
         if not activation_key:
-            from django_registration.exceptions import ActivationError
             return self.activation_failure(ActivationError("Missing activation key."))
         try:
-            from django_registration.backends.activation.forms import ActivationForm
             form = ActivationForm(data={"activation_key": activation_key})
-            if form.is_valid():
+            if not form.is_valid():
+                # Expired or tampered signature.
+                return render(
+                    request, "django_registration/activation_failed.html", {"form": form}
+                )
+            try:
                 activated_user = self.activate(form)
-                return redirect("django_registration_activation_complete")
-            else:
-                return render(request, "django_registration/activation_failed.html", {"form": form})
+            except ActivationError as error:
+                return self._activation_error_response(request, form, error)
+            # Sign in only on the genuine inactive -> active transition. That
+            # makes the key single-use as a credential: replaying it lands in
+            # the already_activated branch below, which does NOT sign anyone in.
+            return self._signed_in_redirect(request, activated_user)
         except Exception:
             return render(request, "django_registration/activation_failed.html", {})
 
+    def _activation_error_response(self, request, form, error):
+        """Handle ActivationError from activate().
+
+        `already_activated` with a still-valid key is not a real failure: mail
+        scanners routinely pre-fetch links, so activation may already have
+        happened before the human clicked. Route them onward rather than
+        dead-ending on the failure page.
+
+        We deliberately do NOT sign them in here. Auto-login on a replayable
+        key would turn the activation link into a bearer token good for the
+        whole ACCOUNT_ACTIVATION_DAYS window: anyone who later obtained the
+        email (forward, shared inbox, history sync) could sign in as the user.
+        Activation itself is safe to auto-login because it can only ever
+        succeed once. See design.md Risks.
+        """
+        if getattr(error, "code", None) == "already_activated":
+            if request.user.is_authenticated:
+                return redirect(conf_settings.LOGIN_REDIRECT_URL)
+            return redirect(f"{conf_settings.LOGIN_URL}?activated=1")
+        return render(
+            request,
+            "django_registration/activation_failed.html",
+            {"form": form, "activation_error": {
+                "message": getattr(error, "message", ""),
+                "code": getattr(error, "code", ""),
+            }},
+        )
+
+    def _signed_in_redirect(self, request, user):
+        """Log the freshly activated `user` in and redirect to the editor."""
+        from django.contrib.auth import login as auth_login
+
+        if user is None or not user.is_active:
+            return render(request, "django_registration/activation_failed.html", {})
+        # Explicit backend: login() normally reads user.backend, set by
+        # authenticate() — which never runs on this path.
+        auth_login(request, user, backend=self.AUTH_BACKEND)
+        return redirect(conf_settings.LOGIN_REDIRECT_URL)
+
     def activation_failure(self, error):
         return render(self.request, "django_registration/activation_failed.html", {})
+
+
+class ResendActivationView(AsyncEmailRegistrationView):
+    """Re-send an activation email for an account that never activated.
+
+    Subclasses the registration view purely to reuse its activation-key
+    generation and threaded HTML mail sending — it never registers anyone.
+
+    Every POST ends at the same neutral confirmation page, whatever happened:
+    email sent, address unknown, account already active, honeypot filled, or
+    rate limit hit. That uniformity is the anti-enumeration property, so keep
+    it if you touch this. Mail goes out only for an existing INACTIVE account,
+    at most RESEND_ACTIVATION_RATE_LIMIT_DAY times per address per day.
+
+    See openspec/changes/activation-funnel-autologin/design.md (D3).
+    """
+
+    form_class = ResendActivationForm
+    template_name = "django_registration/resend_activation_form.html"
+
+    def get(self, request, *args, **kwargs):
+        return render(request, self.template_name, {"form": ResendActivationForm()})
+
+    def post(self, request, *args, **kwargs):
+        from django.contrib.auth import get_user_model
+
+        # 1. Honeypot — read raw, before validation (same rationale as
+        # AbuseProtectedRegistrationView.post).
+        if request.POST.get(HONEYPOT_FIELD_NAME, "").strip():
+            log_abuse_event("honeypot", request, "resend_filled")
+            return self._neutral_response(request)
+
+        # 2. Rate limits. Per-IP hourly caps a single attacker; per-email daily
+        # caps how much mail any one inbox can be made to receive even from
+        # rotating IPs. Fail-open on cache errors, as with registration.
+        limits = (
+            ("resend_activation_hour",
+             f"{conf_settings.RESEND_ACTIVATION_RATE_LIMIT_HOUR}/h",
+             "survey.abuse.ratelimit_key", "resend_hour"),
+            ("resend_activation_day",
+             f"{conf_settings.RESEND_ACTIVATION_RATE_LIMIT_DAY}/d",
+             "survey.abuse.ratelimit_email_key", "resend_day"),
+        )
+        for group, rate, key, detail in limits:
+            try:
+                limited = is_ratelimited(
+                    request=request, group=group, fn=None,
+                    key=key, rate=rate, method="POST", increment=True,
+                )
+            except Exception:
+                limited = False
+            if limited:
+                log_abuse_event("ratelimit", request, detail)
+                # Neutral, not 429: a 429 here would confirm to an attacker
+                # that they found a real throttle worth routing around, and
+                # would differ from the response an ordinary user gets.
+                return self._neutral_response(request)
+
+        form = ResendActivationForm(data=request.POST)
+        if not form.is_valid():
+            return self._neutral_response(request)
+
+        email = form.cleaned_data["email"]
+        User = get_user_model()
+        user = User.objects.filter(email__iexact=email, is_active=False).first()
+        if user is not None:
+            # Keys are stateless signed values, so "re-issuing" is just signing
+            # the username again — no DB write, and any older key for the same
+            # account stays valid until its own expiry.
+            self.send_activation_email(user)
+        return self._neutral_response(request)
+
+    def _neutral_response(self, request):
+        return redirect("django_registration_resend_activation_done")
 
 
 def resolve_survey(survey_slug):


### PR DESCRIPTION
## Why

Production funnel data (2026-07-27) showed two leaks before users ever reach the product:

- **53 accounts never activated** — the emailed link was never clicked, or clicked too late.
- **24 accounts activated but never logged in** — they clicked the link and then stopped.

The second cohort is disproportionately institutional: a state education department, a housing association, a county government, two universities. These are exactly the accounts outreach is trying to convert.

Three causes, all addressed here.

## What changed

**1. Auto-login after activation.** Activation used to redirect to a page whose only affordance was a "Sign In" button — asking users to re-enter credentials they had typed two minutes earlier. That was the measured drop-off point. They now land authenticated in `/editor/`.

**2. `ACCOUNT_ACTIVATION_DAYS` 1 → 7** (django-registration's own default), env-overridable. A 24-hour window dead-ends anyone who opens their mail the next day.

**3. Resend-activation flow.** The failure page previously offered "try registering again", which can only fail — the inactive account still holds the username and email. It now links to `/accounts/activate/resend/`, which issues a fresh link.

**4. Funnel dashboard gains Activated and Logged-in stages** between Regs and Created, so this leak is visible per cohort and the fix is measurable going forward.

## Two decisions worth reviewing

**Auto-login fires only on the genuine inactive→active transition, never on a replay.** The design originally allowed signing in on an already-activated key too (nicer for the mail-scanner-then-human sequence). Rejected during implementation: activation keys stay valid for the whole window, so signing in on replay would turn the emailed link into a login credential good for 7 days — a forwarded message, shared inbox or synced browser history would mean account takeover. Activation itself is safe to auto-login because it can only succeed once. Replays redirect to the login form, which still fixes the scanner dead-end. Locked in by `test_replayed_key_does_not_sign_anyone_in`.

**The resend endpoint is treated as a bombing vector, not a convenience.** It emails an address its caller need not control, which makes it more attractive than registration — already abused in May 2026. It reuses the registration defenses (honeypot, per-IP hourly limit) and adds a **per-email daily limit** so an attacker rotating IPs still cannot hammer one inbox. Every outcome — sent, unknown address, already active, malformed, honeypot, throttled — returns the same neutral redirect, and mail is dispatched off-thread so response *time* stays uniform as well. Both channels matter: either would otherwise reveal which addresses have accounts. That is also why throttling returns the neutral page rather than a 429.

## Notes

- **No migrations.** Over-limit hits reuse the existing `AbuseEvent.defense` choices and are distinguished by `detail` (`resend_hour`, `resend_day`, `resend_filled`).
- Two test-harness details that are easy to regress, documented in `tasks.md`:
  - Rate-limit tests must pin `CACHES` to LocMem — the configured Redis backend runs with `IGNORE_EXCEPTIONS`, so without Redis the counters silently no-op and limit tests pass vacuously.
  - `_InlineThread` makes `mail.outbox` assertions deterministic without removing the background send (the send stays threaded on purpose — see above).

## Testing

`./run_tests.sh survey`: **711 → 734 tests, +23, no new failures.** The 2 remaining errors are pre-existing in `LastActivityMiddlewareTest` (unrelated `UserActivity` middleware) and present on `master`.

Not visually inspected in a browser — templates are exercised by real rendering in tests, but a look at the two new pages before merge would be worthwhile.

## Spec

OpenSpec change `activation-funnel-autologin`: new `account-activation` capability, delta on `creator-funnel-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
