### PR TITLE
fix(export): correct the values in the respondent-data download

### DIFF
--- a/openspec/changes/export-data-integrity/.openspec.yaml
+++ b/openspec/changes/export-data-integrity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/export-data-integrity/design.md
+++ b/openspec/changes/export-data-integrity/design.md
@@ -1,0 +1,162 @@
+## Context
+
+`_export_survey_data` (`survey/views.py:1053`) builds the respondent-data ZIP: one GeoJSON layer per
+geo question, plus one CSV for everything else. Both branches translate an `Answer` row into a cell
+value, and both do it with the same hand-written `elif` chain over `input_type`, duplicated:
+
+| | GeoJSON sub-question loop (`:1099-1123`) | CSV loop (`:1166-1188`) |
+|---|---|---|
+| `text`, `text_line` | `answer.text` | `answer.text` |
+| `number`, `range` | `numeric`, else `selected_choices[0]`, else `""` | identical |
+| `choice`, `rating` | first choice name | identical |
+| `multichoice` | choice names joined by `"; "` | identical |
+| anything else | *falls through, no assignment* | `else: continue` |
+
+The two chains are byte-for-byte equivalent except in how they end, and that ending is where both
+bugs live. The GeoJSON branch compounds it by initialising the accumulator once before the loop
+(`:1098`) rather than per iteration, so a fall-through does not merely produce nothing — it
+produces the previous sub-question's value.
+
+The fall-through is reached more often than it looks. Sub-answers are written only for keys present
+in the submitted feature's `properties` (`views.py:841`), so a sub-question the respondent left
+blank has **no `Answer` row at all**; `subAnswers()` then yields an empty list for it, no branch
+assigns, and the stale value is written out under that sub-question's name. A `datetime`, `image`
+or `html` sub-question falls through the same way regardless of whether it was answered.
+
+Constraints worth stating: the export view is unauthenticated for public surveys and must not raise
+on unexpected data — denying someone their data is a worse failure than an imperfect cell. The
+output is consumed by QGIS and Excel, so column presence and stability matter as much as values.
+There is no migration surface here; this is a read path only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A sub-question's exported property depends only on that sub-question's own answer.
+- `datetime` answers reach the CSV.
+- An input type that no branch handles cannot silently disappear from the download.
+- Value-level test coverage: assert which value lands in which column and property, including the
+  partially-filled sub-question case that produced the bug.
+- Confirm or refute that the accumulator fix also resolves backlog #23 (number sub-question exports
+  blank), rather than assuming it.
+
+**Non-Goals:**
+
+- The CASCADE deletion of answers when a question is removed (backlog #98). Different code path,
+  different decision, tracked separately.
+- The asymmetry where the sub-answer *save* path branches on `sub_question.choices` rather than
+  `input_type` (`views.py:845-856`), which means a `choice` sub-question with no choices defined
+  silently stores nothing. Real, but a write-path bug; fixing it here would mix a data-collection
+  change into a data-export change.
+- Adding media, ranking or scale types to the export (backlog #102) — the allowlist introduced here
+  is what makes adding them safe later.
+- Shapefile / GeoPackage output (backlog #8).
+
+## Decisions
+
+### D1 — Extract one shared cell formatter instead of fixing each chain in place
+
+Replace both duplicated chains with a single helper, `_answer_cell(question, answers)`, returning
+the formatted value for one question from that question's answer rows. Both call sites use it.
+
+*Why over the minimal fix:* moving `result = ""` inside the loop is two characters and repairs the
+symptom, but leaves two copies of the same chain that already drifted apart once — the drift *is*
+the bug. With one formatter there is no accumulator to leak across iterations, because each call
+returns its own value; the bug becomes structurally unavailable rather than merely absent.
+
+*Cost:* a larger diff than the symptom fix, touching the CSV path which nobody reported as broken.
+Mitigated by the fact that the chains are provably equivalent today (table above), so the CSV
+branch's observable behaviour is unchanged except for the two intended fixes. The tests added under
+D5 pin the existing CSV behaviour before the refactor lands.
+
+### D2 — Classify input types explicitly; no bare `else`
+
+The helper dispatches on three named sets rather than falling off the end of a chain:
+
+- **value types** — `text`, `text_line`, `number`, `range`, `choice`, `rating`, `multichoice`,
+  `datetime`: formatted as today, with `datetime` added.
+- **geometry types** — `point`, `line`, `polygon`: not CSV cells; they are the GeoJSON layers
+  themselves. The helper reports "not applicable" and the CSV caller omits the column, preserving
+  current behaviour.
+- **display-only types** — `image`, `html`: presentational, carry no respondent input. Omitted for
+  the same reason, but for a different reason, and the code should say which.
+
+Anything not in any set — i.e. a type added to `INPUT_TYPE_CHOICES` later — logs a warning naming
+the type and exports an empty cell under the question's name.
+
+*Why empty-and-warn over raising:* an exception here fails the whole download for every respondent
+because one question has an unrecognised type. *Why over silently skipping:* silent skipping is
+precisely what hid the `datetime` defect; a column of blanks is visible to the creator and the
+warning is visible to us.
+
+### D3 — Serialise `datetime` as ISO 8601, from `answer.text`
+
+`datetime` answers are stored by the save path alongside text (`views.py:702`), so the value in
+`answer.text` is whatever the `datetime-local` input posted. Normalise to ISO 8601 on export rather
+than passing the raw string through, so the column is machine-readable and stable regardless of
+what a future widget change posts. Values that fail to parse pass through unchanged rather than
+being dropped — a raw string the creator can interpret beats a blank.
+
+*Alternative rejected:* locale-formatted output for Excel friendliness. Excel's interpretation
+depends on the reader's locale, which makes the file non-portable; ISO 8601 is unambiguous and
+QGIS-safe.
+
+### D4 — Stop rebinding `answer` inside the sub-question loop
+
+The current code assigns the sub-answer to `answer` (`:1103`, `:1107`, `:1116`), shadowing the geo
+answer being exported, which is why `properties["session"]` at `:1125` reads from a sub-answer row.
+It happens to be the same session today. D1 removes the rebinding as a side effect since the
+formatter owns its own locals; this is called out so the reviewer knows it was deliberate and the
+session properties are asserted in tests.
+
+### D5 — Pin behaviour with value-level tests, characterisation first
+
+Existing export tests assert row counts and metadata columns only, never that an answer value
+reached the correct column. Order the work so the tests come first:
+
+1. Characterisation tests for current *correct* behaviour across every value type, CSV and GeoJSON,
+   written against the unrefactored code and passing before any change.
+2. Failing tests for the three defects: partially-filled sub-questions, a `datetime` question, and
+   a number sub-question mirroring backlog #23's setup.
+3. The refactor, turning (2) green while (1) stays green.
+
+The #23 test is the arbiter of whether that backlog item closes here: if it passes after the fix,
+#23 was the same bug; if it still fails, #23 is separate and stays open with a sharper reproduction
+than it has now.
+
+## Risks / Trade-offs
+
+**Re-exporting a survey now returns different attribute values than the file the customer already
+downloaded** → This is the fix working, but a creator who has published analysis from the old export
+will find the numbers moved and no explanation. Anyone with an affected export in hand (Manuel
+Frost, bisq) should be told directly rather than discovering it. Not a deploy blocker; it is a
+communication task attached to the release.
+
+**The refactor touches the CSV path, which nobody reported as broken** → Characterisation tests
+(D5.1) land and pass before the refactor, so any behaviour change shows up as a red test rather
+than in a customer's spreadsheet.
+
+**A warning for an unhandled type is only useful if anyone reads it** → Root logger is at WARNING in
+production and reaches Render logs (added with the web-concurrency work), so this surfaces. It is
+still weaker than a test; the allowlist in D2 is the real guard, since adding a type to
+`INPUT_TYPE_CHOICES` without classifying it is a visible omission in review.
+
+**`datetime` normalisation could mangle values stored by an older widget** → Parse failures pass the
+raw string through unchanged, so the worst case is the current behaviour plus a column that did not
+exist before.
+
+## Migration Plan
+
+No schema change, no migration, no data backfill. The change is a read path; deploying it changes
+what subsequent downloads contain and nothing already stored.
+
+Rollback is a revert — previously downloaded files are unaffected either way, and no state depends
+on which version produced them.
+
+## Open Questions
+
+- Should affected creators be notified that a re-export will yield corrected values, and does that
+  go out with the release or with the reply already owed to Manuel Frost? Product call, not a
+  technical one.
+- Does #23's reporter (bisq) have a survey still in the database to verify the fix against real
+  rows, or is the mirrored test setup the only available evidence?

--- a/openspec/changes/export-data-integrity/proposal.md
+++ b/openspec/changes/export-data-integrity/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+The respondent-data download produces wrong values, and does so silently. In the GeoJSON branch of
+`_export_survey_data` the `result` accumulator is initialised once before the loop over
+sub-questions instead of once per sub-question (`survey/views.py:1098`), so a sub-question with no
+answer — or with an input type the chain does not handle — is exported carrying the value of
+whichever sub-question was processed before it. The file is well-formed and the values are
+plausible, so nobody downstream can tell which attributes are real. Sub-questions of a geo question
+are the documented way to model attributes of a mapped object, which puts this on the main path for
+the platform's core use case.
+
+Two smaller defects sit in the same function: `datetime` answers are stored (the save path folds
+them in with text, `views.py:702`) but dropped by the CSV chain's `else: continue`
+(`views.py:1185`), and the same `else` will silently swallow any input type added later.
+
+All three survived because the existing tests assert row counts and metadata columns
+(`validation_status`, `session_id`) and never assert that an answer value reaches the correct
+column, nor exercise sub-question properties at all. Fixing the three without closing that gap
+leaves the next value-level regression just as invisible.
+
+Now, because a customer has already hit the visible symptom and the correctness of exports is the
+product's output of record — a survey platform whose download cannot be trusted has no deliverable.
+
+## What Changes
+
+- Scope the property accumulator to a single sub-question so a blank or unhandled sub-question
+  exports as empty rather than inheriting its predecessor's value.
+- Export `datetime` answers to CSV, reading `answer.text`, serialised as ISO 8601.
+- Replace the silent `else: continue` for unhandled input types with an explicit, documented
+  behaviour, so a type added later cannot vanish from the download without anyone noticing.
+- Stop rebinding `answer` to a sub-answer inside the sub-question loop (`views.py:1103` and
+  siblings). Currently benign, but it makes `properties["session"]` read from the wrong row and is
+  a trap for the next edit.
+- Add value-level test coverage for the download: which value lands in which column, and what a
+  partially-filled set of sub-questions produces in the GeoJSON.
+
+Not in scope: the CASCADE deletion of answers when a question is removed (backlog #98) and the
+blank-number report (#23) as a separate investigation. #23 is expected to be resolved by the
+accumulator fix — the reporter's number lived in a sub-question of a geo question — and the change
+should confirm or refute that with a test rather than assume it.
+
+**Output changes, not breaking API:** CSVs gain a column for every `datetime` question, which is
+additive. GeoJSON property *values* change for partially-filled sub-questions — that is the fix,
+but anyone who has already analysed a previous export will get different numbers from a re-export,
+which needs saying out loud rather than shipping quietly.
+
+## Capabilities
+
+### New Capabilities
+- `response-data-export`: the content of the respondent-data download (`/surveys/<slug>/download`) —
+  which answers appear in the CSV and in the per-question GeoJSON layers, under which column or
+  property name, and in what serialised form. Covers value correctness only; the version-filter UI
+  around it is already specified by `version-export-ui`, and the CLI survey export by
+  `survey-serialization`.
+
+### Modified Capabilities
+
+None. `version-export-ui` specifies the download dropdown and version filter, neither of which
+changes here. `survey-serialization` specifies the `export_survey` management command, which is a
+different code path.
+
+## Impact
+
+- `survey/views.py` — `_export_survey_data` (both the GeoJSON and the CSV branch); `download_data`
+  unchanged.
+- `survey/tests.py` — new value-level cases; existing export tests keep passing unmodified.
+- No model change, no migration, no template change.
+- Backlog items closed: 96, 97; 23 confirmed or refuted.
+- Anyone re-exporting a survey with sub-questions will see corrected attribute values. Manuel Frost
+  (Berlin Senate) and bisq both have affected exports in hand.

--- a/openspec/changes/export-data-integrity/proposal.md
+++ b/openspec/changes/export-data-integrity/proposal.md
@@ -39,6 +39,12 @@ blank-number report (#23) as a separate investigation. #23 is expected to be res
 accumulator fix — the reporter's number lived in a sub-question of a geo question — and the change
 should confirm or refute that with a test rather than assume it.
 
+> **Refuted during implementation (2026-08-04).** The expectation above was wrong. Tests written
+> against the unfixed code showed that both a number sub-question and a top-level number question
+> already exported correctly, so #23 has a different cause and stays open, now pointing at the
+> write path. Kept here rather than rewritten, so the record shows what was assumed going in. See
+> tasks 2.4 and 5.2.
+
 **Output changes, not breaking API:** CSVs gain a column for every `datetime` question, which is
 additive. GeoJSON property *values* change for partially-filled sub-questions — that is the fix,
 but anyone who has already analysed a previous export will get different numbers from a re-export,

--- a/openspec/changes/export-data-integrity/specs/response-data-export/spec.md
+++ b/openspec/changes/export-data-integrity/specs/response-data-export/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Each exported value derives only from its own question
+
+Every cell in the CSV and every property in a GeoJSON feature SHALL be derived solely from the
+answer rows belonging to that question. A question with no answer row, or whose answer carries no
+value, SHALL export as empty — never as the value of another question.
+
+#### Scenario: Sub-question left blank exports empty, not the neighbour's value
+
+- **WHEN** a geo answer has two sub-questions in order, the first answered "Lärm" and the second
+  left blank so that no `Answer` row exists for it
+- **THEN** the GeoJSON feature's properties contain `"Lärm"` under the first sub-question's name
+- **AND** an empty value under the second sub-question's name
+
+#### Scenario: Several consecutive blank sub-questions all export empty
+
+- **WHEN** a geo answer has an answered sub-question followed by three sub-questions with no
+  `Answer` rows
+- **THEN** all three export as empty values, and none carries the answered sub-question's value
+
+#### Scenario: Sub-question of a display-only type does not absorb a neighbour's value
+
+- **WHEN** a geo answer has an answered text sub-question followed by an `html` sub-question
+- **THEN** the `html` sub-question exports as empty
+
+#### Scenario: Number sub-question exports its own value
+
+- **WHEN** a respondent places a point and enters `7` in a `number` sub-question
+- **THEN** the feature's properties contain `7` under that sub-question's name
+
+### Requirement: Answers of every value-bearing type reach the export
+
+The export SHALL emit a column or property for each question whose type can hold respondent input:
+`text`, `text_line`, `number`, `range`, `choice`, `rating`, `multichoice`, `datetime`. No such
+answer may be omitted from the download.
+
+#### Scenario: datetime answer appears in the CSV
+
+- **WHEN** a respondent answers a `datetime` question and the creator downloads the data
+- **THEN** the CSV contains a column named after that question
+- **AND** the row holds the answered moment serialised as ISO 8601
+
+#### Scenario: datetime value that cannot be parsed is passed through, not dropped
+
+- **WHEN** a `datetime` answer holds a string that does not parse as a datetime
+- **THEN** the CSV cell contains that string unchanged
+
+#### Scenario: choice answer exports the choice name, not its code
+
+- **WHEN** a respondent selects a choice whose code is `2` and whose name is "Ruhig"
+- **THEN** the CSV cell contains `Ruhig`
+
+#### Scenario: multichoice answer exports all selected names
+
+- **WHEN** a respondent selects two options of a `multichoice` question
+- **THEN** the CSV cell contains both names separated by `"; "`
+
+### Requirement: Types excluded from the CSV are excluded deliberately
+
+Geometry questions (`point`, `line`, `polygon`) SHALL NOT produce CSV columns, because their answers
+are exported as GeoJSON layers. Display-only questions (`image`, `html`) SHALL NOT produce CSV
+columns, because they carry no respondent input.
+
+#### Scenario: Geo question produces a layer, not a CSV column
+
+- **WHEN** a survey has a `point` question and responses exist
+- **THEN** the ZIP contains a `.geojson` file for that question
+- **AND** the CSV has no column named after it
+
+#### Scenario: Display-only question produces no CSV column
+
+- **WHEN** a survey has an `html` question
+- **THEN** the CSV has no column named after it
+
+### Requirement: An unrecognised question type is visible, not silent
+
+If a question's type belongs to none of the classified sets, the export SHALL still emit a column
+named after that question, holding an empty value, and SHALL log a warning naming the unrecognised
+type. The download SHALL NOT fail.
+
+#### Scenario: Unclassified type yields an empty column and a warning
+
+- **WHEN** a question carries an `input_type` that the export does not classify
+- **THEN** the CSV contains a column named after that question with empty values
+- **AND** a warning naming the unrecognised type is logged
+- **AND** the response is a valid ZIP with status 200
+
+### Requirement: Session metadata identifies the responding session
+
+Each CSV row and each GeoJSON feature SHALL carry the session identifiers of the response it came
+from, taken from that response's own session.
+
+#### Scenario: GeoJSON feature reports the session that submitted it
+
+- **WHEN** two sessions each place a point with answered sub-questions
+- **THEN** each feature's `session_id` property is that of the session which submitted it
+- **AND** each feature's `validation_status` and `language` properties come from the same session

--- a/openspec/changes/export-data-integrity/tasks.md
+++ b/openspec/changes/export-data-integrity/tasks.md
@@ -18,54 +18,91 @@
 
 ## 2. Failing tests for the three defects
 
-- [ ] 2.1 Test: geo answer with a first sub-question answered and a second with no `Answer` row →
+- [x] 2.1 Test: geo answer with a first sub-question answered and a second with no `Answer` row →
       second property is empty. Expected to fail with the neighbour's value.
-- [ ] 2.2 Test: three consecutive sub-questions with no `Answer` rows → all empty. Expected to fail.
-- [ ] 2.3 Test: `datetime` question answered → CSV has a column with the ISO 8601 value. Expected to
+- [x] 2.2 Test: three consecutive sub-questions with no `Answer` rows → all empty. Expected to fail.
+- [x] 2.3 Test: `datetime` question answered → CSV has a column with the ISO 8601 value. Expected to
       fail with the column absent.
-- [ ] 2.4 Test mirroring backlog #23: a `number` sub-question of a geo question, answered, exported.
+- [x] 2.4 Test mirroring backlog #23: a `number` sub-question of a geo question, answered, exported.
       Record whether it passes or fails on unmodified code — this decides whether #23 closes here.
-- [ ] 2.5 Test: two sessions each with a geo answer → each feature's `session_id`,
+- [x] 2.5 Test: two sessions each with a geo answer → each feature's `session_id`,
       `validation_status` and `language` match its own session.
+
+  Outcome on unmodified code, as predicted for 2.1–2.3 and **not** as expected for 2.4:
+  three bleed tests failed with `'Lärm' != ''`, two datetime tests failed with the column absent,
+  and 2.5 passed (the `answer` rebinding was benign, as the design assumed). **Both 2.4 tests
+  passed before any fix** — a number sub-question and a top-level number question each export
+  correctly — so #23 is not this bug. See 5.2.
 
 ## 3. Shared cell formatter
 
-- [ ] 3.1 Add `_answer_cell(question, answers)` to `survey/views.py` returning the formatted value
+- [x] 3.1 Add `_answer_cell(question, answers)` to `survey/views.py` returning the formatted value
       for one question from its own answer rows, plus a sentinel distinguishing "no column for this
       question" from "empty value".
-- [ ] 3.2 Classify types into the three named sets from design D2 — value, geometry, display-only —
+- [x] 3.2 Classify types into the three named sets from design D2 — value, geometry, display-only —
       as module-level constants, so an unclassified type is a visible omission in review.
-- [ ] 3.3 Handle `datetime`: parse `answer.text`, emit ISO 8601, pass the raw string through
+- [x] 3.3 Handle `datetime`: parse `answer.text`, emit ISO 8601, pass the raw string through
       unchanged on parse failure.
-- [ ] 3.4 Log a warning naming the type for anything unclassified, and return an empty value rather
+- [x] 3.4 Log a warning naming the type for anything unclassified, and return an empty value rather
       than raising or skipping.
 
 ## 4. Replace both call sites
 
-- [ ] 4.1 Rewrite the GeoJSON sub-question loop to call the formatter per sub-question. The
+- [x] 4.1 Rewrite the GeoJSON sub-question loop to call the formatter per sub-question. The
       accumulator disappears; confirm no variable survives across iterations.
-- [ ] 4.2 Rewrite the CSV loop to call the formatter, honouring the no-column sentinel so geometry
+- [x] 4.2 Rewrite the CSV loop to call the formatter, honouring the no-column sentinel so geometry
       and display-only questions stay out of the CSV.
-- [ ] 4.3 Remove the rebinding of `answer` inside the sub-question loop (design D4) and confirm
+- [x] 4.3 Remove the rebinding of `answer` inside the sub-question loop (design D4) and confirm
       `properties["session"]`, `session_id`, `language` and `validation_status` read from the geo
       answer's session.
-- [ ] 4.4 Confirm the duplicated `elif` chains are gone — one formatter, two call sites.
+- [x] 4.4 Confirm the duplicated `elif` chains are gone — one formatter, two call sites.
 
 ## 5. Verify
 
-- [ ] 5.1 Run the full survey suite: `./run_tests.sh survey`. Tests from §1 still green, tests from
+- [x] 5.1 Run the full survey suite: `./run_tests.sh survey`. Tests from §1 still green, tests from
       §2 now green, no existing export test modified to make it pass.
-- [ ] 5.2 Record the outcome of 2.4: if green after the fix, close backlog #23 as the same root
+
+  867 tests, OK (1 skipped). No existing test touched.
+
+- [x] 5.2 Record the outcome of 2.4: if green after the fix, close backlog #23 as the same root
       cause; if still failing, leave #23 open and attach the reproduction as a note.
-- [ ] 5.3 Export a survey with sub-questions by hand and open the GeoJSON in QGIS — the attribute
+
+  **#23 stays open — the shared-root hypothesis in the proposal was wrong.** Both 2.4 tests passed
+  against unfixed code, so a number answer that exists has always exported correctly, in the CSV
+  and in feature properties alike. The two tests remain as the reproduction #23 previously lacked,
+  and the item now points at the write path instead: sub-answer storage branches on whether
+  `sub_question.choices` is set rather than on `input_type` (`views.py:845-856`), which is where a
+  value can fail to be stored in the first place. Deliberately not pulled into this change, which
+  is scoped to the read path.
+
+- [x] 5.3 Export a survey with sub-questions by hand and open the GeoJSON in QGIS — the attribute
       table is what the customer actually reads, and no unit test checks that it loads.
+
+  **Partially done, and the gap is worth naming: QGIS itself was not opened.** What was verified is
+  the machine-checkable part, as two tests: every feature in a collection exposes the identical
+  property key set (a varying attribute set is exactly what makes a layer awkward in QGIS, and is
+  why blank sub-questions keep an empty property rather than being omitted), and every exported
+  geometry — point, line, polygon — parses back through `GEOSGeometry` and reports valid. Loading
+  the file in a real QGIS session remains unverified and is a reasonable thing to ask of a reviewer
+  with the GUI to hand.
 
 ## 6. Close the loop
 
-- [ ] 6.1 Update backlog items 96 and 97 to point at this change; update #23 per 5.2.
-- [ ] 6.2 Correct the wording in backlog 96, 97 and 23 that says `download_data` has no test
+- [x] 6.1 Update backlog items 96 and 97 to point at this change; update #23 per 5.2.
+- [x] 6.2 Correct the wording in backlog 96, 97 and 23 that says `download_data` has no test
       coverage — it has count-level and metadata-level tests; the gap was value-level. The claim is
       wrong as written and will mislead whoever reads it next.
-- [ ] 6.3 Note in the change that affected creators (Manuel Frost, bisq) hold exports whose
+
+  6.1 and 6.2 done in commit `de26f73` on branch `chore/backlog-manuel-frost-feedback`, not here:
+  items 96-102 do not exist on this branch, which was cut from `origin/master`. The two branches
+  merge into master independently.
+
+- [x] 6.3 Note in the change that affected creators (Manuel Frost, bisq) hold exports whose
       attribute values a re-export will change, and that this needs saying to them — decision and
       wording belong to the reply already owed, not to this change.
+
+  Standing: anyone who exported a survey with sub-questions before this fix holds a file whose
+  attribute values may be attached to the wrong attribute. A re-export will return different
+  numbers with no explanation attached. Manuel Frost is the known case; bisq's item turned out to
+  be a different defect but he also has geo sub-questions. Telling them is a product decision that
+  belongs with the reply already owed to Manuel, not with this branch.

--- a/openspec/changes/export-data-integrity/tasks.md
+++ b/openspec/changes/export-data-integrity/tasks.md
@@ -1,14 +1,20 @@
 ## 1. Characterisation tests (must pass before any production code changes)
 
-- [ ] 1.1 Add an export test case with a survey covering every value-bearing type — `text`,
+- [x] 1.1 Add an export test case with a survey covering every value-bearing type — `text`,
       `text_line`, `number`, `range`, `choice`, `rating`, `multichoice` — one answered session, and
       assert the exact CSV cell for each. This pins today's correct behaviour before the refactor.
-- [ ] 1.2 Add the GeoJSON counterpart: a geo question whose sub-questions cover the same types, all
+- [x] 1.2 Add the GeoJSON counterpart: a geo question whose sub-questions cover the same types, all
       answered, asserting each property value. Pins the sub-question path.
-- [ ] 1.3 Assert that geometry questions produce a `.geojson` entry and no CSV column, and that an
+- [x] 1.3 Assert that geometry questions produce a `.geojson` entry and no CSV column, and that an
       `html` question produces neither.
-- [ ] 1.4 Run the suite and confirm 1.1–1.3 pass against unmodified code. If any fails, stop — the
+- [x] 1.4 Run the suite and confirm 1.1–1.3 pass against unmodified code. If any fails, stop — the
       chain is not equivalent to what the design assumes, and the design needs revising first.
+
+  Done in `ExportValueCorrectnessTest` (`survey/tests.py`), 6 tests, all green against unmodified
+  code — the two chains behave as the design's equivalence table claims, so the refactor may
+  proceed. Recorded while writing them: `numeric` is a `FloatField`, so integers reach the CSV as
+  `"7.0"`, not `"7"`. Any later change to that formatting is a visible behaviour change and now has
+  a test holding it.
 
 ## 2. Failing tests for the three defects
 

--- a/openspec/changes/export-data-integrity/tasks.md
+++ b/openspec/changes/export-data-integrity/tasks.md
@@ -1,0 +1,65 @@
+## 1. Characterisation tests (must pass before any production code changes)
+
+- [ ] 1.1 Add an export test case with a survey covering every value-bearing type — `text`,
+      `text_line`, `number`, `range`, `choice`, `rating`, `multichoice` — one answered session, and
+      assert the exact CSV cell for each. This pins today's correct behaviour before the refactor.
+- [ ] 1.2 Add the GeoJSON counterpart: a geo question whose sub-questions cover the same types, all
+      answered, asserting each property value. Pins the sub-question path.
+- [ ] 1.3 Assert that geometry questions produce a `.geojson` entry and no CSV column, and that an
+      `html` question produces neither.
+- [ ] 1.4 Run the suite and confirm 1.1–1.3 pass against unmodified code. If any fails, stop — the
+      chain is not equivalent to what the design assumes, and the design needs revising first.
+
+## 2. Failing tests for the three defects
+
+- [ ] 2.1 Test: geo answer with a first sub-question answered and a second with no `Answer` row →
+      second property is empty. Expected to fail with the neighbour's value.
+- [ ] 2.2 Test: three consecutive sub-questions with no `Answer` rows → all empty. Expected to fail.
+- [ ] 2.3 Test: `datetime` question answered → CSV has a column with the ISO 8601 value. Expected to
+      fail with the column absent.
+- [ ] 2.4 Test mirroring backlog #23: a `number` sub-question of a geo question, answered, exported.
+      Record whether it passes or fails on unmodified code — this decides whether #23 closes here.
+- [ ] 2.5 Test: two sessions each with a geo answer → each feature's `session_id`,
+      `validation_status` and `language` match its own session.
+
+## 3. Shared cell formatter
+
+- [ ] 3.1 Add `_answer_cell(question, answers)` to `survey/views.py` returning the formatted value
+      for one question from its own answer rows, plus a sentinel distinguishing "no column for this
+      question" from "empty value".
+- [ ] 3.2 Classify types into the three named sets from design D2 — value, geometry, display-only —
+      as module-level constants, so an unclassified type is a visible omission in review.
+- [ ] 3.3 Handle `datetime`: parse `answer.text`, emit ISO 8601, pass the raw string through
+      unchanged on parse failure.
+- [ ] 3.4 Log a warning naming the type for anything unclassified, and return an empty value rather
+      than raising or skipping.
+
+## 4. Replace both call sites
+
+- [ ] 4.1 Rewrite the GeoJSON sub-question loop to call the formatter per sub-question. The
+      accumulator disappears; confirm no variable survives across iterations.
+- [ ] 4.2 Rewrite the CSV loop to call the formatter, honouring the no-column sentinel so geometry
+      and display-only questions stay out of the CSV.
+- [ ] 4.3 Remove the rebinding of `answer` inside the sub-question loop (design D4) and confirm
+      `properties["session"]`, `session_id`, `language` and `validation_status` read from the geo
+      answer's session.
+- [ ] 4.4 Confirm the duplicated `elif` chains are gone — one formatter, two call sites.
+
+## 5. Verify
+
+- [ ] 5.1 Run the full survey suite: `./run_tests.sh survey`. Tests from §1 still green, tests from
+      §2 now green, no existing export test modified to make it pass.
+- [ ] 5.2 Record the outcome of 2.4: if green after the fix, close backlog #23 as the same root
+      cause; if still failing, leave #23 open and attach the reproduction as a note.
+- [ ] 5.3 Export a survey with sub-questions by hand and open the GeoJSON in QGIS — the attribute
+      table is what the customer actually reads, and no unit test checks that it loads.
+
+## 6. Close the loop
+
+- [ ] 6.1 Update backlog items 96 and 97 to point at this change; update #23 per 5.2.
+- [ ] 6.2 Correct the wording in backlog 96, 97 and 23 that says `download_data` has no test
+      coverage — it has count-level and metadata-level tests; the gap was value-level. The claim is
+      wrong as written and will mislead whoever reads it next.
+- [ ] 6.3 Note in the change that affected creators (Manuel Frost, bisq) hold exports whose
+      attribute values a re-export will change, and that this needs saying to them — decision and
+      wording belong to the reply already owed, not to this change.

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -11157,6 +11157,207 @@ class CleanExportTest(TestCase):
         self.assertEqual(props['session_id'], s.id)
 
 
+class ExportValueCorrectnessTest(TestCase):
+    """Value-level tests for the respondent-data download.
+
+    The existing export tests assert how many rows come back and that the
+    metadata columns are present. None of them assert that a given answer
+    reaches a given column, and none exercise sub-question properties at all —
+    which is why the defects in change `export-data-integrity` survived.
+
+    Tests here are characterisation tests: they pin the behaviour that is
+    already correct, so the refactor that fixes the defects cannot quietly
+    change anything else.
+    """
+
+    CHOICES = [
+        {"code": 1, "name": {"en": "Ruhig"}},
+        {"code": 2, "name": {"en": "Laut"}},
+    ]
+
+    def setUp(self):
+        self.org = _make_org('ValueExportOrg')
+        self.user = User.objects.create_user('valueexportuser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+
+        self.survey = SurveyHeader.objects.create(
+            name='value_export_test', organization=self.org,
+            created_by=self.user, status='published',
+        )
+        self.section = SurveySection.objects.create(
+            survey_header=self.survey, name='sec1', code='S1', is_head=True,
+        )
+
+        def q(name, code, input_type, order, choices=None, parent=None):
+            return Question.objects.create(
+                survey_section=self.section, name=name, code=code,
+                input_type=input_type, order_number=order,
+                choices=choices, parent_question_id=parent,
+            )
+
+        self.q_text = q('Comment', 'q_text', 'text', 1)
+        self.q_text_line = q('Title', 'q_line', 'text_line', 2)
+        self.q_number = q('District', 'q_num', 'number', 3)
+        self.q_range = q('Loudness', 'q_range', 'range', 4, self.CHOICES)
+        self.q_choice = q('Character', 'q_choice', 'choice', 5, self.CHOICES)
+        self.q_rating = q('Quality', 'q_rating', 'rating', 6, self.CHOICES)
+        self.q_multi = q('Sources', 'q_multi', 'multichoice', 7, self.CHOICES)
+        self.q_html = q('Intro', 'q_html', 'html', 8)
+
+        self.q_point = q('Location', 'q_point', 'point', 9)
+        self.sub_text = q('SubComment', 'sq_text', 'text', 1, parent=self.q_point)
+        self.sub_number = q('SubCount', 'sq_num', 'number', 2, parent=self.q_point)
+        self.sub_choice = q('SubCharacter', 'sq_choice', 'choice', 3,
+                            self.CHOICES, parent=self.q_point)
+
+        self.client.login(username='valueexportuser', password='pass')
+
+    def _session(self, **kwargs):
+        return SurveySession.objects.create(survey=self.survey, **kwargs)
+
+    def _answer(self, session, question, parent=None, **fields):
+        return Answer.objects.create(
+            survey_session=session, question=question,
+            parent_answer_id=parent, **fields,
+        )
+
+    def _download(self):
+        return self.client.get(f'/surveys/{self.survey.uuid}/download')
+
+    def _csv_rows(self, response):
+        import csv
+        import io
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            name = [n for n in zf.namelist() if n.endswith('.csv')][0]
+            text = zf.read(name).decode('utf-8')
+        return list(csv.DictReader(io.StringIO(text)))
+
+    def _geojson(self, response, question_name='Location'):
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            name = [n for n in zf.namelist()
+                    if n.endswith('.geojson') and question_name in n][0]
+            return json.loads(zf.read(name))
+
+    def _answer_all_flat(self, session):
+        """Answer every non-geo question of the survey."""
+        self._answer(session, self.q_text, text='Ein Kommentar')
+        self._answer(session, self.q_text_line, text='Ein Titel')
+        self._answer(session, self.q_number, numeric=7)
+        self._answer(session, self.q_range, numeric=5)
+        self._answer(session, self.q_choice, selected_choices=[2])
+        self._answer(session, self.q_rating, selected_choices=[1])
+        self._answer(session, self.q_multi, selected_choices=[1, 2])
+
+    # ── 1.1 CSV: every value-bearing type lands in its own column ──────────
+
+    def test_csv_exports_each_value_type_in_its_own_column(self):
+        """
+        GIVEN one session answering every non-geo question type
+        WHEN the data is downloaded
+        THEN each answer appears in the column named after its own question
+        """
+        self._answer_all_flat(self._session())
+
+        rows = self._csv_rows(self._download())
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row['Comment'], 'Ein Kommentar')
+        self.assertEqual(row['Title'], 'Ein Titel')
+        self.assertEqual(row['District'], '7.0')
+        self.assertEqual(row['Loudness'], '5.0')
+        self.assertEqual(row['Character'], 'Laut')
+        self.assertEqual(row['Quality'], 'Ruhig')
+        self.assertEqual(row['Sources'], 'Ruhig; Laut')
+
+    def test_csv_keeps_values_on_their_own_row(self):
+        """
+        GIVEN two sessions answering the same question differently
+        WHEN the data is downloaded
+        THEN each row carries its own session's answer
+        """
+        first = self._session()
+        self._answer(first, self.q_text, text='erste')
+        second = self._session()
+        self._answer(second, self.q_text, text='zweite')
+
+        rows = self._csv_rows(self._download())
+
+        self.assertEqual(len(rows), 2)
+        by_session = {int(r['session_id']): r['Comment'] for r in rows}
+        self.assertEqual(by_session[first.id], 'erste')
+        self.assertEqual(by_session[second.id], 'zweite')
+
+    # ── 1.2 GeoJSON: sub-question properties ───────────────────────────────
+
+    def test_geojson_exports_each_subquestion_property(self):
+        """
+        GIVEN a geo answer whose sub-questions are all answered
+        WHEN the data is downloaded
+        THEN each property holds its own sub-question's value
+        """
+        session = self._session()
+        geo = self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, self.sub_text, parent=geo, text='Lärm')
+        self._answer(session, self.sub_number, parent=geo, numeric=7)
+        self._answer(session, self.sub_choice, parent=geo, selected_choices=[2])
+
+        geojson = self._geojson(self._download())
+
+        self.assertEqual(len(geojson['features']), 1)
+        props = geojson['features'][0]['properties']
+        self.assertEqual(props['SubComment'], 'Lärm')
+        self.assertEqual(props['SubCount'], 7)
+        self.assertEqual(props['SubCharacter'], 'Laut')
+
+    def test_geojson_geometry_matches_the_answer(self):
+        """
+        GIVEN a geo answer at a known coordinate
+        WHEN the data is downloaded
+        THEN the feature geometry carries that coordinate
+        """
+        session = self._session()
+        self._answer(session, self.q_point, point=Point(13.4, 52.5))
+
+        geojson = self._geojson(self._download())
+
+        geometry = geojson['features'][0]['geometry']
+        self.assertEqual(geometry['type'], 'Point')
+        self.assertAlmostEqual(geometry['coordinates'][0], 13.4)
+        self.assertAlmostEqual(geometry['coordinates'][1], 52.5)
+
+    # ── 1.3 Which questions produce a CSV column at all ────────────────────
+
+    def test_geo_question_produces_a_layer_and_no_csv_column(self):
+        """
+        GIVEN a survey with a geo question that has been answered
+        WHEN the data is downloaded
+        THEN the geometry is exported as a GeoJSON layer, not a CSV column
+        """
+        session = self._session()
+        self._answer_all_flat(session)
+        self._answer(session, self.q_point, point=Point(13.4, 52.5))
+
+        response = self._download()
+
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            names = zf.namelist()
+        self.assertTrue(any(n.endswith('.geojson') and 'Location' in n for n in names))
+        self.assertNotIn('Location', self._csv_rows(response)[0])
+
+    def test_display_only_question_produces_no_csv_column(self):
+        """
+        GIVEN a survey containing an html question, which collects nothing
+        WHEN the data is downloaded
+        THEN no column is named after it
+        """
+        self._answer_all_flat(self._session())
+
+        rows = self._csv_rows(self._download())
+
+        self.assertNotIn('Intro', rows[0])
+
+
 class BulkOperationsTest(TestCase):
     """Tests for bulk operations on survey sessions."""
 

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -11357,6 +11357,221 @@ class ExportValueCorrectnessTest(TestCase):
 
         self.assertNotIn('Intro', rows[0])
 
+    # ── 2.1-2.2 A blank sub-question must not inherit its neighbour ────────
+
+    def test_blank_subquestion_exports_empty_not_the_neighbours_value(self):
+        """
+        GIVEN a geo answer whose first sub-question is answered and whose
+              second has no Answer row at all
+        WHEN the data is downloaded
+        THEN the second sub-question's property is empty
+        """
+        session = self._session()
+        geo = self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, self.sub_text, parent=geo, text='Lärm')
+
+        props = self._geojson(self._download())['features'][0]['properties']
+
+        self.assertEqual(props['SubComment'], 'Lärm')
+        self.assertEqual(props['SubCount'], '')
+
+    def test_consecutive_blank_subquestions_all_export_empty(self):
+        """
+        GIVEN a geo answer with one answered sub-question followed by three
+              with no Answer rows
+        WHEN the data is downloaded
+        THEN none of the three carries the answered sub-question's value
+        """
+        extra = Question.objects.create(
+            survey_section=self.section, name='SubExtra', code='sq_extra',
+            input_type='text_line', order_number=4, parent_question_id=self.q_point,
+        )
+        session = self._session()
+        geo = self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, self.sub_text, parent=geo, text='Lärm')
+
+        props = self._geojson(self._download())['features'][0]['properties']
+
+        self.assertEqual(props['SubCount'], '')
+        self.assertEqual(props['SubCharacter'], '')
+        self.assertEqual(props[extra.name], '')
+
+    def test_display_only_subquestion_does_not_absorb_a_value(self):
+        """
+        GIVEN a geo answer with an answered text sub-question followed by an
+              html sub-question, which can never hold input
+        WHEN the data is downloaded
+        THEN the html sub-question's property is empty
+        """
+        html_sub = Question.objects.create(
+            survey_section=self.section, name='SubIntro', code='sq_html',
+            input_type='html', order_number=4, parent_question_id=self.q_point,
+        )
+        session = self._session()
+        geo = self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, self.sub_text, parent=geo, text='Lärm')
+
+        props = self._geojson(self._download())['features'][0]['properties']
+
+        self.assertEqual(props[html_sub.name], '')
+
+    # ── 2.3 datetime answers must reach the CSV ────────────────────────────
+
+    def test_datetime_answer_appears_in_csv_as_iso_8601(self):
+        """
+        GIVEN a session answering a datetime question
+        WHEN the data is downloaded
+        THEN the CSV holds the answered moment as ISO 8601
+        """
+        Question.objects.create(
+            survey_section=self.section, name='Observed', code='q_dt',
+            input_type='datetime', order_number=10,
+        )
+        session = self._session()
+        self._answer(session, Question.objects.get(code='q_dt'),
+                     text='2026-08-04T19:21')
+
+        rows = self._csv_rows(self._download())
+
+        self.assertEqual(rows[0]['Observed'], '2026-08-04T19:21:00')
+
+    def test_unparseable_datetime_passes_through_unchanged(self):
+        """
+        GIVEN a datetime answer holding a string that is not a datetime
+        WHEN the data is downloaded
+        THEN the raw string is exported rather than dropped
+        """
+        Question.objects.create(
+            survey_section=self.section, name='Observed', code='q_dt',
+            input_type='datetime', order_number=10,
+        )
+        session = self._session()
+        self._answer(session, Question.objects.get(code='q_dt'), text='sometime')
+
+        rows = self._csv_rows(self._download())
+
+        self.assertEqual(rows[0]['Observed'], 'sometime')
+
+    # ── 2.4 Backlog #23: number sub-question of a geo question ─────────────
+
+    def test_number_subquestion_reaches_the_export(self):
+        """
+        GIVEN a number sub-question of a geo question, answered — the shape
+              reported in backlog #23 as exporting blank
+        WHEN the data is downloaded
+        THEN the value appears in the feature's properties
+        """
+        session = self._session()
+        geo = self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, self.sub_number, parent=geo, numeric=12)
+
+        props = self._geojson(self._download())['features'][0]['properties']
+
+        self.assertEqual(props['SubCount'], 12)
+
+    def test_top_level_number_question_reaches_the_csv(self):
+        """
+        GIVEN a top-level number question, answered
+        WHEN the data is downloaded
+        THEN the value appears in the CSV column named after it
+        """
+        session = self._session()
+        self._answer(session, self.q_number, numeric=12)
+
+        rows = self._csv_rows(self._download())
+
+        self.assertEqual(rows[0]['District'], '12.0')
+
+    # ── 2.5 Session metadata comes from the feature's own session ──────────
+
+    def test_each_feature_reports_its_own_session(self):
+        """
+        GIVEN two sessions that each place a point with an answered
+              sub-question
+        WHEN the data is downloaded
+        THEN each feature's session metadata is its own session's
+        """
+        first = self._session(validation_status='approved', language='de')
+        geo_first = self._answer(first, self.q_point, point=Point(13.4, 52.5))
+        self._answer(first, self.sub_text, parent=geo_first, text='erste')
+
+        second = self._session(validation_status='not_checked', language='en')
+        geo_second = self._answer(second, self.q_point, point=Point(13.5, 52.6))
+        self._answer(second, self.sub_text, parent=geo_second, text='zweite')
+
+        features = self._geojson(self._download())['features']
+
+        by_session = {f['properties']['session_id']: f['properties'] for f in features}
+        self.assertEqual(by_session[first.id]['SubComment'], 'erste')
+        self.assertEqual(by_session[first.id]['validation_status'], 'approved')
+        self.assertEqual(by_session[first.id]['language'], 'de')
+        self.assertEqual(by_session[second.id]['SubComment'], 'zweite')
+        self.assertEqual(by_session[second.id]['validation_status'], 'not_checked')
+        self.assertEqual(by_session[second.id]['language'], 'en')
+
+    # ── The layer has to be readable as a layer, not just as JSON ──────────
+
+    def test_every_feature_carries_the_same_attribute_set(self):
+        """
+        GIVEN two geo answers, one with all sub-questions answered and one
+              with none of them answered
+        WHEN the data is downloaded
+        THEN both features expose the same property keys
+
+        A feature collection whose attribute set varies per feature loads in
+        QGIS with columns missing for some rows, which is why blank
+        sub-questions keep an empty property rather than being omitted.
+        """
+        complete = self._session()
+        geo_complete = self._answer(complete, self.q_point, point=Point(13.4, 52.5))
+        self._answer(complete, self.sub_text, parent=geo_complete, text='Lärm')
+        self._answer(complete, self.sub_number, parent=geo_complete, numeric=7)
+        self._answer(complete, self.sub_choice, parent=geo_complete, selected_choices=[2])
+
+        empty = self._session()
+        self._answer(empty, self.q_point, point=Point(13.5, 52.6))
+
+        features = self._geojson(self._download())['features']
+
+        self.assertEqual(len(features), 2)
+        key_sets = [set(f['properties']) for f in features]
+        self.assertEqual(key_sets[0], key_sets[1])
+        self.assertIn('SubComment', key_sets[0])
+
+    def test_exported_geometries_parse_as_geometries(self):
+        """
+        GIVEN answers of every geometry type
+        WHEN the data is downloaded
+        THEN each exported geometry is readable by a GIS reader
+        """
+        from django.contrib.gis.geos import GEOSGeometry
+
+        q_line = Question.objects.create(
+            survey_section=self.section, name='Route', code='q_line_geo',
+            input_type='line', order_number=11,
+        )
+        q_polygon = Question.objects.create(
+            survey_section=self.section, name='Area', code='q_poly_geo',
+            input_type='polygon', order_number=12,
+        )
+        session = self._session()
+        self._answer(session, self.q_point, point=Point(13.4, 52.5))
+        self._answer(session, q_line, line=LineString((13.4, 52.5), (13.5, 52.6)))
+        self._answer(session, q_polygon, polygon=Polygon(
+            ((13.4, 52.5), (13.5, 52.5), (13.5, 52.6), (13.4, 52.5)),
+        ))
+
+        response = self._download()
+
+        for name, expected in (('Location', 'Point'),
+                               ('Route', 'LineString'),
+                               ('Area', 'Polygon')):
+            collection = self._geojson(response, question_name=name)
+            geometry = collection['features'][0]['geometry']
+            self.assertEqual(geometry['type'], expected)
+            parsed = GEOSGeometry(json.dumps(geometry))
+            self.assertTrue(parsed.valid, f'{name} exported an invalid geometry')
+
 
 class BulkOperationsTest(TestCase):
     """Tests for bulk operations on survey sessions."""

--- a/survey/views.py
+++ b/survey/views.py
@@ -35,6 +35,7 @@ from django.contrib.gis.geos import GEOSGeometry
 import sys
 from io import BytesIO
 import json
+import logging
 from zipfile import ZipFile
 import pandas as pd
 
@@ -63,6 +64,8 @@ from .abuse import (
 from django_ratelimit.core import is_ratelimited
 from django.conf import settings as conf_settings
 from django.http import HttpResponse
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncEmailRegistrationView(
@@ -1050,6 +1053,92 @@ def _sanitize_filename(name):
 	return re.sub(r'[<>:"/\\|?*]', '_', name)
 
 
+# Every input type is classified for export. A type in none of these sets is a
+# bug — it means INPUT_TYPE_CHOICES gained a member and nobody decided how it
+# leaves the platform — so _answer_cell warns rather than dropping it silently,
+# which is how datetime went missing from the download unnoticed.
+
+# Carry respondent input; exported as a CSV column or a GeoJSON property.
+EXPORT_VALUE_TYPES = frozenset({
+	'text', 'text_line', 'number', 'range',
+	'choice', 'rating', 'multichoice', 'datetime',
+})
+
+# Exported as GeoJSON layers in their own right, never as a cell.
+EXPORT_GEOMETRY_TYPES = frozenset({'point', 'line', 'polygon'})
+
+# Presentational; they collect nothing, so there is nothing to export.
+EXPORT_DISPLAY_ONLY_TYPES = frozenset({'image', 'html'})
+
+# Returned by _answer_cell for questions that must not produce a column at all,
+# which is distinct from a question that produces an empty one.
+EXPORT_NO_COLUMN = object()
+
+
+def _format_datetime_cell(raw):
+	"""Serialise a stored datetime answer as ISO 8601.
+
+	Values that do not parse are passed through unchanged: a raw string the
+	creator can still interpret beats a blank cell.
+	"""
+	if not raw:
+		return ""
+	try:
+		return datetime.fromisoformat(raw).isoformat()
+	except (TypeError, ValueError):
+		return raw
+
+
+def _answer_cell(question, answers):
+	"""Format one question's answer for export.
+
+	`answers` holds the rows belonging to this question and nothing else, which
+	is what keeps a blank question from inheriting its neighbour's value: the
+	result is computed per call rather than accumulated across a loop.
+
+	Returns EXPORT_NO_COLUMN for questions that should not appear as a cell.
+	"""
+	input_type = question.input_type
+
+	if input_type in EXPORT_GEOMETRY_TYPES or input_type in EXPORT_DISPLAY_ONLY_TYPES:
+		return EXPORT_NO_COLUMN
+
+	if input_type not in EXPORT_VALUE_TYPES:
+		logger.warning(
+			"Export: question %s has unclassified input_type %r; exporting an "
+			"empty column. Classify it in survey/views.py.",
+			question.code, input_type,
+		)
+		return ""
+
+	if not answers:
+		return ""
+
+	answer = answers[0]
+
+	if input_type in ('text', 'text_line'):
+		return answer.text if answer.text is not None else ""
+
+	if input_type == 'datetime':
+		return _format_datetime_cell(answer.text)
+
+	if input_type in ('number', 'range'):
+		if answer.numeric is not None:
+			return answer.numeric
+		if answer.selected_choices:
+			return answer.selected_choices[0]
+		return ""
+
+	if input_type in ('choice', 'rating'):
+		names = answer.get_selected_choice_names()
+		return names[0] if names else ""
+
+	if input_type == 'multichoice':
+		return "; ".join(answer.get_selected_choice_names())
+
+	return ""
+
+
 def _export_survey_data(zip, survey, prefix='', excluded_session_ids=None):
 	"""Export a single survey's data into the zip with optional filename prefix.
 
@@ -1074,58 +1163,37 @@ def _export_survey_data(zip, survey, prefix='', excluded_session_ids=None):
 		#получить ответы
 		features = []
 		answers = question.answers()
-		for answer in answers:
+		for geo_answer in answers:
 			# Skip excluded sessions
-			if answer.survey_session_id in excluded_session_ids:
+			if geo_answer.survey_session_id in excluded_session_ids:
 				continue
 
 			#получить геометрию
 			geo_type = question.input_type
 			if geo_type == "polygon":
-				coordinates =  [[[i[0],i[1]] for i in answer.polygon.coords[0]]]
+				coordinates =  [[[i[0],i[1]] for i in geo_answer.polygon.coords[0]]]
 				geometry_type = "Polygon"
 			elif geo_type == "line":
-				coordinates =  [[i[0],i[1]] for i in answer.line.coords]
+				coordinates =  [[i[0],i[1]] for i in geo_answer.line.coords]
 				geometry_type = "LineString"
 			elif geo_type == "point":
-				coordinates =  [answer.point.coords[0], answer.point.coords[1]]
+				coordinates =  [geo_answer.point.coords[0], geo_answer.point.coords[1]]
 				geometry_type = "Point"
 
 			#получить properties из subquestions
-			subquestions = question.subQuestions()
 			properties = {}
-			subanswers = answer.subAnswers()
-			result = ""
-			for key in subanswers:
-				input_type = key.input_type
-				if (input_type == "text" or input_type == "text_line"):
-					if subanswers[key]:
-						answer = subanswers[key][0]
-						result = answer.text
-				elif input_type == "number" or input_type == "range":
-					if subanswers[key]:
-						answer = subanswers[key][0]
-						if answer.numeric is not None:
-							result = answer.numeric
-						elif answer.selected_choices:
-							result = answer.selected_choices[0]
-						else:
-							result = ""
-				elif input_type == "choice" or input_type == "rating":
-					if subanswers[key]:
-						answer = subanswers[key][0]
-						names = answer.get_selected_choice_names()
-						result = names[0] if names else ""
-				elif input_type == "multichoice":
-					if subanswers[key]:
-						result = "; ".join(subanswers[key][0].get_selected_choice_names())
+			subanswers = geo_answer.subAnswers()
+			for subquestion, rows in subanswers.items():
+				cell = _answer_cell(subquestion, rows)
+				# Unlike the CSV, every sub-question keeps a property even when
+				# it holds nothing: a feature collection whose attribute set
+				# varies per feature is awkward to read in QGIS.
+				properties[subquestion.name] = "" if cell is EXPORT_NO_COLUMN else cell
 
-				properties[key.name] = result
-
-			properties["session"] = str(answer.survey_session)
-			properties["session_id"] = answer.survey_session_id
-			properties["language"] = answer.survey_session.language or ''
-			properties["validation_status"] = answer.survey_session.validation_status or ''
+			properties["session"] = str(geo_answer.survey_session)
+			properties["session_id"] = geo_answer.survey_session_id
+			properties["language"] = geo_answer.survey_session.language or ''
+			properties["validation_status"] = geo_answer.survey_session.validation_status or ''
 
 			feature = {
 				"type": "Feature",
@@ -1162,30 +1230,17 @@ def _export_survey_data(zip, survey, prefix='', excluded_session_ids=None):
 
 		properties = {}
 		answers = session.answers()
-		result = ""
 		for answer in answers:
 			if not answer.question:
 				continue
-			input_type = answer.question.input_type
 
-			if (input_type == "text" or input_type == "text_line"):
-				result = answer.text
-			elif input_type == "number" or input_type == "range":
-				if answer.numeric is not None:
-					result = answer.numeric
-				elif answer.selected_choices:
-					result = answer.selected_choices[0]
-				else:
-					result = ""
-			elif input_type == "choice" or input_type == "rating":
-				names = answer.get_selected_choice_names()
-				result = names[0] if names else ""
-			elif input_type == "multichoice":
-				result = "; ".join(answer.get_selected_choice_names())
-			else:
+			cell = _answer_cell(answer.question, [answer])
+			# Geometry questions are exported as their own GeoJSON layers and
+			# display-only questions collect nothing, so neither gets a column.
+			if cell is EXPORT_NO_COLUMN:
 				continue
 
-			properties[answer.question.name] = result
+			properties[answer.question.name] = cell
 
 		properties["session"] = str(session)
 		properties["session_id"] = session.id


### PR DESCRIPTION
Fixes three defects in `_export_survey_data`, all in how an `Answer` row becomes a cell. Two of them corrupted data silently.

Reported by Manuel Frost (Berlin Senate) as "on export, only the last answer contains data" — that symptom turned out to be a different bug (backlog #98, not fixed here), but investigating it surfaced these.

## The defects

**GeoJSON sub-question properties inherited their neighbour's value.** The accumulator was initialised before the loop over sub-questions instead of per iteration, so a sub-question with no answer was exported carrying whatever the previous one produced. The file stays well-formed and the values stay plausible, so nobody downstream can tell which attributes are real.

This fires on the ordinary path, not an edge case: sub-answers are written only for keys present in the submitted feature's `properties` (`views.py:841`), so a sub-question the respondent skipped has **no `Answer` row at all**. Any survey whose geo questions carry attributes is affected — which is the documented way to model attributes of a mapped object.

**`datetime` answers never reached the CSV.** They were stored all along (the save path folds them in with text) and dropped by the chain's `else: continue`. The creator sees the question in the editor, sees answers in analytics, and gets a download with no such column.

**The geo loop rebound `answer` to a sub-answer**, so the session properties read from whichever sub-answer was processed last. Benign today, since it is the same session, but wrong and a trap for the next edit.

## Approach

Both duplicated `elif` chains are replaced by one `_answer_cell(question, answers)`. The chains were equivalent and differed only in how they ended — which is where both bugs lived. With one formatter there is no accumulator to leak: the bug becomes structurally unavailable rather than merely absent.

Input types are now classified explicitly into value / geometry / display-only sets. A type in none of them gets an empty column plus a logged warning, so the next addition to `INPUT_TYPE_CHOICES` cannot repeat the `datetime` defect. Raising was considered and rejected — one unrecognised question would deny every respondent's data.

One deliberate asymmetry: GeoJSON keeps a property for every sub-question even when empty, while the CSV omits geometry and display-only columns entirely. A feature collection whose attribute set varies per feature loads badly in QGIS. Both behaviours are covered by tests.

## Tests

`ExportValueCorrectnessTest` — 16 tests, added in two stages. Characterisation tests landed and passed **before** any production change, pinning the behaviour that was already correct so the refactor could not alter it unnoticed. Then the failing tests for the defects, then the fix.

The existing export tests asserted row counts, the version filter and metadata columns. None asserted that an answer reached a given column, and none exercised sub-questions — which is why all three defects survived. That gap is what this PR closes; the fixes fall out of it.

869 tests pass. No existing test was modified to accommodate the change.

## What this PR does not do

- **Backlog #23 (number field blank in CSV) is refuted, not fixed.** The proposal expected it to share this root cause. Two tests written against the unfixed code both passed, so a number answer that exists has always exported correctly. #23 stays open and now points at the write path, where sub-answer storage branches on whether `choices` is set rather than on `input_type` (`views.py:845-856`). The original expectation is kept in the proposal with a correction under it.
- **Backlog #98** (deleting a question CASCADEs its answers) — the actual cause of Manuel's reported symptom. Different code path, needs a product decision on the intended behaviour.
- **QGIS was not opened.** Attribute-set stability and geometry validity are covered by tests; loading the file in a real QGIS session is worth a reviewer with the GUI to hand.

## Needs a decision

Anyone who exported a survey with sub-questions before this fix holds a file whose attribute values may be attached to the wrong attribute. A re-export will return different numbers with no explanation attached. Manuel Frost is the known case. Telling affected creators is a product call that belongs with the reply already owed to him, not with this branch.

## Artifacts

OpenSpec change `export-data-integrity` — proposal, design (decisions D1–D5 with the alternatives rejected), specs under the new `response-data-export` capability, and tasks recording outcomes including where they contradicted the plan.

Backlog updates are in #50, a separate PR, because items 96-102 do not exist on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
