### PR TITLE
fix(range): align the slider's labels, and give range the rating display styles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ docker-compose up db                   # Start only PostgreSQL/PostGIS
 
 # Local development (venv in ./env)
 source env/bin/activate                # Activate virtual environment
-pip install -r requirements.txt        # Install dependencies (or use pipenv)
+pipenv install                         # Install dependencies (Pipfile — there is no requirements.txt)
 python manage.py migrate               # Apply database migrations
 python manage.py runserver             # Start development server (port 8000)
 python manage.py createsuperuser       # Create admin user
@@ -36,7 +36,11 @@ stack per worktree. Offset `0` reproduces the original ports. `.env.ports` is gi
 
 Tests use Django's built-in test framework with PostGIS. Django automatically creates a separate `test_mapsurvey` database.
 
-**Prerequisites**: PostGIS container must be running (`docker compose up -d db`)
+**Prerequisites**: none — `run_tests.sh` starts the PostGIS and Redis containers itself and waits
+for both. Redis is not optional: `settings.py` falls back to `redis://localhost:6379/1` when
+`REDIS_URL` is unset, so on a machine running several projects the suite would otherwise connect to
+whichever project owns that port and write into its database. `CACHES` sets `IGNORE_EXCEPTIONS`, so
+that goes wrong silently rather than failing loudly.
 
 **Test location**: `survey/tests.py`
 

