### PR TITLE
[DO NOT MERGE] loadtest baseline — master app config for PR #47 comparison

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,10 @@ services:
   - type: redis
     name: mapsurvey-redis
     plan: free
+    # Render allows one free Key Value instance per workspace and production
+    # holds it, so previews must use a paid plan (prorated for the hours the
+    # preview lives) or their whole sync fails on this resource.
+    previewPlan: starter
     ipAllowList: []
 
   - type: web
@@ -108,6 +112,10 @@ services:
     name: mapsurvey-celery
     runtime: docker
     plan: starter
+    # Previews exist to exercise the web service (PR review, load tests); the
+    # async email worker and the metrics cron only add per-hour instance cost.
+    previews:
+      generation: off
     dockerfilePath: ./Dockerfile
     dockerContext: .
     dockerCommand: celery -A mapsurvey worker -l info --concurrency 2
@@ -162,6 +170,8 @@ services:
     name: mapsurvey-acquisition-sync
     runtime: docker
     plan: starter
+    previews:
+      generation: off
     schedule: "0 5 * * *"
     dockerfilePath: ./Dockerfile
     dockerContext: .

--- a/survey/management/commands/seed_loadtest_survey.py
+++ b/survey/management/commands/seed_loadtest_survey.py
@@ -1,0 +1,75 @@
+"""
+Seed a published one-question point survey for load testing.
+
+Reproduces the shape of the survey that collapsed under a lecture-hall burst on
+2026-07-13: a single section with one `point` question. Used to give a Render PR
+preview (which always starts with an empty database) something to load-test, so
+baseline and fixed builds are measured against identical content.
+
+Idempotent — re-running returns the existing survey instead of creating a second.
+
+Usage:
+    python manage.py seed_loadtest_survey
+    python manage.py seed_loadtest_survey --name my-load-test
+"""
+from django.contrib.gis.geos import Point
+from django.core.management.base import BaseCommand
+
+from survey.models import Organization, Question, SurveyHeader, SurveySection
+
+
+class Command(BaseCommand):
+    help = 'Seed a published single-point survey for load testing'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--name',
+            type=str,
+            default='loadtest-lecture',
+            help='Survey name (default: loadtest-lecture)',
+        )
+
+    def handle(self, *args, **options):
+        name = options['name']
+
+        existing = SurveyHeader.objects.filter(name=name, is_canonical=True).first()
+        if existing:
+            self.stdout.write(f'Survey "{name}" already exists.')
+            self._report(existing)
+            return
+
+        org, _ = Organization.objects.get_or_create(
+            slug='loadtest',
+            defaults={'name': 'Load Test'},
+        )
+        survey = SurveyHeader.objects.create(
+            name=name,
+            organization=org,
+            status='published',
+        )
+        section = SurveySection.objects.create(
+            survey_header=survey,
+            name='section_1',
+            title='Where are you from?',
+            subheading='Drop a pin on your place of origin',
+            code='S1',
+            is_head=True,
+            start_map_postion=Point(13.405, 52.52),
+            start_map_zoom=4,
+        )
+        Question.objects.create(
+            survey_section=section,
+            code='Q001',
+            order_number=1,
+            name='Your place of origin',
+            input_type='point',
+            required=True,
+        )
+
+        self.stdout.write(self.style.SUCCESS(f'Created survey "{name}".'))
+        self._report(survey)
+
+    def _report(self, survey):
+        self.stdout.write(f'uuid:   {survey.uuid}')
+        self.stdout.write(f'status: {survey.status}')
+        self.stdout.write(f'path:   /surveys/{survey.uuid}/section_1/')


### PR DESCRIPTION
Exists only to make Render generate a preview running the **pre-fix** configuration (1 gunicorn sync worker, non-manifest static) so the load test in #47 has a baseline on identical hardware.

Carries only the preview deployability fixes (redis `previewPlan`, celery/cron skipped in previews) and the seed command. Deliberately excludes the `WEB_CONCURRENCY` env vars — gunicorn honors that variable natively, which would silently turn this baseline into 2 workers.

Close without merging once #47's load test results are recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)