### PR TITLE
fix(survey-form): stop clipping rating labels, widen sub-question popup

### DIFF
--- a/openspec/backlog/bug-rating-text-labels-clipped.md
+++ b/openspec/backlog/bug-rating-text-labels-clipped.md
@@ -1,0 +1,73 @@
+# Rating question clips text labels
+
+**Type**: bug
+**Priority**: high
+**Area**: frontend
+**Created**: 2026-07-28
+
+> **Promoted to the OpenSpec change `fix-geo-form-ui` on 2026-07-28 and fixed there.**
+> The CSS now sizes rating options to their content and wraps long labels.
+
+## Description
+
+A `rating` question whose choices are words instead of numbers renders unreadably: every
+option is forced to the same width and the label is cut off mid-word. With five options
+like "very unsure / rather unsure / undecided / rather confident / very confident" the
+respondent sees "very unsur", "rather unsur", "undecid", "rather confide", "very confident".
+
+The option text is never wrapped and never truncated gracefully — it simply overflows its
+box. Any survey author who builds a Likert scale with worded anchors (the most common form
+of a rating scale) hits this.
+
+## Root cause
+
+`survey/assets/css/main.css:325`
+
+```css
+.question-card--rating > div > div {
+  flex: 1;
+  min-width: 0;
+}
+```
+
+- `flex: 1` resolves to `flex-basis: 0`, so all options get **identical width regardless of
+  label length**, driven by the container, not the content.
+- `min-width: 0` allows each cell to shrink below its content width.
+- The label (`.question-card--rating label:has(input[type="radio"])`, line 330) sets
+  `flex-direction: column` and `text-align: center` but no `overflow-wrap` / `hyphens`, so
+  long words neither wrap nor break.
+- `flex-wrap: wrap` on the parent (line 320) does not help: it wraps *items*, and items with
+  a zero flex-basis always fit on one line.
+
+The widget itself is a plain `forms.ChoiceField` + `RadioSelect` (`survey/forms.py:212-214`),
+so nothing constrains label length at the form layer either.
+
+## Reproduce
+
+1. Create a question with `input_type: rating`.
+2. Give it 5 choices with worded labels, e.g. "very unsure" … "very confident".
+3. Open the survey on a desktop viewport — labels are clipped.
+
+Live example while it lasts: the ThINK demo survey,
+`user_surveys/waermeplanung_quedlinburg_demo/`, section "Your view of the neighbourhood".
+
+## Proposed fix
+
+Rating scales with worded anchors are standard in survey tooling, so the fix should make
+them a first-class case rather than telling authors to use numbers:
+
+1. **Let the content drive the width.** Replace `flex: 1; min-width: 0` with something like
+   `flex: 1 1 auto; min-width: min-content`, and add `overflow-wrap: anywhere` (or
+   `hyphens: auto`) on the label so long words wrap instead of overflowing.
+2. **Wrap to a second row** when the labels genuinely do not fit — `flex-wrap: wrap` already
+   exists and starts working once the basis is content-driven.
+3. **Consider the anchor-label pattern** used by Qualtrics/SurveyMonkey for long scales:
+   numbered buttons `1 … 5` with the worded poles printed under the two ends. Cleaner than
+   five long labels at any viewport, and it keeps the numeric coding in the data.
+4. **Fall back to a vertical list** when labels exceed a length threshold — at some point a
+   horizontal segmented control is the wrong control.
+
+## Notes
+
+- Test at mobile width as well; the desktop case is already broken, mobile will be worse.
+- Related: the same survey exposed [Sub-question popup is too narrow](bug-subquestion-popup-too-narrow.md).