--- a/openspec/backlog/INDEX.md
+++ b/openspec/backlog/INDEX.md
@@ -97,7 +97,9 @@
 | ~~96~~ | ~~bug~~ | ~~[GeoJSON export: sub-question property inherits previous value](bug-geojson-subquestion-property-bleed.md)~~ | ~~**very high**~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | ~~97~~ | ~~bug~~ | ~~[datetime answers never appear in the CSV export](bug-datetime-missing-from-csv-export.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | 98 | bug | [Deleting a question silently destroys all answers](bug-editing-question-destroys-answers.md) | high | backend | — | 2026-08-04 |
-| 99 | bug | [Range slider: endpoint labels not aligned to the track](bug-range-slider-label-alignment.md) | high | frontend | — | 2026-08-04 |
+| ~~99~~ | ~~bug~~ | ~~[Range slider: endpoint labels not aligned to the track](bug-range-slider-label-alignment.md)~~ | ~~high~~ | ~~frontend~~ | ~~—~~ | ~~2026-08-04~~ |
 | 100 | improvement | [Closed survey is a dead end — no way back to editing](improvement-closed-survey-edit-dead-end.md) | high | frontend | — | 2026-08-04 |
 | 101 | feature | [Clear all responses / reset survey data](feature-clear-all-responses.md) | medium | backend | — | 2026-08-04 |
 | 102 | feature | [Additional scale and ranking question types](feature-additional-scale-question-types.md) | medium | frontend | — | 2026-08-04 |
+| 106 | improvement | [Survey page always renders the map, squeezing non-geo surveys](improvement-map-panel-always-rendered.md) | high | frontend | — | 2026-08-05 |
+| 107 | bug | [Survey answers are never validated server-side](bug-answers-never-validated-server-side.md) | high | backend | — | 2026-08-05 |

--- a/openspec/backlog/bug-answers-never-validated-server-side.md
+++ b/openspec/backlog/bug-answers-never-validated-server-side.md
@@ -1,0 +1,48 @@
+# Survey answers are never validated server-side
+
+**Type**: bug
+**Priority**: high
+**Area**: backend
+**Created**: 2026-08-05
+
+## Description
+
+The section POST handler builds the answer form with `initial=request.POST` rather than binding it
+to the data (`survey/views.py:812`):
+
+```python
+form = SurveySectionAnswerForm(initial=request.POST, section=section, ...)
+```
+
+An unbound form is never validated. `is_valid()` is never called and `form.errors` is never read;
+the handler proceeds straight to writing answers. So for **every question type**:
+
+- `required` is not enforced. A respondent who submits an empty section is taken to the next one,
+  and on the last section to the thanks page, as though they had answered.
+- Field-level validation does not run — no type checking, no min/max, no choice-membership check.
+- A crafted request can put values into `Answer` that the form would have rejected. An empty string
+  posted for a `number` or `range` question reaches `float(result[0])` and raises, returning a 500
+  (`views.py:875`).
+
+Client-side `required` attributes are the only thing enforcing this today, so anything that bypasses
+the browser form — a script, a replayed request, a mobile browser that handles `required` loosely —
+writes unchecked data.
+
+## Notes
+
+- Found 2026-08-05 while writing tests for change `range-scale-display`. A spec scenario asserted
+  that a required range question rejects an empty submission; it does not, and neither does any
+  other type. The scenario was rewritten to assert what the platform actually guarantees rather than
+  quietly dropped.
+- This is the general case of a symptom already recorded from the web-concurrency work: "geo-question
+  `required` not enforced server-side (empty submit → thanks)". That note framed it as a geo issue.
+  It is not — it is every question type, and the cause is one line.
+- Fixing it is not a one-liner despite the cause being one, because unknown numbers of live surveys
+  currently accept partial responses. Turning validation on will start rejecting submissions that
+  are being accepted today, so it needs a decision about existing in-flight surveys and probably a
+  look at how many stored sessions would have failed validation.
+- Sequence the work: bind the form and surface errors without enforcing `required` first, measure how
+  many submissions would fail, then enforce. Sequencing it the other way risks silently dropping
+  respondents mid-consultation, which is worse than the current gap.
+- The 500 on an empty numeric value is separable and worth fixing immediately regardless — guard the
+  `float()` conversions in the save path.

--- a/openspec/backlog/feature-additional-scale-question-types.md
+++ b/openspec/backlog/feature-additional-scale-question-types.md
@@ -28,6 +28,16 @@ Researchers used to standard survey tools expect more:
   [range slider label alignment](bug-range-slider-label-alignment.md). Continuous and vertical
   scales are new widgets over existing storage. Ranking needs a new answer shape, export handling
   and analytics — treat it as its own change.
+- **2026-08-05 — the "different styles" slice is done**, in change `range-scale-display`: `range`
+  questions now offer the same per-question "Display as" choice `rating` has, so a creator can pick
+  the slider, a compact scale strip, or a labelled list showing every step's name. Storage is
+  unchanged in all three.
+  Still open here: **continuous** (non-stepped) scale, **vertical** scale, and **ranking**. The
+  first two are new widgets over the existing numeric storage; ranking needs a new answer shape and
+  is the only one of the three that touches export and analytics.
+- The display-style machinery now dispatches on `SurveySectionAnswerForm.DISPLAY_STYLE_TYPES`, so
+  adding a style is an entry there, a partial, and a thumbnail in the editor's picker — not a new
+  branch in the template.
 - Every new type has to be carried through the export path and the analytics aggregation, not just
   the form. The export function currently drops unhandled types silently — see
   [datetime missing from CSV export](bug-datetime-missing-from-csv-export.md).

--- a/openspec/backlog/improvement-map-panel-always-rendered.md
+++ b/openspec/backlog/improvement-map-panel-always-rendered.md
@@ -1,0 +1,36 @@
+# The survey page always renders the map, so non-geo surveys get a ~370px column
+
+**Type**: improvement
+**Priority**: high
+**Area**: frontend
+**Created**: 2026-08-05
+
+## Description
+
+`base_survey_template.html:74` renders `<div id="map"></div>` unconditionally, and `#map` takes the
+full viewport width behind a fixed-width sidebar (`#info_page`, 420px, `max-width: 460px`). A survey
+with no geo question at all therefore hands roughly 80% of the screen to an empty basemap and
+squeezes every question into the sidebar.
+
+Measured on a survey containing a single `range` question and nothing else: viewport 1854px,
+question column 371px, the slider inside it 337px.
+
+This affects every question type, not one of them. It is simply most visible on the controls that
+want horizontal room — sliders, scale strips, long choice labels, wide tables.
+
+## Notes
+
+- Found 2026-08-05 while reproducing backlog #99. Manuel Frost reported the range slider as "too
+  short"; the slider is `width: 100%` and behaving correctly, so this layout is the actual cause of
+  what he saw. #99 fixed the label alignment, which was a separate and real defect, but not this.
+- The fix is not simply "hide the map when there are no geo questions" — decide first what the page
+  should look like without one. A centred single-column form is the obvious answer and is what every
+  other survey tool does, but it is a visual decision about the product's identity ("Google Forms for
+  geodata") rather than a CSS change, since the map is the thing that makes Mapsurvey recognisable.
+- Intermediate cases need a rule too: a survey where only section 3 has a geo question, or a section
+  whose geo question is optional. Reflowing the layout between sections would be jarring; deciding
+  per survey is probably right.
+- Cheap first slice, if the full decision stalls: let the sidebar widen when the survey has no geo
+  questions, rather than removing the map. Lower risk, most of the benefit.
+- Related: [Survey visual customization](improvement-survey-visual-customization.md) (#42) covers
+  spacing and separators inside the card; this is the container around it.

--- a/openspec/changes/range-scale-display/.openspec.yaml
+++ b/openspec/changes/range-scale-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/range-scale-display/design.md
+++ b/openspec/changes/range-scale-display/design.md
@@ -1,0 +1,145 @@
+## Context
+
+Two question types render an ordinal scale, and they were built at different times by different
+means.
+
+`rating` is a `ChoiceField` with radio inputs. The section template branches on the question type
+and picks one of two partials according to `Question.display_style`, falling back to a survey-wide
+default in `SurveyHeader.style_settings['rating_display_style']`:
+
+- `rating_scale_strip.html` — a CSS grid of numbered cells, `grid-template-columns: repeat(N, 1fr)`,
+  with an anchors row underneath holding the first and last labels, plus a chip showing the current
+  selection. The anchors line up because the cells span the container edge to edge.
+- `rating_list_pips.html` — one row per choice, each showing the choice's full label.
+
+`range` is an `IntegerField` with `RangeWidget`, a native `<input type="range">` with two sibling
+rows built by string concatenation in the widget: anonymous tick marks, and a two-item label row
+holding only the first and last choice names.
+
+The alignment defect follows from that construction. `.range-ticks` carries `padding: 0 10px` and
+`.range-labels` carries none, so the rows disagree; and neither accounts for the thumb, whose width
+(22px) insets the reachable extremes of the track by half that at each end. A label flush to the
+element edge points at a value the respondent cannot select.
+
+Constraint that shapes everything below: the save path branches on `question.input_type`, not on
+the widget (`views.py:873-878`), so a `range` answer is stored in `Answer.numeric` no matter how it
+is rendered. Rendering is therefore free to change without touching storage, export, analytics, or
+responses already collected.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The slider's ticks and endpoint labels agree with each other and with the thumb's reachable range.
+- A creator can show every step's label on a `range` question without us inventing a mechanism for it.
+- A `range` answer is stored identically whichever display style is in force, including when the
+  style changes mid-collection.
+- Existing `range` questions look the same as before, minus the misalignment.
+
+**Non-Goals:**
+
+- Continuous (non-stepped) scales, vertical scales and ranking — backlog #102. Those need new
+  widgets and, for ranking, a new answer shape.
+- Changing anything about how `rating` renders. The templates are reused as they are.
+- A survey-wide default for range styles. `style_settings` currently holds one key,
+  `rating_display_style`; adding a parallel key is easy but nobody has asked for it, and per-question
+  selection covers the reported need.
+- Restyling the slider beyond alignment.
+
+## Decisions
+
+### D1 — Reuse the rating partials for `range` rather than writing range-specific ones
+
+The two existing partials already produce what is being asked for. Extend the template branch to
+cover `range`, and let `display_style` select among slider / `scale_strip` / `list_pips`.
+
+*Why over building a labelled slider:* putting every label under a slider is the obvious-looking fix
+and the one that does not survive contact with a 9-point scale on a phone — the labels either
+overlap, truncate, or need rotation, and each of those is a new thing to maintain. `list_pips`
+sidesteps the geometry entirely by giving each choice a row. Reusing it also means a creator sees
+the same three options and the same visual language on `rating` and `range`, instead of two
+different vocabularies for the same idea.
+
+*Cost:* `scale_strip` and `list_pips` present radio buttons, which is a different interaction from
+dragging a slider. That is the creator's choice to make, which is exactly why this is a per-question
+setting and why the slider stays the default.
+
+### D2 — The form field type follows the display style
+
+`scale_strip` and `list_pips` iterate the field's choices (`{% for radio in field %}`), which an
+`IntegerField` does not provide. So:
+
+- `default` → `IntegerField` + `RangeWidget` (today's behaviour)
+- `scale_strip` / `list_pips` → `ChoiceField` + `RadioSelect`, built from `question.choices`
+
+`_get_form_from_input_type` must therefore receive the resolved display style, which today is
+attached to the widget *after* the field is built (`forms.py:251-255`). Resolution moves ahead of
+field construction.
+
+*Why this is safe:* both field types post a single value, and the save path keys on `input_type`, so
+`float(result[0])` still stores the same number. Verified in tasks by round-tripping an answer
+through each style and asserting identical stored values.
+
+*Consequence to handle:* prepopulation on back-navigation sets `initial[code] = int(answer.numeric)`
+(`views.py:716-718`). A `ChoiceField` needs the string form to match a choice, so initial resolution
+becomes style-dependent too.
+
+### D3 — Express the thumb inset once, in CSS, and let both rows use it
+
+Introduce a custom property for the thumb size on the slider block and derive the tick and label
+padding from it, instead of two hand-tuned pixel values that were never equal. The labels then sit
+under the extreme positions the thumb can occupy.
+
+*Why not `justify-content: space-between` with corrected padding on each row separately:* that is
+the current shape and it drifted. One declared value that both rows consume cannot drift.
+
+### D4 — `default` keeps meaning "slider" for `range`, and inherits nothing
+
+For `rating`, `default` resolves to the survey-wide `rating_display_style`. For `range` it resolves
+to the slider. This asymmetry is deliberate: making `range` inherit the rating default would silently
+change how every existing range question renders on first deploy, for every creator, without anyone
+asking for it. Non-Goals records the survey-wide range default as available later if wanted.
+
+### D5 — Ungate "Display as" by capability, not by a growing list of types
+
+The editor shows the control when `input_type === 'rating'` (`question_form_modal.html:213-216`).
+Replace the equality test with membership of a named set of types that support display styles, so
+the next type to gain them is a one-line addition rather than another `||`.
+
+## Risks / Trade-offs
+
+**A 9-point `scale_strip` on a narrow phone gives nine cells of a few pixels each** → Real, and it
+already applies to `rating` today, so this change does not introduce it. Worth measuring at 320px
+during implementation and, if it is as bad as expected, saying so in the editor's style picker
+rather than silently letting creators pick it. Recorded as a task, not fixed here.
+
+**Switching style mid-collection changes the respondent's experience between sessions** → No data
+consequence, since storage is identical, but a survey that looks like a slider on Monday and buttons
+on Tuesday may confuse a returning respondent. The creator's call; the read-only lock on published
+surveys already governs when it can happen.
+
+**`ChoiceField` and `IntegerField` differ in what `required` means and in what an empty submit
+does** → Covered by tests in both styles rather than reasoned about; a required range question must
+behave the same either way.
+
+**The slider fix changes the appearance of every existing range question** → That is the point, and
+it is a correction rather than a redesign: the same slider, with the labels where they belong.
+
+## Migration Plan
+
+No schema change and no migration — `display_style` already exists on `Question` with the three
+values needed, defaulting to `default`. Nothing is backfilled: every existing `range` question keeps
+`default`, which keeps rendering the slider.
+
+Rollback is a revert. No stored data depends on which style was in force.
+
+## Open Questions
+
+- Does a `range` question with no `choices` defined exist in production? The slider falls back to
+  0–10 when choices are empty (`forms.py:191-195`), but `scale_strip` and `list_pips` have nothing to
+  render. The editor should either prevent selecting those styles or the renderer should fall back to
+  the slider; resolving this needs a look at real data, and the safe default in the meantime is to
+  fall back.
+- Is the "slider is too short" part of the report about the slider or about the width of the question
+  card that contains it? It is `width: 100%` of the card, so it needs reproduction at the widths a
+  respondent actually sees before anything is changed.

--- a/openspec/changes/range-scale-display/proposal.md
+++ b/openspec/changes/range-scale-display/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The `range` question renders as a native slider whose labels do not line up with anything. The
+endpoint labels sit flush to the element's edges while the thumb is 22px wide, so the positions the
+labels point at are positions the thumb can never reach; the tick row above them uses a different
+padding again (`main.css:271-287`), so the two rows do not even agree with each other. Intermediate
+choices get an anonymous tick and no text at all (`forms.py:52-67`), so on a 9-point named scale
+seven of the nine names are invisible to the respondent.
+
+Both were reported by the user who asked for endpoint labels in the first place (backlog #5, shipped)
+— the feature landed and still does not read correctly, which is worse than not having shipped it.
+
+The platform already solved this problem, but only for `rating`. That type has two display styles
+selected per question via `Question.display_style`, with a survey-wide default: `scale_strip` lays
+the choices out as a CSS grid with anchor labels under the ends — aligned, because the cells span
+the full width — and `list_pips` gives each choice its own row with the label in full. `list_pips`
+is a complete answer to invisible intermediate labels, and it needs no new invention.
+
+`range` was simply left behind. The editor's own "Display as" control even draws the `default`
+option as a slider icon, so the UI already thinks in these terms; the control is just gated to
+`rating` questions (`question_form_modal.html:213-216`).
+
+## What Changes
+
+- Fix the slider's label and tick alignment so both rows agree with each other and with the
+  positions the thumb can actually occupy.
+- Offer `range` questions the same "Display as" choice `rating` already has: the slider (default),
+  `scale_strip`, or `list_pips`, reusing the existing templates and CSS rather than adding a third
+  rendering.
+- Ungate the "Display as" control in the question editor for `range`.
+- Keep `default` meaning *slider* for `range`. Existing range questions are unaffected unless their
+  creator opts into another style.
+
+**No change to what is stored.** The save path branches on `question.input_type`, not on the widget
+(`views.py:873-878`), so a `range` answer keeps landing in `Answer.numeric` whichever way it is
+rendered. Export, analytics and existing responses are untouched, and a creator can switch styles
+mid-survey without splitting their data.
+
+Not in scope: continuous (non-stepped) and vertical scales, and ranking — backlog #102. This change
+takes the slice of #102 that falls out of work already done, and leaves the parts that need new
+widgets.
+
+## Capabilities
+
+### New Capabilities
+- `range-question-display`: how a `range` question is presented to the respondent — the slider's
+  geometry and labelling, the set of display styles available to the creator, and which one applies
+  when.
+
+### Modified Capabilities
+
+None. `rating`'s display styles are not specified in `openspec/specs/` today, so there is no
+existing requirement to amend; this change specifies `range` only and leaves `rating` behaviour
+exactly as it is.
+
+## Impact
+
+- `survey/forms.py` — `RangeWidget`, and `_get_form_from_input_type`, which must now know the
+  display style to decide the field type.
+- `survey/assets/css/main.css` — slider alignment; the rating style blocks are reused unchanged.
+- `survey/templates/partials/survey_section_partial.html` — the render branch currently keyed on
+  `rating`.
+- `survey/templates/editor/partials/question_form_modal.html` — ungate "Display as".
+- `survey/models.py` — `display_style` help text, which says "only used by rating questions".
+- No migration: `display_style` already exists on `Question` with the values needed.
+- Backlog #99 closed; part of #102 closed.

--- a/openspec/changes/range-scale-display/specs/range-question-display/spec.md
+++ b/openspec/changes/range-scale-display/specs/range-question-display/spec.md
@@ -78,14 +78,20 @@ display style, because the choice-based styles have nothing to lay out.
 - **THEN** it renders as a slider
 - **AND** the page renders without error
 
-### Requirement: A required range question is enforced in every style
+### Requirement: An unanswered range question behaves the same in every style
 
-A `range` question marked required SHALL reject an empty submission identically in every display
-style.
+A `range` question left unanswered SHALL produce no answer row and SHALL NOT error, identically in
+every display style.
 
-#### Scenario: Empty submission rejected in each style
+Note: this deliberately does **not** say the submission is rejected. Answers are not validated
+server-side at all — the POST handler builds the form with `initial=request.POST`, so it is never
+bound and `required` is never enforced, for any question type. That is a pre-existing platform-wide
+gap, recorded separately; this requirement pins only that the display style does not change the
+behaviour.
 
-- **WHEN** a required range question is submitted with no value, rendered as a slider, as
+#### Scenario: Nothing selected in each style
+
+- **WHEN** a range question is submitted with its field absent, rendered as a slider, as
   `scale_strip`, and as `list_pips` in turn
-- **THEN** each submission is rejected with a validation error
-- **AND** no answer row is created
+- **THEN** no answer row is created in any of the three
+- **AND** the request completes without error

--- a/openspec/changes/range-scale-display/specs/range-question-display/spec.md
+++ b/openspec/changes/range-scale-display/specs/range-question-display/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: A range question is stored identically whatever its display style
+
+The display style SHALL affect presentation only. A `range` answer SHALL be stored in
+`Answer.numeric` regardless of which style rendered the question, and changing the style SHALL NOT
+alter, invalidate, or split answers already collected.
+
+#### Scenario: The same answer stored through each style
+
+- **WHEN** a respondent selects the value `5` on a range question rendered as a slider, and another
+  respondent selects `5` on the same question rendered as `scale_strip`
+- **THEN** both answers are stored with `numeric = 5`
+
+#### Scenario: Style changed after responses exist
+
+- **WHEN** a creator changes a range question's display style and the survey already holds answers
+- **THEN** the existing answers are unchanged
+- **AND** they continue to appear in the export under the same column
+
+### Requirement: Slider labels mark positions the respondent can reach
+
+When a range question renders as a slider, the endpoint labels and the tick marks SHALL be
+positioned against the range the slider's thumb can actually occupy, and SHALL agree with each
+other.
+
+#### Scenario: Endpoint labels align with the extreme thumb positions
+
+- **WHEN** a range question renders as a slider
+- **THEN** the first and last labels are positioned at the extreme positions the thumb can occupy,
+  not at the outer edges of the slider element
+
+#### Scenario: Ticks and labels share one alignment
+
+- **WHEN** a range question renders as a slider
+- **THEN** the tick row and the label row use the same horizontal inset
+
+### Requirement: A creator can choose how a range question is displayed
+
+A `range` question SHALL offer the same display styles as a `rating` question: the slider, a compact
+scale strip, and a labelled list. The choice SHALL be made per question in the question editor.
+
+#### Scenario: Display style control is offered for range questions
+
+- **WHEN** a creator opens the question editor for a `range` question
+- **THEN** the "Display as" control is shown, offering the slider, the scale strip and the labelled
+  list
+
+#### Scenario: Labelled list shows every choice's name
+
+- **WHEN** a range question with nine named choices renders as `list_pips`
+- **THEN** all nine names are present in the rendered output
+
+#### Scenario: Scale strip shows the endpoint names as anchors
+
+- **WHEN** a range question renders as `scale_strip`
+- **THEN** one cell is rendered per choice
+- **AND** the first and last choice names are shown as anchors beneath the strip
+
+### Requirement: An unset display style renders a range question as a slider
+
+For a `range` question, the `default` display style SHALL resolve to the slider. It SHALL NOT
+inherit the survey-wide rating display style.
+
+#### Scenario: Existing question keeps rendering as a slider
+
+- **WHEN** a range question has `display_style = 'default'`
+- **THEN** it renders as a slider, whatever the survey's `rating_display_style` is set to
+
+### Requirement: A range question without choices remains usable
+
+If a `range` question has no choices defined, it SHALL render as a slider regardless of the selected
+display style, because the choice-based styles have nothing to lay out.
+
+#### Scenario: Choice-based style falls back when there are no choices
+
+- **WHEN** a range question with no choices has `display_style = 'scale_strip'`
+- **THEN** it renders as a slider
+- **AND** the page renders without error
+
+### Requirement: A required range question is enforced in every style
+
+A `range` question marked required SHALL reject an empty submission identically in every display
+style.
+
+#### Scenario: Empty submission rejected in each style
+
+- **WHEN** a required range question is submitted with no value, rendered as a slider, as
+  `scale_strip`, and as `list_pips` in turn
+- **THEN** each submission is rejected with a validation error
+- **AND** no answer row is created

--- a/openspec/changes/range-scale-display/tasks.md
+++ b/openspec/changes/range-scale-display/tasks.md
@@ -38,68 +38,113 @@
 
 ## 2. Slider alignment
 
-- [ ] 2.1 Introduce a custom property for the thumb size on the slider block and derive the tick and
+- [x] 2.1 Introduce a custom property for the thumb size on the slider block and derive the tick and
       label insets from it, so both rows consume one declared value (design D3).
-- [ ] 2.2 Confirm the endpoint labels sit under the extreme positions the thumb can occupy, at both
+- [x] 2.2 Confirm the endpoint labels sit under the extreme positions the thumb can occupy, at both
       widths from 1.1.
-- [ ] 2.3 Act on 1.2's finding, or record explicitly that the width complaint was the question card
+- [x] 2.3 Act on 1.2's finding, or record explicitly that the width complaint was the question card
       and belongs to backlog #42 rather than here.
 
 ## 3. Display style for range questions
 
-- [ ] 3.1 Resolve the display style before the form field is built, rather than attaching it to the
+- [x] 3.1 Resolve the display style before the form field is built, rather than attaching it to the
       widget afterwards (`forms.py:251-255`). Range resolves `default` to the slider and does not
       consult the survey-wide rating default (design D4).
-- [ ] 3.2 Build a `ChoiceField` with `RadioSelect` for `scale_strip` and `list_pips`, keeping
+- [x] 3.2 Build a `ChoiceField` with `RadioSelect` for `scale_strip` and `list_pips`, keeping
       `IntegerField` + `RangeWidget` for the slider (design D2).
-- [ ] 3.3 Extend the render branch in `survey_section_partial.html` to cover `range`, reusing
+- [x] 3.3 Extend the render branch in `survey_section_partial.html` to cover `range`, reusing
       `rating_scale_strip.html` and `rating_list_pips.html` unchanged.
-- [ ] 3.4 Make prepopulation style-aware: `initial` is an int for the slider and the string form of
+- [x] 3.4 Make prepopulation style-aware: `initial` is an int for the slider and the string form of
       the choice code for the radio styles (`views.py:716-718`).
-- [ ] 3.5 Verify the same in the editor's live preview, which renders through its own frame
+- [x] 3.5 Verify the same in the editor's live preview, which renders through its own frame
       (`question_preview_frame.html`).
 
 ## 4. Fallback and editor
 
-- [ ] 4.1 Fall back to the slider when a range question has no choices, whatever style is selected,
+- [x] 4.1 Fall back to the slider when a range question has no choices, whatever style is selected,
       and render without error.
-- [ ] 4.2 Replace the `input_type === 'rating'` test that gates "Display as" with membership of a
+- [x] 4.2 Replace the `input_type === 'rating'` test that gates "Display as" with membership of a
       named set of types supporting display styles (design D5).
-- [ ] 4.3 Update the `display_style` help text on `Question`, which currently says "only used by
+- [x] 4.3 Update the `display_style` help text on `Question`, which currently says "only used by
       rating questions".
+
+  **Deliberately not done.** Django generates an `AlterField` migration for a `help_text` change, and
+  migration-number collisions between parallel worktree branches are a recurring problem here — not
+  worth it for a string. It is also not user-visible: `question_form_modal.html` excludes
+  `display_style` from its generic field loop and renders the control by hand without the help text,
+  so the sentence only exists in the model. Fold it into the next change that touches `Question` for
+  a real reason. The comment above `DISPLAY_STYLE_TYPES` in `forms.py` now carries the accurate
+  version.
 
 ## 5. Tests
 
-- [ ] 5.1 Round-trip an answer through all three styles and assert `Answer.numeric` is identical —
+- [x] 5.1 Round-trip an answer through all three styles and assert `Answer.numeric` is identical —
       the claim the whole change rests on.
-- [ ] 5.2 Assert a style change on a question with existing answers leaves those answers and their
+- [x] 5.2 Assert a style change on a question with existing answers leaves those answers and their
       export column untouched.
-- [ ] 5.3 Assert `list_pips` renders all nine names of a 9-point scale, and `scale_strip` renders one
+- [x] 5.3 Assert `list_pips` renders all nine names of a 9-point scale, and `scale_strip` renders one
       cell per choice plus the two anchors.
-- [ ] 5.4 Assert `default` renders a slider even when the survey's `rating_display_style` is set to
+- [x] 5.4 Assert `default` renders a slider even when the survey's `rating_display_style` is set to
       something else.
-- [ ] 5.5 Assert a required range question rejects an empty submission in each style, creating no
+- [x] 5.5 Assert a required range question rejects an empty submission in each style, creating no
       answer row.
-- [ ] 5.6 Assert a choice-less range question renders as a slider under a choice-based style.
-- [ ] 5.7 Assert back-navigation prepopulates the previous answer in each style.
+
+  **Rewritten, because the platform does not do this.** Answers are never validated server-side —
+  the POST handler passes `request.POST` as `initial`, so the form is never bound and `required` is
+  not enforced for any question type (filed as #107). The test now asserts what this change actually
+  guarantees: an unanswered range question stores nothing and does not error, identically in all
+  three styles. The spec scenario was corrected to match rather than left describing behaviour that
+  does not exist.
+- [x] 5.6 Assert a choice-less range question renders as a slider under a choice-based style.
+- [x] 5.7 Assert back-navigation prepopulates the previous answer in each style.
 
 ## 6. Verify
 
-- [ ] 6.1 Run the full survey suite: `./run_tests.sh survey`.
-- [ ] 6.2 Capture the after-picture at both widths from 1.1 and compare against the before.
-- [ ] 6.3 Measure `scale_strip` with nine choices at 320px. If the cells are unusably small, say so
+- [x] 6.1 Run the full survey suite: `./run_tests.sh survey`.
+
+  879 tests, OK. Two of them — LastActivityMiddleware's — had been failing before this change and
+  were nearly written off as environmental. They were not: `run_tests.sh` started only the db
+  container and passed no `REDIS_URL`, so `settings.py` fell back to `redis://localhost:6379/1`,
+  which on this machine belongs to an unrelated project. `CACHES` sets `IGNORE_EXCEPTIONS`, so the
+  suite was silently reading and writing another project's Redis. The runner now brings up redis
+  too, waits for both services instead of sleeping, and passes a `REDIS_URL` derived from
+  `PORT_OFFSET`. Committed separately (`c2c25f4`) since it is test infrastructure, not this feature.
+- [x] 6.2 Capture the after-picture at both widths from 1.1 and compare against the before.
+
+  Endpoint label error went from 11px on each side to **0** — the labels now sit exactly on the
+  extreme positions the thumb can occupy. Ticks are within half a pixel, which is the 1px tick's own
+  width. The 320px case was measured through the DOM rather than captured as an image, because the
+  browser window would not resize below its current size.
+- [x] 6.3 Measure `scale_strip` with nine choices at 320px. If the cells are unusably small, say so
       in the editor's style picker rather than letting creators pick it blind — or record explicitly
       that it was measured and judged acceptable.
 
+  Measured at a 320px panel: nine cells come out **20.5px wide** by 46px tall — under half the ~44px
+  a reliable touch target wants. `list_pips` at the same width keeps every label unclipped, and the
+  slider's end labels do not collide. So the strip is genuinely a poor choice for a long scale, and
+  the editor now says so: a hint appears under "Display as" when the strip is selected with more
+  than seven options. Note this applies to `rating` today too — the change did not introduce it,
+  it just stopped hiding it.
+
 ## 7. Close the loop
 
-- [ ] 7.1 Strike backlog #99; note in #102 which slice this covered and what remains (continuous
+- [x] 7.1 Strike backlog #99; note in #102 which slice this covered and what remains (continuous
       scale, vertical scale, ranking).
-- [ ] 7.2 Note that this is the second attempt at the same reporter's request — #5 shipped labels
+- [x] 7.2 Note that this is the second attempt at the same reporter's request — #5 shipped labels
       that did not align — so the after-picture is worth putting in front of him rather than
       announcing it as done.
-- [ ] 7.3 File a new backlog item for the finding in 1.2: the survey page always renders the map
+
+  Standing. The screenshot to send is the one from 6.2. Worth saying plainly that his "too short"
+  observation was correct and is a separate, larger problem now filed as #106, rather than implying
+  the whole report is closed.
+- [x] 7.3 Filed as **#106**. File a new backlog item for the finding in 1.2: the survey page always renders the map
       panel, so a survey with no geo questions gives ~80% of the viewport to an empty map and
       squeezes every question into a ~370px column. This is the actual cause of "the slider is too
       short", it affects every question type rather than just `range`, and it is plausibly a bigger
       readability problem than anything in this change. Deliberately out of scope here.
+
+- [x] 7.4 File the finding from §5: answers are never validated server-side, because the POST
+      handler passes `request.POST` as `initial` so the form is never bound. Filed as **#107**. It
+      is the general case of a symptom previously recorded as geo-only, and it is why the spec
+      requirement about required questions was rewritten to assert sameness across styles instead of
+      rejection.

--- a/openspec/changes/range-scale-display/tasks.md
+++ b/openspec/changes/range-scale-display/tasks.md
@@ -1,13 +1,40 @@
 ## 1. Reproduce before changing anything
 
-- [ ] 1.1 Build a survey with a 9-point named range question mirroring the reporter's ("(positive)
+- [x] 1.1 Build a survey with a 9-point named range question mirroring the reporter's ("(positive)
       Geräusche" → "(negativer) Lärm") and capture the slider as rendered, at desktop width and at
       320px. This is the before-picture the fix is judged against.
-- [ ] 1.2 Answer the open question from the design: is "the slider is too short" about the slider or
+
+  Reproduced locally. Measured geometry: the slider spans x=41→378 (337px), the thumb is 22px so
+  the extreme thumb *centres* sit at 52 and 367. The tick row (`padding: 0 10px`) puts its outer
+  ticks at 51.5 and 367.5 — near enough. The label row (`padding: 0`) starts at 41 and ends at 378,
+  so **each endpoint label is 11px outside the position it claims to mark**. The error is a
+  constant, independent of width, so it grows as a proportion on a narrower panel.
+  Desktop capture: `screenshot-1785912570031-0.jpg`. The 320px capture was not taken — the window
+  would not resize below its current size — but the constant-offset finding makes the fix
+  width-independent, so it does not gate the work.
+
+- [x] 1.2 Answer the open question from the design: is "the slider is too short" about the slider or
       about the width of the question card containing it? Measure both; do not change anything until
       it is known which.
-- [ ] 1.3 Check production for `range` questions with no `choices` defined. Their existence decides
+
+  **Neither — it is the page layout, and it is not a range problem at all.** At a 1854px viewport
+  the question panel is 371px, because `base_survey_template.html:74` renders `<div id="map">`
+  unconditionally and it claims the rest of the width. The reproduction survey has no geo question
+  whatsoever and still gives ~80% of the screen to an empty map. Every question type in a non-geo
+  survey is squeezed the same way; the slider is just where it shows most, being the one control
+  that wants horizontal room.
+  Filed separately rather than fixed here — see 7.3. §2.3 below is therefore a no-op beyond
+  recording this.
+
+- [x] 1.3 Check production for `range` questions with no `choices` defined. Their existence decides
       whether the fallback in §4 is a real path or a defensive one.
+
+  **A real path: 34 of 122 range questions in production have no choices** (28%). They currently
+  render on the slider's 0–10 fallback (`forms.py:191-195`). Under a choice-based style they would
+  have nothing to lay out, so §4.1 is load-bearing and needs a test, not a comment.
+  Also confirmed: `display_style` is `default` on every range question in production (0 non-default),
+  which is expected since the control has never been offered for them — so no existing question
+  changes appearance when the styles are ungated.
 
 ## 2. Slider alignment
 
@@ -71,3 +98,8 @@
 - [ ] 7.2 Note that this is the second attempt at the same reporter's request — #5 shipped labels
       that did not align — so the after-picture is worth putting in front of him rather than
       announcing it as done.
+- [ ] 7.3 File a new backlog item for the finding in 1.2: the survey page always renders the map
+      panel, so a survey with no geo questions gives ~80% of the viewport to an empty map and
+      squeezes every question into a ~370px column. This is the actual cause of "the slider is too
+      short", it affects every question type rather than just `range`, and it is plausibly a bigger
+      readability problem than anything in this change. Deliberately out of scope here.

--- a/openspec/changes/range-scale-display/tasks.md
+++ b/openspec/changes/range-scale-display/tasks.md
@@ -1,0 +1,73 @@
+## 1. Reproduce before changing anything
+
+- [ ] 1.1 Build a survey with a 9-point named range question mirroring the reporter's ("(positive)
+      Geräusche" → "(negativer) Lärm") and capture the slider as rendered, at desktop width and at
+      320px. This is the before-picture the fix is judged against.
+- [ ] 1.2 Answer the open question from the design: is "the slider is too short" about the slider or
+      about the width of the question card containing it? Measure both; do not change anything until
+      it is known which.
+- [ ] 1.3 Check production for `range` questions with no `choices` defined. Their existence decides
+      whether the fallback in §4 is a real path or a defensive one.
+
+## 2. Slider alignment
+
+- [ ] 2.1 Introduce a custom property for the thumb size on the slider block and derive the tick and
+      label insets from it, so both rows consume one declared value (design D3).
+- [ ] 2.2 Confirm the endpoint labels sit under the extreme positions the thumb can occupy, at both
+      widths from 1.1.
+- [ ] 2.3 Act on 1.2's finding, or record explicitly that the width complaint was the question card
+      and belongs to backlog #42 rather than here.
+
+## 3. Display style for range questions
+
+- [ ] 3.1 Resolve the display style before the form field is built, rather than attaching it to the
+      widget afterwards (`forms.py:251-255`). Range resolves `default` to the slider and does not
+      consult the survey-wide rating default (design D4).
+- [ ] 3.2 Build a `ChoiceField` with `RadioSelect` for `scale_strip` and `list_pips`, keeping
+      `IntegerField` + `RangeWidget` for the slider (design D2).
+- [ ] 3.3 Extend the render branch in `survey_section_partial.html` to cover `range`, reusing
+      `rating_scale_strip.html` and `rating_list_pips.html` unchanged.
+- [ ] 3.4 Make prepopulation style-aware: `initial` is an int for the slider and the string form of
+      the choice code for the radio styles (`views.py:716-718`).
+- [ ] 3.5 Verify the same in the editor's live preview, which renders through its own frame
+      (`question_preview_frame.html`).
+
+## 4. Fallback and editor
+
+- [ ] 4.1 Fall back to the slider when a range question has no choices, whatever style is selected,
+      and render without error.
+- [ ] 4.2 Replace the `input_type === 'rating'` test that gates "Display as" with membership of a
+      named set of types supporting display styles (design D5).
+- [ ] 4.3 Update the `display_style` help text on `Question`, which currently says "only used by
+      rating questions".
+
+## 5. Tests
+
+- [ ] 5.1 Round-trip an answer through all three styles and assert `Answer.numeric` is identical —
+      the claim the whole change rests on.
+- [ ] 5.2 Assert a style change on a question with existing answers leaves those answers and their
+      export column untouched.
+- [ ] 5.3 Assert `list_pips` renders all nine names of a 9-point scale, and `scale_strip` renders one
+      cell per choice plus the two anchors.
+- [ ] 5.4 Assert `default` renders a slider even when the survey's `rating_display_style` is set to
+      something else.
+- [ ] 5.5 Assert a required range question rejects an empty submission in each style, creating no
+      answer row.
+- [ ] 5.6 Assert a choice-less range question renders as a slider under a choice-based style.
+- [ ] 5.7 Assert back-navigation prepopulates the previous answer in each style.
+
+## 6. Verify
+
+- [ ] 6.1 Run the full survey suite: `./run_tests.sh survey`.
+- [ ] 6.2 Capture the after-picture at both widths from 1.1 and compare against the before.
+- [ ] 6.3 Measure `scale_strip` with nine choices at 320px. If the cells are unusably small, say so
+      in the editor's style picker rather than letting creators pick it blind — or record explicitly
+      that it was measured and judged acceptable.
+
+## 7. Close the loop
+
+- [ ] 7.1 Strike backlog #99; note in #102 which slice this covered and what remains (continuous
+      scale, vertical scale, ranking).
+- [ ] 7.2 Note that this is the second attempt at the same reporter's request — #5 shipped labels
+      that did not align — so the after-picture is worth putting in front of him rather than
+      announcing it as done.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
-# Run Django tests with PostGIS database
+# Run Django tests with PostGIS and Redis
 
 # Per-worktree port isolation (see .env.ports.example). Tests reuse the dev
-# PostGIS container of this worktree; Django creates its own test_ database.
+# PostGIS and Redis containers of this worktree; Django creates its own test_
+# database.
 [ -f .env.ports ] && source .env.ports
 PORT_OFFSET="${PORT_OFFSET:-0}"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-mapsurvey}"
 export HOST_DB_PORT=$((5434 + PORT_OFFSET))
+export HOST_REDIS_PORT=$((6379 + PORT_OFFSET))
 
-# Ensure db container is running
-docker compose up -d db
+# Redis matters even though few tests touch it directly. settings.py falls back
+# to redis://localhost:6379/1 when REDIS_URL is unset, and on a machine running
+# several projects that port belongs to whichever one started first — so the
+# suite would connect to a stranger's Redis and write into its database.
+# CACHES sets IGNORE_EXCEPTIONS, so this fails silently rather than loudly:
+# cache-backed behaviour (LastActivityMiddleware's throttle, rate limiting) just
+# quietly does the wrong thing.
+docker compose up -d db redis
 
-# Wait for database to be ready
-sleep 2
+echo "⏳ Waiting for PostGIS on :$HOST_DB_PORT and Redis on :$HOST_REDIS_PORT..."
+until pg_isready -h localhost -p "$HOST_DB_PORT" -U mapsurvey >/dev/null 2>&1; do
+    sleep 1
+done
+until docker compose exec -T redis redis-cli ping >/dev/null 2>&1; do
+    sleep 1
+done
 
 # Run tests with proper environment
 source env/bin/activate
@@ -22,4 +35,5 @@ SQL_USER=mapsurvey \
 SQL_PASSWORD=mapsurvey \
 SQL_HOST=localhost \
 SQL_PORT=$HOST_DB_PORT \
+REDIS_URL=redis://localhost:$HOST_REDIS_PORT/1 \
 python manage.py test "$@"

--- a/survey/assets/css/main.css
+++ b/survey/assets/css/main.css
@@ -257,7 +257,15 @@ ul {
   min-height: 80px;
 }
 
-/* Range slider */
+/* Range slider
+   The thumb is round and wide, so the leftmost and rightmost positions it can
+   occupy are inset from the track's own edges by half its width. Ticks and
+   labels must use that same inset or they mark positions the respondent
+   cannot select. Both derive it from one declared value. */
+.range-field {
+  --range-thumb-size: 22px;
+  --range-track-inset: calc(var(--range-thumb-size) / 2);
+}
 .question-card input[type="range"] {
   width: 100%;
   -webkit-appearance: none;
@@ -268,10 +276,11 @@ ul {
   outline: none;
   margin: 16px 0 4px;
 }
-.range-ticks {
+.range-ticks,
+.range-labels {
   display: flex;
   justify-content: space-between;
-  padding: 0 10px;
+  padding: 0 var(--range-track-inset);
 }
 .range-ticks span {
   width: 1px;
@@ -279,18 +288,26 @@ ul {
   background: #ccc;
 }
 .range-labels {
-  display: flex;
-  justify-content: space-between;
   font-size: 0.75rem;
   color: #888;
   margin-top: 2px;
+  gap: 12px;
+}
+/* The end labels read as anchors for the ends of the scale, so they hug the
+   extremes rather than centring on them — a centred first label would start
+   outside the card. */
+.range-labels span:first-child {
+  text-align: left;
+}
+.range-labels span:last-child {
+  text-align: right;
 }
 
 .question-card input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 22px;
-  height: 22px;
+  width: var(--range-thumb-size);
+  height: var(--range-thumb-size);
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
@@ -304,8 +321,8 @@ ul {
 }
 
 .question-card input[type="range"]::-moz-range-thumb {
-  width: 22px;
-  height: 22px;
+  width: var(--range-thumb-size);
+  height: var(--range-thumb-size);
   border: none;
   border-radius: 50%;
   background: var(--accent);
@@ -316,15 +333,15 @@ ul {
    Rating question — two display styles
    (scale_strip / list_pips, per Question.display_style)
    ============================================ */
-.question-card--rating label > input[type="radio"] {
+.question-card--scale label > input[type="radio"] {
   opacity: 0;
   position: absolute;
   width: 0;
   height: 0;
 }
 
-.question-card--rating label:has(input[type="radio"])::before,
-.question-card--rating label:has(input[type="radio"])::after {
+.question-card--scale label:has(input[type="radio"])::before,
+.question-card--scale label:has(input[type="radio"])::after {
   display: none;
 }
 
@@ -335,7 +352,7 @@ ul {
   margin-top: 4px;
 }
 
-.question-card--rating .rating-scale-strip__cell:has(input[type="radio"]) {
+.question-card--scale .rating-scale-strip__cell:has(input[type="radio"]) {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -353,19 +370,19 @@ ul {
   transition: all var(--transition);
 }
 
-.question-card--rating .rating-scale-strip__cell:has(input[type="radio"]):hover {
+.question-card--scale .rating-scale-strip__cell:has(input[type="radio"]):hover {
   border-color: var(--accent);
   background: var(--accent-light);
 }
 
-.question-card--rating .rating-scale-strip__cell:has(input[type="radio"]:checked) {
+.question-card--scale .rating-scale-strip__cell:has(input[type="radio"]:checked) {
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
   box-shadow: 0 2px 8px rgba(79, 70, 229, 0.3);
 }
 
-.question-card--rating .rating-scale-strip__cell:has(input[type="radio"]:checked):hover {
+.question-card--scale .rating-scale-strip__cell:has(input[type="radio"]:checked):hover {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
 }
@@ -412,7 +429,7 @@ ul {
   margin-top: 4px;
 }
 
-.question-card--rating .rating-list-pips__row:has(input[type="radio"]) {
+.question-card--scale .rating-list-pips__row:has(input[type="radio"]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -431,7 +448,7 @@ ul {
   transition: all var(--transition);
 }
 
-.question-card--rating .rating-list-pips__row:has(input[type="radio"]):hover {
+.question-card--scale .rating-list-pips__row:has(input[type="radio"]):hover {
   border-color: var(--accent);
   background: var(--accent-light);
 }
@@ -458,18 +475,18 @@ ul {
   background: #b4b9c4;
 }
 
-.question-card--rating .rating-list-pips__row:has(input[type="radio"]:checked) {
+.question-card--scale .rating-list-pips__row:has(input[type="radio"]:checked) {
   border-color: var(--accent);
   background: var(--accent-light);
   color: var(--accent);
   font-weight: 600;
 }
 
-.question-card--rating .rating-list-pips__row:has(input[type="radio"]:checked) .rating-list-pips__pips i {
+.question-card--scale .rating-list-pips__row:has(input[type="radio"]:checked) .rating-list-pips__pips i {
   background: #c7cdf7;
 }
 
-.question-card--rating .rating-list-pips__row:has(input[type="radio"]:checked) .rating-list-pips__pips i.on {
+.question-card--scale .rating-list-pips__row:has(input[type="radio"]:checked) .rating-list-pips__pips i.on {
   background: var(--accent);
 }
 

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -66,7 +66,13 @@ class RangeWidget(widgets.Input):
         else:
             labels_html = ''
 
-        return mark_safe(input_html + ticks_html + labels_html)
+        # The wrapper scopes --range-thumb-size, from which the tick and label
+        # rows derive their inset. Without it each row guesses separately and
+        # they drift apart, which is how the labels came to sit outside the
+        # positions the thumb can actually reach.
+        return mark_safe(
+            '<div class="range-field">' + input_html + ticks_html + labels_html + '</div>'
+        )
 
 
 class LeafletDrawButtonWidget(widgets.Widget):
@@ -163,7 +169,43 @@ class ShowImageField(forms.Field):
 
 class SurveySectionAnswerForm(forms.Form):
 
-    def _get_form_from_input_type(self, input_type, required, question, label, sublabel, color, icon_class, image_source, language=None):
+    # Question types whose rendering the creator can pick. Membership, rather
+    # than a chain of equality tests, so the next type to gain display styles
+    # is one entry here and in the editor's gate.
+    DISPLAY_STYLE_TYPES = ('rating', 'range')
+
+    # Styles that lay out one element per choice, and so need choices to exist.
+    CHOICE_BASED_STYLES = ('scale_strip', 'list_pips')
+
+    @classmethod
+    def resolve_display_style(cls, question, survey_rating_style):
+        """Decide how a question is rendered.
+
+        For `range`, `default` means the slider and deliberately does not
+        inherit the survey-wide rating style — inheriting would silently
+        restyle every existing range question the first time this deploys.
+
+        A choice-based style with no choices to lay out falls back to the
+        slider rather than rendering an empty control. 28% of range questions
+        in production have no choices, so this is a live path.
+        """
+        # Types that do not support display styles must resolve to the plain
+        # rendering. Without this every question — text, number, geo — inherits
+        # the survey-wide rating style and any consumer keying on the resolved
+        # value alone will send a textarea through the scale partials.
+        if question.input_type not in cls.DISPLAY_STYLE_TYPES:
+            return 'default'
+
+        chosen = question.display_style if question.display_style in cls.CHOICE_BASED_STYLES else None
+
+        if question.input_type == 'range':
+            if chosen and not question.choices:
+                return 'default'
+            return chosen or 'default'
+
+        return chosen or survey_rating_style
+
+    def _get_form_from_input_type(self, input_type, required, question, label, sublabel, color, icon_class, image_source, language=None, display_style='default'):
 
         if input_type == 'text':
             return forms.CharField(widget=forms.Textarea, label=label, required=required)
@@ -189,6 +231,18 @@ class SurveySectionAnswerForm(forms.Form):
 
         elif input_type == 'range':
             choices = question.choices or []
+
+            # The choice-based styles render one radio per choice, which an
+            # IntegerField cannot supply. The stored value is unaffected: the
+            # save path keys on question.input_type, not on the widget.
+            if display_style in self.CHOICE_BASED_STYLES and choices:
+                return forms.ChoiceField(
+                    widget=forms.RadioSelect(),
+                    choices=[(c["code"], question.get_choice_name(c["code"], language)) for c in choices],
+                    label=label,
+                    required=required,
+                )
+
             codes = [c["code"] for c in choices]
             minimum = min(codes) if codes else 0
             maximum = max(codes) if codes else 10
@@ -246,13 +300,13 @@ class SurveySectionAnswerForm(forms.Form):
             field_icon_class = question.icon_class
             image_source = question.image.url if question.image else None
 
-            self.fields[field_name] = self._get_form_from_input_type(question.input_type, question.required, question, field_label, field_sublabel, field_color, field_icon_class, image_source, language)
+            # Resolved before the field is built, because for `range` it
+            # decides which kind of field to build.
+            resolved_style = self.resolve_display_style(question, survey_rating_style)
+
+            self.fields[field_name] = self._get_form_from_input_type(question.input_type, question.required, question, field_label, field_sublabel, field_color, field_icon_class, image_source, language, display_style=resolved_style)
             self.fields[field_name].widget.question_type = question.input_type
-            self.fields[field_name].widget.display_style = (
-                question.display_style
-                if question.display_style in ('scale_strip', 'list_pips')
-                else survey_rating_style
-            )
+            self.fields[field_name].widget.display_style = resolved_style
 
 
     def save(self):

--- a/survey/templates/editor/partials/question_form_modal.html
+++ b/survey/templates/editor/partials/question_form_modal.html
@@ -68,6 +68,12 @@
                 </label>
                 {% endfor %}
             </div>
+            <small id="scale-strip-width-hint" class="form-text text-muted" style="display:none;">
+                <i class="fas fa-info-circle"></i>
+                With this many options the strip gets cramped on a phone — measured at roughly 20px
+                per option on a 320px screen, which is hard to tap. The labelled list stays readable
+                at any length.
+            </small>
         </div>
         <style>
             #display-style-fields .ds-option input[type="radio"] { position:absolute; opacity:0; width:0; height:0; }
@@ -214,9 +220,24 @@
     // SurveySectionAnswerForm.DISPLAY_STYLE_TYPES — keep the two in step.
     var DISPLAY_STYLE_TYPES = ['rating', 'range'];
 
+    // Beyond this many options the scale strip is under ~25px per cell on a
+    // 320px screen. Measured, not guessed: nine options give 20.5px.
+    var STRIP_CRAMPED_ABOVE = 7;
+
+    function toggleStripWidthHint() {
+        var hint = document.getElementById('scale-strip-width-hint');
+        if (!hint) return;
+        var tbody = document.getElementById('choices-rows');
+        var count = tbody ? tbody.querySelectorAll('.choice-code').length : 0;
+        var stripSelected = document.querySelector('#display-style-fields input[value="scale_strip"]:checked');
+        hint.style.display = (stripSelected && count > STRIP_CRAMPED_ABOVE) ? 'block' : 'none';
+    }
+    window.toggleStripWidthHint = toggleStripWidthHint;
+
     function toggleDisplayStyleFields() {
         var el = document.getElementById('display-style-fields');
         if (el) el.style.display = (inputTypeSelect && DISPLAY_STYLE_TYPES.indexOf(inputTypeSelect.value) !== -1) ? 'block' : 'none';
+        toggleStripWidthHint();
     }
 
     if (inputTypeSelect) {
@@ -225,6 +246,10 @@
         toggleValidationFields();
         toggleDisplayStyleFields();
     }
+
+    document.querySelectorAll('#display-style-fields input[name="display_style"]').forEach(function(radio) {
+        radio.addEventListener('change', toggleStripWidthHint);
+    });
 
     window.addChoiceRow = function(code, name) {
         var tbody = document.getElementById('choices-rows');
@@ -468,5 +493,8 @@
         addChoiceRow(choice.code, choice.name);
     });
     {% endif %}
+
+    // After the rows exist, so the count is right on first open.
+    toggleStripWidthHint();
 })();
 </script>

--- a/survey/templates/editor/partials/question_form_modal.html
+++ b/survey/templates/editor/partials/question_form_modal.html
@@ -44,7 +44,7 @@
         {% endif %}
         {% endfor %}
 
-        <!-- Display style (rating only) -->
+        <!-- Display style (see DISPLAY_STYLE_TYPES below) -->
         <div id="display-style-fields" style="display:none;" class="mb-3">
             <label style="font-weight:600;">Display as</label>
             <div style="display:flex;gap:8px;">
@@ -210,9 +210,13 @@
         if (polyEl) polyEl.style.display = (t === 'polygon') ? 'block' : 'none';
     }
 
+    // Types whose rendering the creator can pick. Mirrors
+    // SurveySectionAnswerForm.DISPLAY_STYLE_TYPES — keep the two in step.
+    var DISPLAY_STYLE_TYPES = ['rating', 'range'];
+
     function toggleDisplayStyleFields() {
         var el = document.getElementById('display-style-fields');
-        if (el) el.style.display = (inputTypeSelect && inputTypeSelect.value === 'rating') ? 'block' : 'none';
+        if (el) el.style.display = (inputTypeSelect && DISPLAY_STYLE_TYPES.indexOf(inputTypeSelect.value) !== -1) ? 'block' : 'none';
     }
 
     if (inputTypeSelect) {

--- a/survey/templates/editor/partials/question_preview_frame.html
+++ b/survey/templates/editor/partials/question_preview_frame.html
@@ -15,8 +15,8 @@
 <body>
     <div class="questions">
         {% for field in form.visible_fields %}
-            {% if field|question_type == 'rating' %}
-                <div class="question-card question-card--rating">
+            {% if field|uses_scale_style %}
+                <div class="question-card question-card--scale">
                     {% if field.label %}<label for="{{ field.id_for_label }}">{{ field.label }}</label>{% endif %}
                     {% if field|rating_display_style == 'list_pips' %}
                         {% include "partials/rating_list_pips.html" %}

--- a/survey/templates/partials/survey_section_partial.html
+++ b/survey/templates/partials/survey_section_partial.html
@@ -36,8 +36,8 @@
                 {% csrf_token %}
                 {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
                 {% for field in form.visible_fields %}
-                    {% if field|question_type == 'rating' %}
-                        <div class="question-card question-card--rating">
+                    {% if field|uses_scale_style %}
+                        <div class="question-card question-card--scale">
                             {% if field.label %}<label for="{{ field.id_for_label }}">{{ field.label }}</label>{% endif %}
                             {{ field.errors }}
                             {% if field|rating_display_style == 'list_pips' %}

--- a/survey/templatetags/question_utils.py
+++ b/survey/templatetags/question_utils.py
@@ -21,6 +21,28 @@ def rating_display_style(field):
     return getattr(field.field.widget, 'display_style', 'scale_strip')
 
 
+# Styles that lay out one element per choice, and so share the scale partials.
+CHOICE_BASED_STYLES = {'scale_strip', 'list_pips'}
+
+# Types that can render through those partials. The style alone is not enough
+# to decide: a text question would be sent through them and blow up on
+# field.field.choices.
+SCALE_STYLE_TYPES = {'rating', 'range'}
+
+
+@register.filter
+def uses_scale_style(field):
+    """True when the question renders through the shared scale partials.
+
+    `rating` always resolves to one of these. `range` only does so when its
+    creator picked one — `default` keeps the slider, which renders as an
+    ordinary card question.
+    """
+    if getattr(field.field.widget, 'question_type', None) not in SCALE_STYLE_TYPES:
+        return False
+    return getattr(field.field.widget, 'display_style', None) in CHOICE_BASED_STYLES
+
+
 @register.filter
 def get_range(count):
     return range(int(count))

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -17759,3 +17759,244 @@ class AcquisitionDashboardRenderTest(TestCase):
 
         self.assertEqual(resp.status_code, 302)
         self.assertIn("/admin/login/", resp["Location"])
+
+
+class RangeDisplayStyleTest(TestCase):
+    """Display styles for range questions.
+
+    The change rests on one claim — that the display style is presentation
+    only and never touches what is stored — so that is asserted first and
+    most directly.
+    """
+
+    LABELS = [
+        '(positive) Geräusche', 'sehr angenehm', 'angenehm', 'eher angenehm',
+        'neutral', 'eher störend', 'störend', 'sehr störend', '(negativer) Lärm',
+    ]
+
+    def setUp(self):
+        self.org = _make_org('RangeStyleOrg')
+        self.user = User.objects.create_user('rangeuser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+        self.choices = [{"code": i + 1, "name": {"en": name}}
+                        for i, name in enumerate(self.LABELS)]
+
+    def _survey(self, display_style='default', choices='use-default', required=False,
+                rating_default='scale_strip'):
+        survey = SurveyHeader.objects.create(
+            name=f'range_{display_style}_{id(self)}', organization=self.org,
+            created_by=self.user, status='published',
+            style_settings={'rating_display_style': rating_default},
+        )
+        section = SurveySection.objects.create(
+            survey_header=survey, name='s1', code='S1', is_head=True,
+        )
+        question = Question.objects.create(
+            survey_section=section, name='Loudness', code='q_range',
+            input_type='range', order_number=1, required=required,
+            choices=self.choices if choices == 'use-default' else choices,
+            display_style=display_style,
+        )
+        # A fresh client per survey: request.session['survey_session_id'] binds
+        # to the first survey a client visits, and every fixture here names its
+        # section s1, so a reused client would write answers into the previous
+        # survey's section. Per survey, not per request — the session has to
+        # survive between submitting and navigating back.
+        self.client = Client()
+        return survey, section, question
+
+    def _get(self, survey):
+        return self.client.get(f'/surveys/{survey.uuid}/s1/')
+
+    def _submit(self, survey, data):
+        return self.client.post(f'/surveys/{survey.uuid}/s1/', data)
+
+    # ── The claim the whole change rests on ────────────────────────────────
+
+    def test_every_style_stores_the_same_value(self):
+        """
+        GIVEN the same range question rendered as a slider, a scale strip and
+              a labelled list
+        WHEN a respondent answers 5 in each
+        THEN all three are stored as numeric 5
+        """
+        stored = {}
+        for style in ('default', 'scale_strip', 'list_pips'):
+            survey, _section, question = self._survey(display_style=style)
+            self._get(survey)
+            self._submit(survey, {'q_range': '5'})
+            answer = Answer.objects.get(question=question)
+            stored[style] = (answer.numeric, answer.selected_choices)
+
+        self.assertEqual(stored['default'][0], 5)
+        self.assertEqual(stored['scale_strip'], stored['default'])
+        self.assertEqual(stored['list_pips'], stored['default'])
+
+    def test_changing_style_leaves_existing_answers_untouched(self):
+        """
+        GIVEN a range question with an answer already collected
+        WHEN the creator switches its display style
+        THEN the stored answer is unchanged and still exports in its column
+        """
+        survey, _section, question = self._survey(display_style='default')
+        self._get(survey)
+        self._submit(survey, {'q_range': '7'})
+        before = Answer.objects.get(question=question)
+
+        question.display_style = 'list_pips'
+        question.save()
+
+        after = Answer.objects.get(pk=before.pk)
+        self.assertEqual(after.numeric, before.numeric)
+        self.assertEqual(after.selected_choices, before.selected_choices)
+
+        self.client.login(username='rangeuser', password='pass')
+        response = self.client.get(f'/surveys/{survey.uuid}/download')
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            csv_name = [n for n in zf.namelist() if n.endswith('.csv')][0]
+            csv_text = zf.read(csv_name).decode('utf-8')
+        self.assertIn('Loudness', csv_text)
+        self.assertIn('7.0', csv_text)
+
+    # ── What each style renders ────────────────────────────────────────────
+
+    def test_list_pips_shows_every_choice_name(self):
+        """
+        GIVEN a nine-point range question displayed as a labelled list
+        WHEN a respondent opens the section
+        THEN all nine names are present, not just the endpoints
+        """
+        survey, _section, _q = self._survey(display_style='list_pips')
+
+        response = self._get(survey)
+
+        for name in self.LABELS:
+            self.assertContains(response, name)
+
+    def test_scale_strip_renders_one_cell_per_choice_with_anchors(self):
+        """
+        GIVEN a nine-point range question displayed as a scale strip
+        WHEN a respondent opens the section
+        THEN there is one cell per choice and the endpoint names anchor it
+        """
+        survey, _section, _q = self._survey(display_style='scale_strip')
+
+        response = self._get(survey)
+        content = response.content.decode()
+
+        # The trailing quote matters: the container is __cells, which contains
+        # __cell as a prefix and would inflate the count to ten.
+        self.assertEqual(content.count('rating-scale-strip__cell"'), 9)
+        self.assertIn('(positive) Geräusche', content)
+        self.assertIn('(negativer) Lärm', content)
+
+    def test_default_renders_a_slider_regardless_of_the_rating_default(self):
+        """
+        GIVEN a range question with no display style chosen, in a survey whose
+              rating default is list_pips
+        WHEN a respondent opens the section
+        THEN it renders as a slider, not as the rating default
+        """
+        survey, _section, _q = self._survey(
+            display_style='default', rating_default='list_pips',
+        )
+
+        content = self._get(survey).content.decode()
+
+        self.assertIn('type="range"', content)
+        self.assertNotIn('rating-list-pips', content)
+
+    def test_choice_based_style_falls_back_when_there_are_no_choices(self):
+        """
+        GIVEN a range question with no choices but a choice-based style
+        WHEN a respondent opens the section
+        THEN it renders as a slider without error
+
+        28% of range questions in production have no choices, so this is a
+        live path rather than a defensive one.
+        """
+        survey, _section, _q = self._survey(display_style='scale_strip', choices=None)
+
+        response = self._get(survey)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('type="range"', content)
+        # Not the bare block name: base_survey_template.html carries inline JS
+        # referencing .rating-scale-strip__chip on every page.
+        self.assertNotIn('rating-scale-strip__cell', content)
+
+    # ── Behaviour that must not differ between styles ──────────────────────
+
+    def test_unanswered_question_behaves_the_same_in_every_style(self):
+        """
+        GIVEN a required range question
+        WHEN the section is submitted with the field absent, in each style
+        THEN no answer is stored and the request does not error
+
+        This asserts sameness across styles, not rejection: answers are never
+        validated server-side, because the POST handler passes request.POST as
+        `initial` so the form is never bound. Pre-existing and platform-wide.
+        """
+        for style in ('default', 'scale_strip', 'list_pips'):
+            with self.subTest(style=style):
+                survey, _section, question = self._survey(
+                    display_style=style, required=True,
+                )
+                self._get(survey)
+
+                response = self._submit(survey, {})
+
+                self.assertIn(response.status_code, (200, 302))
+                self.assertFalse(Answer.objects.filter(question=question).exists())
+
+    def test_previous_answer_is_prepopulated_in_every_style(self):
+        """
+        GIVEN a range question already answered
+        WHEN the respondent navigates back to the section in each style
+        THEN the previous value is preselected
+        """
+        for style in ('default', 'scale_strip', 'list_pips'):
+            with self.subTest(style=style):
+                survey, _section, _q = self._survey(display_style=style)
+                self._get(survey)
+                self._submit(survey, {'q_range': '4'})
+
+                content = self._get(survey).content.decode()
+
+                if style == 'default':
+                    self.assertIn('value="4"', content)
+                else:
+                    # id sits between value and checked, so match the input as
+                    # a whole rather than assuming attribute adjacency.
+                    self.assertRegex(
+                        content,
+                        r'<input[^>]*name="q_range"[^>]*value="4"[^>]*checked',
+                    )
+
+    # ── Style resolution in isolation ──────────────────────────────────────
+
+    def test_rating_still_inherits_the_survey_default(self):
+        """
+        GIVEN a rating question with no style of its own
+        WHEN the style is resolved
+        THEN it inherits the survey-wide rating default, as before this change
+        """
+        _survey, _section, question = self._survey()
+        question.input_type = 'rating'
+
+        resolved = SurveySectionAnswerForm.resolve_display_style(question, 'list_pips')
+
+        self.assertEqual(resolved, 'list_pips')
+
+    def test_range_does_not_inherit_the_survey_default(self):
+        """
+        GIVEN a range question with no style of its own
+        WHEN the style is resolved
+        THEN it is the slider, whatever the survey-wide rating default is
+        """
+        _survey, _section, question = self._survey()
+
+        resolved = SurveySectionAnswerForm.resolve_display_style(question, 'list_pips')
+
+        self.assertEqual(resolved, 'default')

--- a/survey/views.py
+++ b/survey/views.py
@@ -718,7 +718,16 @@ def _build_section_context(request, survey, session_survey, section, selected_la
 					initial[question.code] = [str(c) for c in answer.selected_choices]
 			elif question.input_type == 'range':
 				if answer.numeric is not None:
-					initial[question.code] = int(answer.numeric)
+					# The slider takes an int; the choice-based styles are radios
+					# and need the string form to match one of their choices.
+					# Same stored value either way — only the shape differs.
+					resolved_style = SurveySectionAnswerForm.resolve_display_style(
+						question, section.survey_header.get_default_rating_display_style()
+					)
+					if resolved_style in SurveySectionAnswerForm.CHOICE_BASED_STYLES:
+						initial[question.code] = str(int(answer.numeric))
+					else:
+						initial[question.code] = int(answer.numeric)
 
 	form = SurveySectionAnswerForm(initial=initial, section=section, question=None, survey_session_id=request.session['survey_session_id'], language=selected_language)
 


### PR DESCRIPTION
Backlog #99. Second attempt at the same reporter's request — #5 shipped endpoint labels and they did not line up, which is worse than not having shipped them.

## The defects

**Labels marked positions the respondent cannot reach.** The tick row carried `padding: 0 10px`, the label row carried none, and neither accounted for the 22px thumb, whose width insets the reachable extremes of the track by half that at each end. Measured before the fix: each endpoint label sat **11px outside** the position it claimed to mark. A constant offset, so it grows as a proportion on a narrow panel.

**Seven of nine names were invisible.** The widget emitted anonymous ticks for intermediate values and text only for the first and last choice. On the reporter's 9-point named scale that hides most of the scale.

## Approach

Alignment: both rows now derive their inset from `--range-thumb-size` on a `.range-field` wrapper, so there is one declared value instead of two that drifted apart. Error after the fix: **0px** on both sides.

Labels: rather than inventing a "show all labels" mechanism, `range` gets the display styles `rating` already has. `scale_strip` lays the choices out as a grid with aligned anchors; `list_pips` gives each choice a row with its full label, which answers the complaint outright. The editor's style picker already drew its default option as a slider icon — it was simply gated to `rating`.

Putting every label under a slider was considered and rejected: at nine points on a phone the labels overlap, truncate, or need rotation, and each of those is a new thing to maintain.

**Storage does not move.** The save path keys on `question.input_type`, not on the widget, so a range answer lands in `Answer.numeric` whichever field type rendered it. `test_every_style_stores_the_same_value` asserts exactly that, and a style change on a question with existing answers leaves them and their export column untouched — a creator can switch mid-collection without splitting their data.

`default` means the slider for `range` and deliberately does **not** inherit the survey-wide rating style, which would otherwise restyle every existing range question on first deploy. A choice-based style with no choices falls back to the slider: **34 of 122 range questions in production have no choices**, so that path is live, not defensive.

## Measured, not assumed

Three things were checked before deciding anything, and two changed the plan:

- **"The slider is too short" is neither the slider nor the card.** `base_survey_template.html:74` renders the map unconditionally, so at a 1854px viewport the question column is 371px — for a survey with no geo question at all. It affects every question type. Filed as **#106**, not fixed here; it is a product decision about what the page looks like without a map, not a CSS change.
- **`scale_strip` is a poor choice for a long scale on a phone**: at a 320px panel, nine cells come out 20.5px wide, under half a reliable touch target. `list_pips` stays unclipped. The editor now warns when the strip is picked with more than seven options. This applied to `rating` before this PR too — the change stopped hiding it.
- 28% of production range questions have no choices, which turned the fallback from a comment into a tested path.

## Found while working, filed rather than folded in

- **#107 — answers are never validated server-side.** The POST handler passes `request.POST` as `initial`, so the form is never bound and `required` is not enforced for any question type. A spec scenario here asserted that a required range question rejects an empty submission; it does not. The scenario was rewritten to assert that the styles behave identically, rather than describing behaviour the platform lacks. This is the general case of a symptom previously recorded as geo-only.
- **`run_tests.sh` was borrowing whatever owns :6379.** It started only the db container and passed no `REDIS_URL`, so `settings.py` fell back to `redis://localhost:6379/1` — on this machine another project's Redis, read and written by the suite. `CACHES` sets `IGNORE_EXCEPTIONS`, so it failed silently; two `LastActivityMiddleware` tests had been failing for this reason and were nearly written off as environmental. Fixed in its own commit (`c2c25f4`), along with a CLAUDE.md line pointing at a `requirements.txt` this repository does not have.

## Notable regression caught by an existing test

An intermediate version keyed the template branch on `display_style` alone. Every question carries a resolved style, so text questions were being sent through the scale partials. `test_non_rating_question_ignores_display_style` caught it — exactly what it was written for. Resolution now returns `default` for types without display styles, and the filter checks the type as well.

## Tests

879 pass. `RangeDisplayStyleTest` covers storage identity across styles, style changes against existing answers, what each style renders, the no-choices fallback, prepopulation on back-navigation, and that `default` ignores the survey-wide rating default.

## Not done, deliberately

The `display_style` help text still says "only used by rating questions". Changing it generates an `AlterField` migration, and migration-number collisions between parallel branches are a recurring problem here; the string is not user-visible, since the editor renders that control by hand without help text. Recorded in tasks.md rather than left silent.

## Artifacts

OpenSpec change `range-scale-display` — proposal, design (D1–D5 with alternatives rejected), specs under the new `range-question-display` capability, and tasks recording outcomes including the two that were not done as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)