--- a/openspec/backlog/bug-subquestion-popup-too-narrow.md
+++ b/openspec/backlog/bug-subquestion-popup-too-narrow.md
@@ -1,0 +1,76 @@
+# Sub-question popup is too narrow (Leaflet default width)
+
+**Type**: bug
+**Priority**: high
+**Area**: frontend
+**Created**: 2026-07-28
+
+> **Promoted to the OpenSpec change `fix-geo-form-ui` on 2026-07-28.** The width/height
+> defaults were fixed there. The **side-panel redesign** described under "Longer-term"
+> was deliberately left out of that change and is still open.
+
+## Description
+
+When a geo question has several sub-questions, the popup that opens after placing a
+point/line/polygon is a narrow 300px column with an internal scrollbar. The respondent has
+to scroll a long list of radio groups inside a small box floating over the map, while the
+popup simultaneously hides the feature being described.
+
+This matters more than it looks: sub-questions of a geo question are the **only** way to get
+attributes into the exported GeoJSON `properties` (see `survey/views.py:941`), so any survey
+that produces a usable attribute layer is pushed into exactly this pattern. The richer the
+data model, the worse the form.
+
+## Root cause
+
+`survey/templates/base_survey_template.html:383` (and the duplicate at `:513`)
+
+```js
+layer.bindPopup(_buildPopupHtml(formId, sqHtml), {
+    maxHeight: $(document).height()*0.8,
+});
+```
+
+**`maxWidth` is never set**, so Leaflet's default of 300px applies. Height is configured;
+width is not. Note also that `maxHeight` is derived from `$(document).height()`, which is the
+document, not the viewport — on a long page this can exceed the visible area.
+
+## Reproduce
+
+1. Create a `point` question and attach 6-8 `choice` sub-questions.
+2. Open the survey, place a point.
+3. The popup is ~300px wide with a scrollbar; options wrap onto two lines each.
+
+Live example: the ThINK demo survey (`user_surveys/waermeplanung_quedlinburg_demo/`), where
+the building point carries 8 attribute sub-questions.
+
+## Proposed fix
+
+**Do not expose width/height as author-facing settings.** The survey author does not know the
+respondent's screen, will mostly leave the default alone, and can only make it worse. Ship
+sensible defaults first; a per-survey override can come later if a real case demands it.
+
+```js
+maxWidth:  Math.min(520, $(window).width() * 0.9),
+minWidth:  300,
+maxHeight: $(window).height() * 0.7,
+```
+
+- Width driven by the **viewport**, capped around 520px so desktop gets a comfortable column
+  and mobile gets nearly the full screen.
+- Height from `$(window).height()`, not `$(document).height()`.
+- Apply to **both** call sites (`:383` and `:513`) — they are currently duplicated.
+
+## Longer-term
+
+A form of 8 attributes does not belong in a popup over the map at all. In GIS tooling the
+attribute form lives in a **side panel**: there is room, the map stays visible, and the
+feature being edited is not covered by its own form. Worth a separate change proposal —
+render sub-questions in the left panel (with the feature highlighted on the map) instead of,
+or in addition to, the popup.
+
+## Notes
+
+- Raised by the user 2026-07-28 while reviewing the ThINK demo.
+- Related: [Rating question clips text labels](bug-rating-text-labels-clipped.md),
+  [Image sub-question breaks point placement](bug-image-subquestion-breaks-geo-point.md).

--- a/openspec/changes/fix-geo-form-ui/.openspec.yaml
+++ b/openspec/changes/fix-geo-form-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-geo-form-ui/proposal.md
+++ b/openspec/changes/fix-geo-form-ui/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Two rendering defects make the respondent-facing form look broken in exactly the
+configurations we recommend to serious users. Both surfaced while building a demo survey
+for a prospective German client (ThINK Jena, kommunale Wärmeplanung), but neither is
+specific to that survey — any author hitting the same, entirely ordinary, patterns sees
+the same result.
+
+1. **`rating` clips worded labels** (backlog #85). A Likert scale with worded anchors
+   ("very unsure" … "very confident") renders as five equal-width boxes with the text cut
+   off mid-word. Worded anchors are the *normal* form of a rating scale, so this is not an
+   edge case.
+2. **Sub-question popup is 300px wide** (backlog #86). Sub-questions of a geo question are
+   the only route for attributes to reach the exported GeoJSON `properties`
+   (`survey/views.py:941`), so every survey that produces a usable attribute layer is
+   pushed into this pattern. With 6-8 sub-questions the respondent scrolls a narrow column
+   floating over the map, which also hides the feature being described.
+
+## What Changes
+
+- **Rating options size to their content and wrap.** Replace the fixed `flex: 1` /
+  `min-width: 0` sizing with content-driven sizing plus word wrapping, so long labels wrap
+  (and, when needed, the row wraps) instead of overflowing their box.
+- **Sub-question popup gets a sensible width and a viewport-based height.** Set `maxWidth`
+  (currently unset, so Leaflet's 300px default applies) and `minWidth`, and derive
+  `maxHeight` from the viewport rather than the document. Applied at both `bindPopup` call
+  sites, which are currently duplicated.
+
+Explicitly **not** in scope: exposing popup width/height as author-facing settings. The
+survey author cannot know the respondent's screen and would mostly leave the default alone;
+the default has to be right on its own. Also out of scope: moving the attribute form from
+the popup into a side panel — worth doing, but a separate, larger change.
+
+## Capabilities
+
+### Modified Capabilities
+- `survey-response-form`: rating options wrap instead of clipping; geo sub-question popups
+  size to the viewport instead of Leaflet's default.
+
+## Impact
+
+- `survey/assets/css/main.css` — rating layout rules (~line 318-345). Requires
+  `collectstatic`.
+- `survey/templates/base_survey_template.html` — `bindPopup` options at both call sites
+  (~line 383 and ~line 513).
+- No model, migration, or API changes. No data migration. Purely presentational.
+- Risk: low, but the CSS change alters the visual width of rating buttons for every
+  existing survey using that type — they become content-sized rather than equal-width.
+  Numeric scales (1-5) keep looking essentially the same because their labels are equally
+  short.

--- a/openspec/changes/fix-geo-form-ui/tasks.md
+++ b/openspec/changes/fix-geo-form-ui/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## 1. Rating: stop clipping worded labels (backlog #85)
+
+- [x] 1.1 In `survey/assets/css/main.css`, change `.question-card--rating > div > div`
+      from `flex: 1; min-width: 0` to content-driven sizing (`flex: 1 1 auto`,
+      `min-width: min-content`) so an option is never squeezed below its text.
+- [x] 1.2 On `.question-card--rating label:has(input[type="radio"])`, add `width: 100%`,
+      `overflow-wrap: anywhere` and `hyphens: auto` so a long single word wraps rather
+      than overflowing. Padding raised from `8px 4px` to `8px 8px` for breathing room.
+- [x] 1.3 Verify the existing `flex-wrap: wrap` now actually wraps a long scale onto a
+      second row once the basis is content-driven. Confirmed: the five-option scale
+      "very unsure … very confident" wraps to three rows in the 350px side panel, all
+      labels fully readable.
+- [x] 1.4 Check that a numeric scale (1-5) still renders as evenly sized buttons —
+      equal-length labels give equal widths via `flex-grow`.
+
+## 2. Sub-question popup width (backlog #86)
+
+- [x] 2.1 Added `_subquestionPopupOptions()` in
+      `survey/templates/base_survey_template.html` (next to `_buildPopupHtml`) returning
+      `maxWidth: min(520, 90vw)`, `minWidth: min(300, 90vw)`,
+      `maxHeight: 70vh` — width was previously unset, so Leaflet's 300px default applied.
+- [x] 2.2 Both `bindPopup` call sites now use the shared helper instead of duplicating
+      inline options, so they cannot drift apart again.
+- [x] 2.3 Verified with the 8-sub-question building form: popup renders at 520px on a
+      1854px viewport (was 300px). Options that previously wrapped onto two lines each
+      now fit on one. A scrollbar remains for 8 groups, which is expected — the deeper
+      fix is the side-panel redesign left open in backlog #86.
+
+## 3. Verify
+
+- [x] 3.1 `python manage.py collectstatic --noinput` — 2 files copied, 169 post-processed.
+- [x] 3.2 Checked in a browser against the local Quedlinburg demo survey (id 720), which
+      still carries the original worded rating scale and the 8-sub-question geo point.
+- [x] 3.3 `./run_tests.sh survey` — **711 tests, OK**.
+- [x] 3.4 Backlog #85 struck through in `openspec/backlog/INDEX.md`; both files carry a
+      "promoted to `fix-geo-form-ui`" note. #86 stays open for the side-panel redesign.
+
+## 4. Not done here (deliberate)
+
+- Author-facing settings for popup width/height — rejected in the proposal: the author
+  cannot know the respondent's screen, so the default has to be right on its own.
+- Moving the attribute form from the popup into a side panel — larger change, still
+  tracked under backlog #86.

--- a/survey/assets/css/main.css
+++ b/survey/assets/css/main.css
@@ -323,8 +323,11 @@ ul {
 }
 
 .question-card--rating > div > div {
-  flex: 1;
-  min-width: 0;
+  /* Content-driven basis: options never shrink below their label, so worded
+     scales ("very unsure" ... "very confident") wrap instead of being clipped.
+     flex-grow still shares any leftover space evenly. */
+  flex: 1 1 auto;
+  min-width: min-content;
 }
 
 .question-card--rating label:has(input[type="radio"]) {
@@ -333,8 +336,11 @@ ul {
   align-items: center;
   justify-content: center;
   min-height: 48px;
-  padding: 8px 4px;
+  padding: 8px 8px;
   margin: 0;
+  width: 100%;
+  overflow-wrap: anywhere;
+  hyphens: auto;
   border-radius: var(--radius-sm);
   border: 1px solid var(--input-border);
   background: var(--input-bg);

--- a/survey/templates/base_survey_template.html
+++ b/survey/templates/base_survey_template.html
@@ -341,6 +341,17 @@
             + '</div></form>';
     }
 
+    // Sub-question forms can hold many fields, so Leaflet's 300px default is far
+    // too narrow. Size to the viewport (not the document): a comfortable column on
+    // desktop, nearly full width on a phone.
+    function _subquestionPopupOptions() {
+        return {
+            maxWidth: Math.min(520, Math.round($(window).width() * 0.9)),
+            minWidth: Math.min(300, Math.round($(window).width() * 0.9)),
+            maxHeight: Math.round($(window).height() * 0.7)
+        };
+    }
+
     function _getDrawButtonAttrs(questionCode) {
         var btn = $('button.drawbutton[name="' + questionCode + '"]');
         return {
@@ -380,9 +391,7 @@
 
         var sqHtml = window._subquestionsForms[currentQ] || '';
 
-        layer.bindPopup(_buildPopupHtml(formId, sqHtml), {
-            maxHeight: $(document).height()*0.8,
-        });
+        layer.bindPopup(_buildPopupHtml(formId, sqHtml), _subquestionPopupOptions());
 
         layer.on("popupopen", onPopupOpen);
         layer.on("popupclose", onPopupClose);
@@ -510,9 +519,7 @@
                     layer._formId = formId;
                     var sqHtml = window._subquestionsForms[questionCode] || '';
 
-                    layer.bindPopup(_buildPopupHtml(formId, sqHtml), {
-                        maxHeight: $(document).height()*0.8,
-                    });
+                    layer.bindPopup(_buildPopupHtml(formId, sqHtml), _subquestionPopupOptions());
 
                     layer.on("popupopen", onPopupOpen);
                     layer.on("popupclose", onPopupClose);


### PR DESCRIPTION
Fixes two rendering defects in the respondent-facing form. Both hit ordinary
configurations rather than edge cases, and both surfaced while building a demo survey
for a prospective client.

## Rating clips worded labels (backlog #85)

A Likert scale with worded anchors — "very unsure" … "very confident" — rendered with
the text cut off mid-word.

`.question-card--rating > div > div` used `flex: 1` (which resolves to `flex-basis: 0`)
plus `min-width: 0`, so every option took the container's width regardless of its label,
and long words neither wrapped nor broke. The existing `flex-wrap: wrap` could not help:
it wraps items, and items with a zero basis always fit on one line.

Options are now content-sized (`flex: 1 1 auto`, `min-width: min-content`) with
`overflow-wrap: anywhere` / `hyphens: auto` on the label. Long scales now wrap onto
another row instead of clipping. Numeric scales (1-5) look the same as before, because
equal-length labels still get equal widths from `flex-grow`.

## Sub-question popup was 300px wide (backlog #86)

`maxWidth` was never passed to `bindPopup`, so Leaflet's 300px default applied, and
`maxHeight` was derived from `$(document).height()` rather than the viewport.

This matters more than it looks: sub-questions of a geo question are the **only** route
for attributes to reach the exported GeoJSON `properties` (`survey/views.py:941`), so
every survey that produces a usable attribute layer is pushed into exactly this popup.
The richer the data model, the worse the form.

Both call sites now share a `_subquestionPopupOptions()` helper — `min(520, 90vw)` wide,
`70vh` tall — instead of duplicating inline options that could drift apart.

## Verification

- Checked against a survey with a worded rating scale and a geo point carrying 8
  sub-questions: the popup renders at 520px instead of 300px, and options that
  previously wrapped onto two lines each now fit on one.
- `./run_tests.sh survey` — **711 tests, OK**.
- `collectstatic` run locally; `staticfiles/` is gitignored and rebuilt on deploy.

## Out of scope, deliberately

- **Author-facing width/height settings.** The survey author cannot know the
  respondent's screen and would mostly leave the default alone, so the default has to be
  right on its own.
- **Side-panel redesign.** A form of 8 attributes does not belong in a popup over the
  map — in GIS tooling it lives in a side panel, where the map stays visible and the
  feature is not covered by its own form. Larger change; stays open in backlog #86.

OpenSpec change: `openspec/changes/fix-geo-form-ui/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)