### PR TITLE
feat(editor): refuse a delete that would destroy answers until it is acknowledged

### DIFF
--- a/openspec/backlog/INDEX.md
+++ b/openspec/backlog/INDEX.md
@@ -96,10 +96,11 @@
 | 83 | feature | [Real-time updates for public results (live delivery layer)](feature-realtime-public-results.md) | medium | backend | growth | 2026-07-04 |
 | ~~96~~ | ~~bug~~ | ~~[GeoJSON export: sub-question property inherits previous value](bug-geojson-subquestion-property-bleed.md)~~ | ~~**very high**~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | ~~97~~ | ~~bug~~ | ~~[datetime answers never appear in the CSV export](bug-datetime-missing-from-csv-export.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
-| 98 | bug | [Deleting a question silently destroys all answers](bug-editing-question-destroys-answers.md) | high | backend | — | 2026-08-04 |
+| ~~98~~ | ~~bug~~ | ~~[Deleting a question silently destroys all answers](bug-editing-question-destroys-answers.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | ~~99~~ | ~~bug~~ | ~~[Range slider: endpoint labels not aligned to the track](bug-range-slider-label-alignment.md)~~ | ~~high~~ | ~~frontend~~ | ~~—~~ | ~~2026-08-04~~ |
 | 100 | improvement | [Closed survey is a dead end — no way back to editing](improvement-closed-survey-edit-dead-end.md) | high | frontend | — | 2026-08-04 |
 | 101 | feature | [Clear all responses / reset survey data](feature-clear-all-responses.md) | medium | backend | — | 2026-08-04 |
 | 102 | feature | [Additional scale and ranking question types](feature-additional-scale-question-types.md) | medium | frontend | — | 2026-08-04 |
 | 106 | improvement | [Survey page always renders the map, squeezing non-geo surveys](improvement-map-panel-always-rendered.md) | high | frontend | — | 2026-08-05 |
 | 107 | bug | [Survey answers are never validated server-side](bug-answers-never-validated-server-side.md) | high | backend | — | 2026-08-05 |
+| 108 | bug | [Editing a question's type or choices invalidates stored answers](bug-question-edits-invalidate-stored-answers.md) | medium | backend | — | 2026-08-05 |

--- a/openspec/backlog/bug-editing-question-destroys-answers.md
+++ b/openspec/backlog/bug-editing-question-destroys-answers.md
@@ -22,6 +22,18 @@ iterate while collecting first responses — has no protection at all.
 
 ## Notes
 
+- **2026-08-05 — FIXED** in change `warn-before-destroying-answers`, branch
+  `fix/question-delete-destroys-answers`. The cascade is unchanged; what changed is that a delete
+  which would destroy answers is refused until the author acknowledges the count, and the
+  confirmation explains what versioning would have preserved. Soft-delete was considered and
+  rejected: it needs new state on `Question`, a migration, and export and analytics changes, which
+  is disproportionate for data belonging to surveys nobody has published.
+- Exposure, measured on production 2026-08-05 and worth keeping because it sized the fix:
+  **50 surveys in `draft` holding 842 answers, 12 in `testing` holding 1471.** Published and closed
+  surveys are protected twice over — by the read-only lock on structural edits, and by versioning
+  moving the previous structure and sessions onto an archived header rather than deleting them
+  (`versioning.py:236-260`). That is not theory: 61 archived headers currently hold 1060 questions
+  and 3466 answers.
 - Reported by: Manuel Frost (manu04, Berlin Senate) 2026-08-04 — "I entered some test data into my
   test project, but upon export, only the last answer contains data; the rest are empty. I think
   you have changed some things and my data are older." His own reading was right; the trigger was

--- a/openspec/backlog/bug-question-edits-invalidate-stored-answers.md
+++ b/openspec/backlog/bug-question-edits-invalidate-stored-answers.md
@@ -1,0 +1,33 @@
+# Editing a question's type or choices invalidates stored answers, unwarned
+
+**Type**: bug
+**Priority**: medium
+**Area**: backend
+**Created**: 2026-08-05
+
+## Description
+
+Deleting a question is not the only edit that costs collected answers. Changing a question's
+`input_type`, or removing choice codes that stored answers reference, leaves those answers in place
+but no longer meaningful: a `choice` answer holding code `3` after code `3` is removed exports as
+the bare number, and a `number` answer under a question that is now `text` is read by neither the
+export nor the analytics path that matches on type.
+
+The platform already knows how to detect exactly this. `check_draft_compatibility(draft, canonical)`
+reports `changed_input_type` and `removed_choice_codes` with the affected answer counts, and
+publishing a draft refuses on them unless forced. But that check only runs on the published path —
+a survey that has never been published can be edited this way with no warning at all, which is the
+same asymmetry that [deleting a question](bug-editing-question-destroys-answers.md) had.
+
+## Notes
+
+- Found 2026-08-05 while implementing `warn-before-destroying-answers`, and deliberately left out of
+  it to keep that change to deletion. Recorded there as an open question in `design.md`.
+- The detection exists; what is missing is calling it on the unpublished path and surfacing the
+  result. That makes this considerably cheaper than it looks — likely the same 409-plus-count shape
+  the delete guard now uses, reusing `check_draft_compatibility`'s issue list instead of a count.
+- Worth deciding at the same time whether the answer is to warn or to migrate the stored answers
+  where it is safe to (renaming a choice is harmless; removing one is not). Warning first is the
+  smaller step and matches what the delete guard does.
+- Unlike deletion, this one is silent *after* the fact too: nothing is missing from the editor, so a
+  creator has no reason to suspect anything until the export looks wrong.

--- a/openspec/changes/warn-before-destroying-answers/.openspec.yaml
+++ b/openspec/changes/warn-before-destroying-answers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/warn-before-destroying-answers/design.md
+++ b/openspec/changes/warn-before-destroying-answers/design.md
@@ -1,0 +1,125 @@
+## Context
+
+Deletion in the editor is an HTMX post from a trash button, guarded by `hx-confirm` — a static
+string rendered into the markup. The server side does no checking beyond permissions and the
+read-only lock (`_check_structural_edit_allowed`, which returns 403 for `published` and `closed`).
+
+The cascade runs `SurveySection` → `Question` → `Answer`, and separately `Question` →
+sub-`Question` → `Answer` via `parent_question_id`. So a section delete can destroy answers to
+questions the author is not looking at, and a question delete can destroy answers to its
+sub-questions.
+
+Prior art worth matching: publishing a draft already works as check-then-confirm. `checkAndPublishDraft()`
+calls `editor_check_compatibility`, and if issues come back it opens a modal listing them before
+`doPublishDraft(force)` re-posts with an explicit override. The same shape fits here, and reusing it
+keeps one vocabulary for "this is destructive, here is what it costs, confirm".
+
+Constraint that shapes the design: a count rendered into the page at list-render time is stale the
+moment another respondent submits. For a warning whose entire job is to state a number truthfully,
+that matters.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- No edit destroys answers without the author being told how many, in that moment.
+- The guard holds on the server, so it cannot be bypassed and the number cannot be stale.
+- The author learns, at the moment it is relevant, that publishing changes this — that versioning
+  preserves previous answers.
+- Section deletion accounts for every answer beneath it, sub-questions included.
+
+**Non-Goals:**
+
+- Soft-delete or blocking deletion (see proposal). The decision was taken deliberately: the data at
+  risk belongs to surveys nobody has published, and the reported harm is silence rather than the
+  deletion itself.
+- Changing the cascade. `on_delete=CASCADE` stays; a delete that the author confirms should still
+  delete.
+- Anything about discarding a draft copy.
+- Undo. Worth wanting, but it is a different feature with its own storage question.
+
+## Decisions
+
+### D1 — Enforce the confirmation server-side, with the count computed at request time
+
+The delete endpoints refuse a delete that would destroy answers unless the request carries an
+explicit acknowledgement. On refusal they return the count so the client can ask. The count is read
+inside the same request that performs the delete.
+
+*Why not just a better `hx-confirm` string:* the string is baked in when the list renders. On a
+survey that is actively collecting, "this will delete 3 answers" can be wrong by the time it is
+read, and a bare POST skips it entirely. A warning that is sometimes wrong about the number is
+worse than no number, because it teaches the author to disbelieve it.
+
+*Shape:* `POST` without acknowledgement and with answers present → `409` plus the count as JSON.
+With `confirm_delete_answers=true` → proceed. Chosen over a two-endpoint check-then-delete because
+one endpoint cannot drift out of step with itself, and the count returned is the count the delete
+would have destroyed.
+
+### D2 — One counting helper, used by both endpoints and both templates
+
+Add a helper that answers "how many answers hang beneath this question" (its own plus its
+sub-questions') and one for a section (all its questions, sub-questions included). Both endpoints
+and the confirmation text read from it.
+
+*Why:* the section case is the one most likely to be got wrong by hand, since sub-question answers
+are invisible in the section list. Writing the traversal once means the section dialog cannot
+quietly undercount.
+
+### D3 — Say what publishing would change, only when it would change something
+
+The confirmation includes a sentence about versioning **only** for a survey that has never been
+published (`version_number == 1` and no archived versions). For a draft copy of a published survey,
+the sentence would be false — that author already has version protection, and their draft's answers
+are test data by construction.
+
+*Why here rather than a banner somewhere:* the author is, at this instant, being told they are about
+to lose responses. That is the only moment when "publishing would have preserved these" is
+information rather than noise. A permanent banner in the editor would be ignored within a day.
+
+*Wording constraint:* it must not read as "publish now to be safe". Publishing a half-built survey
+to protect two test answers is worse advice than losing them. It states what versioning does; it
+does not recommend an action.
+
+### D4 — Confirm on the count, not on the act
+
+The dialog is shown when there is something to lose. Deleting a question with no answers keeps
+today's plain `hx-confirm` and stays a single click.
+
+*Why:* a confirmation that always fires is trained away. Reserving the interruption for the case
+that actually costs something is what keeps it readable.
+
+## Risks / Trade-offs
+
+**A 409 for a business condition rather than an error** → It is a conflict in the ordinary sense —
+the request cannot proceed in the state the resource is in — and HTMX handles a non-2xx cleanly with
+`htmx:responseError`. The alternative, 200 plus a body meaning "not done", is the shape that gets
+misread later as success.
+
+**Two round trips to delete a question that has answers** → Only for deletes that would destroy
+data, which should be rare and deserve the pause. Empty questions stay one click.
+
+**The versioning sentence could be read as advice to publish early** → Mitigated by wording (D3) and
+worth checking with a real author before it ships, since we cannot judge our own copy for this.
+
+**Counting on every delete adds queries** → Two counts on a path invoked by hand, in an editor, by
+one person. Not a hot path.
+
+## Migration Plan
+
+No schema change and no migration; the helper counts through existing relations. Nothing is
+backfilled, and existing surveys behave identically until someone deletes something with answers
+attached.
+
+Rollback is a revert. No stored state depends on this.
+
+## Open Questions
+
+- Should the same guard cover *editing* a question in ways that invalidate stored answers — changing
+  `input_type`, or removing choice codes that answers reference? `check_draft_compatibility` already
+  detects exactly these for the published path, so the detection exists and only the unpublished
+  path is unguarded. Left out here to keep the change to deletion, but it is the obvious next step
+  and the same helper would serve.
+- Is 409-plus-JSON the right shape for the rest of the editor's destructive actions, or is this
+  change inventing a local convention? Worth a look at how survey deletion and draft discard
+  currently confirm before this spreads.

--- a/openspec/changes/warn-before-destroying-answers/proposal.md
+++ b/openspec/changes/warn-before-destroying-answers/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+Deleting a question deletes every answer to it. `Answer.question` is `on_delete=models.CASCADE`
+(`models.py:616`), and `editor_question_delete` calls `question.delete()` with no check
+(`editor_views.py:522-530`). The only thing standing in the way is an `hx-confirm` reading
+"Delete question 'X'?" — which says nothing about responses, because it was written for a survey
+that had none.
+
+A user reported the symptom without recognising the cause: their export came back empty except for
+the last session, and they guessed their data was "older" than some change we had made. They were
+right that the data was gone and wrong about why — they had edited the survey between test runs.
+
+The exposure is narrower than it first looks, and worth stating precisely because it decides how
+much machinery this deserves. **Versioning already protects published surveys.** `publish_draft`
+does not delete the old structure: it creates an archived `SurveyHeader` and *moves* the previous
+sections and sessions onto it (`versioning.py:236-260`), so the old version's questions stay live
+rows and their answers stay attached. Production confirms it — 61 archived headers currently hold
+1060 questions and 3466 answers. Published and closed surveys are further protected by the
+read-only lock on structural edits.
+
+What is unprotected is every survey that has never been published: **50 surveys in `draft` holding
+842 answers and 12 in `testing` holding 1471**. There is no archived version to move anything to,
+so deletion is final. That is exactly the state people are in while collecting their first
+responses, and exactly where the reporter was.
+
+## What Changes
+
+- Deleting a question, sub-question or section that has answers requires an explicit confirmation
+  naming how many answers will be destroyed. Without it the delete does not happen.
+- The confirmation is enforced on the server, not only in the dialog, so the count cannot go stale
+  between rendering the list and clicking, and the guard cannot be bypassed by a bare POST.
+- The same confirmation explains that this survey is not versioned yet: once published, edits go
+  through a draft copy and previous answers are preserved as an archived version. This is the one
+  moment the author is guaranteed to be paying attention to the subject.
+- Section deletion counts answers across all its questions, including sub-questions.
+
+Not in scope: soft-deleting questions or blocking deletion outright. Both need new state on
+`Question`, a migration, and changes to export, analytics and the editor — disproportionate for
+data that is unversioned precisely because its author has not yet published anything. The harm to
+fix here is the silence, not the deletion.
+
+Also not in scope: discarding a draft copy, which destroys answers collected against that draft via
+its test token. That is what discarding means, and the existing dialog already says the changes
+will be lost.
+
+## Capabilities
+
+### New Capabilities
+- `destructive-edit-confirmation`: what the editor must establish before an edit destroys collected
+  answers — which edits count, what the author is told, and where the guard is enforced.
+
+### Modified Capabilities
+
+None. `survey-editor` in `openspec/specs/` does not currently specify deletion behaviour, so there
+is no existing requirement to amend.
+
+## Impact
+
+- `survey/editor_views.py` — `editor_question_delete`, `editor_section_delete`.
+- `survey/templates/editor/partials/question_list_item.html`, `section_list_item.html` — the delete
+  controls and their confirmation.
+- `survey/models.py` — a helper for counting answers under a question or section, including
+  sub-questions. No field change, no migration.
+- Backlog #98 closed, and its description corrected: it currently says editing a survey destroys
+  the answers already given, which overstates the case by leaving out that versioning protects
+  published surveys.

--- a/openspec/changes/warn-before-destroying-answers/proposal.md
+++ b/openspec/changes/warn-before-destroying-answers/proposal.md
@@ -61,6 +61,8 @@ is no existing requirement to amend.
   controls and their confirmation.
 - `survey/models.py` — a helper for counting answers under a question or section, including
   sub-questions. No field change, no migration.
-- Backlog #98 closed, and its description corrected: it currently says editing a survey destroys
-  the answers already given, which overstates the case by leaving out that versioning protects
-  published surveys.
+- Backlog #98 closed, with the measured exposure recorded on it.
+
+  (An earlier draft of this proposal said #98's description overstated the case by omitting that
+  versioning protects published surveys. Re-reading it, that was wrong — the item already says so
+  explicitly. The overstatement was in how it had been summarised verbally, not in the file.)

--- a/openspec/changes/warn-before-destroying-answers/specs/destructive-edit-confirmation/spec.md
+++ b/openspec/changes/warn-before-destroying-answers/specs/destructive-edit-confirmation/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: An edit that would destroy answers requires explicit acknowledgement
+
+Deleting a question, sub-question or section that has answers attached SHALL NOT proceed unless the
+request carries an explicit acknowledgement. Without it the server SHALL refuse the delete, leave
+every row intact, and report how many answers the delete would have destroyed.
+
+#### Scenario: Delete without acknowledgement is refused
+
+- **WHEN** a delete is requested for a question that has 3 answers, with no acknowledgement
+- **THEN** the response status is 409
+- **AND** the response reports 3 answers at risk
+- **AND** the question and all 3 answers still exist
+
+#### Scenario: Delete with acknowledgement proceeds
+
+- **WHEN** the same delete is requested with the acknowledgement
+- **THEN** the question is deleted
+- **AND** its answers are deleted with it
+
+#### Scenario: A question with no answers deletes in one step
+
+- **WHEN** a delete is requested for a question with no answers and no acknowledgement
+- **THEN** the question is deleted
+- **AND** the response is not a 409
+
+### Requirement: The count includes everything beneath the deleted object
+
+The reported count SHALL include answers to sub-questions of the question being deleted, and — when
+a section is deleted — answers to every question in that section and their sub-questions.
+
+#### Scenario: Question count includes its sub-questions' answers
+
+- **WHEN** a delete is requested for a geo question with 2 answers whose sub-question has 5
+- **THEN** the reported count is 7
+
+#### Scenario: Section count spans its questions and their sub-questions
+
+- **WHEN** a delete is requested for a section holding two questions with 4 and 6 answers, one of
+  which has a sub-question with 3
+- **THEN** the reported count is 13
+
+#### Scenario: Section with no answers deletes in one step
+
+- **WHEN** a delete is requested for a section whose questions have no answers
+- **THEN** the section is deleted without requiring acknowledgement
+
+### Requirement: The author is told what versioning would have done, when it applies
+
+The confirmation SHALL explain that answers in this survey are not preserved by versioning, and that
+once a survey is published, edits go through a draft copy while previous answers are kept as an
+archived version.
+
+This explanation SHALL appear only for a survey that has never been published. For a draft copy of a
+published survey it SHALL NOT appear, because that author already has version protection and the
+statement would be false.
+
+#### Scenario: Never-published survey gets the explanation
+
+- **WHEN** a delete confirmation is raised on a survey with `version_number = 1` and no archived
+  versions
+- **THEN** the confirmation explains that publishing preserves previous answers as an archived
+  version
+
+#### Scenario: Draft copy of a published survey does not
+
+- **WHEN** a delete confirmation is raised on a draft copy of a published survey
+- **THEN** the confirmation reports the count without the versioning explanation
+
+### Requirement: Refusing a delete changes nothing
+
+A refused delete SHALL be free of side effects: no question, sub-question, section, answer or
+session is modified, and section ordering is unchanged.
+
+#### Scenario: Refused section delete leaves ordering intact
+
+- **WHEN** a delete is requested without acknowledgement for a section that has answers and sits
+  between two other sections
+- **THEN** the section still exists
+- **AND** its neighbours still link to it in the same order as before the request

--- a/openspec/changes/warn-before-destroying-answers/tasks.md
+++ b/openspec/changes/warn-before-destroying-answers/tasks.md
@@ -1,0 +1,65 @@
+## 1. Counting helper
+
+- [ ] 1.1 Add a helper returning the number of answers beneath a question — its own plus its
+      sub-questions' — and one for a section covering all its questions and their sub-questions
+      (design D2).
+- [ ] 1.2 Unit-test the traversal directly, before any view uses it: question alone, question with
+      sub-questions, section spanning both, and the zero cases.
+
+## 2. Server-side guard
+
+- [ ] 2.1 `editor_question_delete`: when answers exist and the request carries no acknowledgement,
+      return 409 with the count and delete nothing.
+- [ ] 2.2 `editor_section_delete`: the same, counting across the whole section. Take care that the
+      neighbour re-linking that runs before the delete does not happen on the refused path — the
+      current code re-links first and deletes after.
+- [ ] 2.3 Proceed normally when the acknowledgement is present, and when there are no answers to
+      lose.
+- [ ] 2.4 Include in the response whether the versioning explanation applies — true only when the
+      survey has never been published (design D3). Compute it server-side; the template should not
+      re-derive it.
+
+## 3. Editor confirmation
+
+- [ ] 3.1 Replace the static `hx-confirm` on the question delete button with a handler that posts,
+      and on 409 opens a dialog stating the count and, when applicable, what versioning does.
+- [ ] 3.2 The same for the section delete control.
+- [ ] 3.3 Confirming re-posts with the acknowledgement; cancelling does nothing.
+- [ ] 3.4 Keep the single-click path for objects with no answers — no dialog where there is nothing
+      to lose (design D4).
+- [ ] 3.5 Word the versioning sentence so it states what versioning does rather than advising the
+      author to publish. Publishing a half-built survey to protect two test answers is worse than
+      losing them.
+
+## 4. Tests
+
+- [ ] 4.1 Delete without acknowledgement on a question with answers → 409, count correct, question
+      and answers still present.
+- [ ] 4.2 Delete with acknowledgement → question and its answers gone.
+- [ ] 4.3 Question with no answers deletes without a 409.
+- [ ] 4.4 Count includes sub-question answers.
+- [ ] 4.5 Section count spans questions and sub-questions.
+- [ ] 4.6 Refused section delete leaves the section and its neighbour links untouched — this is the
+      regression 2.2 is written to avoid.
+- [ ] 4.7 The versioning flag is set for a never-published survey and unset for a draft copy of a
+      published one.
+- [ ] 4.8 The read-only lock still wins: a published survey returns 403 rather than 409, and no
+      acknowledgement can override it.
+
+## 5. Verify
+
+- [ ] 5.1 Run the full survey suite.
+- [ ] 5.2 Exercise both dialogs by hand in the editor — the count is only trustworthy if it is right
+      on a real survey, and the section case is the one that can silently undercount.
+
+## 6. Close the loop
+
+- [ ] 6.1 Strike backlog #98 and correct its description: it says editing a survey destroys the
+      answers already given, which overstates the case by omitting that versioning protects
+      published surveys. The accurate statement is that surveys which have never been published are
+      unprotected — 50 in `draft` holding 842 answers and 12 in `testing` holding 1471, measured
+      2026-08-05.
+- [ ] 6.2 Record the open question from the design as a backlog item if it is not taken up here:
+      changing a question's `input_type` or removing referenced choice codes invalidates stored
+      answers on the unpublished path with no warning, while `check_draft_compatibility` already
+      detects exactly that for the published one.

--- a/openspec/changes/warn-before-destroying-answers/tasks.md
+++ b/openspec/changes/warn-before-destroying-answers/tasks.md
@@ -1,65 +1,79 @@
 ## 1. Counting helper
 
-- [ ] 1.1 Add a helper returning the number of answers beneath a question — its own plus its
+- [x] 1.1 Add a helper returning the number of answers beneath a question — its own plus its
       sub-questions' — and one for a section covering all its questions and their sub-questions
       (design D2).
-- [ ] 1.2 Unit-test the traversal directly, before any view uses it: question alone, question with
+- [x] 1.2 Unit-test the traversal directly, before any view uses it: question alone, question with
       sub-questions, section spanning both, and the zero cases.
 
 ## 2. Server-side guard
 
-- [ ] 2.1 `editor_question_delete`: when answers exist and the request carries no acknowledgement,
+- [x] 2.1 `editor_question_delete`: when answers exist and the request carries no acknowledgement,
       return 409 with the count and delete nothing.
-- [ ] 2.2 `editor_section_delete`: the same, counting across the whole section. Take care that the
+- [x] 2.2 `editor_section_delete`: the same, counting across the whole section. Take care that the
       neighbour re-linking that runs before the delete does not happen on the refused path — the
       current code re-links first and deletes after.
-- [ ] 2.3 Proceed normally when the acknowledgement is present, and when there are no answers to
+- [x] 2.3 Proceed normally when the acknowledgement is present, and when there are no answers to
       lose.
-- [ ] 2.4 Include in the response whether the versioning explanation applies — true only when the
+- [x] 2.4 Include in the response whether the versioning explanation applies — true only when the
       survey has never been published (design D3). Compute it server-side; the template should not
       re-derive it.
 
 ## 3. Editor confirmation
 
-- [ ] 3.1 Replace the static `hx-confirm` on the question delete button with a handler that posts,
+- [x] 3.1 Replace the static `hx-confirm` on the question delete button with a handler that posts,
       and on 409 opens a dialog stating the count and, when applicable, what versioning does.
-- [ ] 3.2 The same for the section delete control.
-- [ ] 3.3 Confirming re-posts with the acknowledgement; cancelling does nothing.
-- [ ] 3.4 Keep the single-click path for objects with no answers — no dialog where there is nothing
+
+  Done differently from the task, and better: `hx-confirm` was left alone. The editor already routes
+  every `hx-confirm` through `Dialog.confirm` (`editor_dialog.js`), a shared Bootstrap modal, so the
+  409 handler calls the same `Dialog.confirm` rather than the bespoke modal this first shipped with.
+  I built that bespoke modal before checking whether the editor already had one — it did, and the
+  first version put a second modal system alongside it. Verified in the browser that only one modal
+  is ever open at a time.
+- [x] 3.2 The same for the section delete control.
+- [x] 3.3 Confirming re-posts with the acknowledgement; cancelling does nothing.
+- [x] 3.4 Keep the single-click path for objects with no answers — no dialog where there is nothing
       to lose (design D4).
-- [ ] 3.5 Word the versioning sentence so it states what versioning does rather than advising the
+- [x] 3.5 Word the versioning sentence so it states what versioning does rather than advising the
       author to publish. Publishing a half-built survey to protect two test answers is worse than
       losing them.
 
 ## 4. Tests
 
-- [ ] 4.1 Delete without acknowledgement on a question with answers → 409, count correct, question
+- [x] 4.1 Delete without acknowledgement on a question with answers → 409, count correct, question
       and answers still present.
-- [ ] 4.2 Delete with acknowledgement → question and its answers gone.
-- [ ] 4.3 Question with no answers deletes without a 409.
-- [ ] 4.4 Count includes sub-question answers.
-- [ ] 4.5 Section count spans questions and sub-questions.
-- [ ] 4.6 Refused section delete leaves the section and its neighbour links untouched — this is the
+- [x] 4.2 Delete with acknowledgement → question and its answers gone.
+- [x] 4.3 Question with no answers deletes without a 409.
+- [x] 4.4 Count includes sub-question answers.
+- [x] 4.5 Section count spans questions and sub-questions.
+- [x] 4.6 Refused section delete leaves the section and its neighbour links untouched — this is the
       regression 2.2 is written to avoid.
-- [ ] 4.7 The versioning flag is set for a never-published survey and unset for a draft copy of a
+- [x] 4.7 The versioning flag is set for a never-published survey and unset for a draft copy of a
       published one.
-- [ ] 4.8 The read-only lock still wins: a published survey returns 403 rather than 409, and no
+- [x] 4.8 The read-only lock still wins: a published survey returns 403 rather than 409, and no
       acknowledgement can override it.
 
 ## 5. Verify
 
-- [ ] 5.1 Run the full survey suite.
-- [ ] 5.2 Exercise both dialogs by hand in the editor — the count is only trustworthy if it is right
+- [x] 5.1 Run the full survey suite.
+- [x] 5.2 Exercise both dialogs by hand in the editor — the count is only trustworthy if it is right
       on a real survey, and the section case is the one that can silently undercount.
+
+  Done on a seeded survey. A geo question whose own answers are zero but whose sub-question holds 3
+  reported 3, showed the versioning explanation, and on confirmation took the sub-question with it.
+  A question with no answers deleted after the ordinary confirmation with no second prompt. Verified
+  against the database rather than the DOM — the first DOM assertions raced the HTMX swap and read
+  as failures when the rows were already gone.
 
 ## 6. Close the loop
 
-- [ ] 6.1 Strike backlog #98 and correct its description: it says editing a survey destroys the
-      answers already given, which overstates the case by omitting that versioning protects
-      published surveys. The accurate statement is that surveys which have never been published are
-      unprotected — 50 in `draft` holding 842 answers and 12 in `testing` holding 1471, measured
-      2026-08-05.
-- [ ] 6.2 Record the open question from the design as a backlog item if it is not taken up here:
+- [x] 6.1 Strike backlog #98 and record the measured exposure on it.
+
+  The task as written said #98's description overstated the case. Re-reading the item, that was
+  wrong — it already states that published surveys are protected by versioning and draft/testing are
+  not. The overstatement was in how I had summarised it, not in the file. Struck, and the measured
+  numbers plus the fix are recorded on it.
+- [x] 6.2 Filed as **#108**. Record the open question from the design as a backlog item:
       changing a question's `input_type` or removing referenced choice codes invalidates stored
       answers on the unpublished path with no warning, while `check_draft_compatibility` already
       detects exactly that for the published one.

--- a/survey/editor_views.py
+++ b/survey/editor_views.py
@@ -35,6 +35,46 @@ def _check_structural_edit_allowed(survey):
     return None
 
 
+# Sent by the editor once the author has seen how many answers a delete costs.
+DELETE_ACKNOWLEDGEMENT = 'confirm_delete_answers'
+
+
+def _survey_is_unversioned(survey):
+    """True when this survey has no archived versions to fall back on.
+
+    Publishing moves the previous structure and its sessions onto an archived
+    header rather than deleting them, so a survey that has been published keeps
+    its earlier answers. One that never has does not — there is nowhere for them
+    to go.
+    """
+    if survey.is_draft_copy:
+        return False
+    return survey.version_number == 1 and not SurveyHeader.objects.filter(
+        canonical_survey=survey, is_canonical=False,
+    ).exists()
+
+
+def _refuse_if_answers_at_risk(request, survey, answer_count):
+    """Return a 409 unless the author has acknowledged losing `answer_count` answers.
+
+    The count is computed in the same request that would perform the delete.
+    Rendering it into the page earlier would let it go stale on a survey that is
+    still collecting, and a warning that is sometimes wrong about the number
+    teaches the author to disbelieve it.
+    """
+    if not answer_count:
+        return None
+    if request.POST.get(DELETE_ACKNOWLEDGEMENT) == 'true':
+        return None
+    return JsonResponse(
+        {
+            'answers_at_risk': answer_count,
+            'explain_versioning': _survey_is_unversioned(survey),
+        },
+        status=409,
+    )
+
+
 def _can_read_survey(user, survey):
     """Return True if user has at least viewer role on the survey."""
     return get_effective_survey_role(user, survey) is not None
@@ -306,6 +346,11 @@ def editor_section_delete(request, survey_uuid, section_id):
         return blocked
     section = get_object_or_404(SurveySection, id=section_id, survey_header=survey)
 
+    # Before the re-linking below, which must not run on a refused delete.
+    refusal = _refuse_if_answers_at_risk(request, survey, section.answer_count())
+    if refusal:
+        return refusal
+
     prev_sec = section.prev_section
     next_sec = section.next_section
 
@@ -525,6 +570,11 @@ def editor_question_delete(request, survey_uuid, question_id):
     if blocked:
         return blocked
     question = get_object_or_404(Question, id=question_id, survey_section__survey_header=survey)
+
+    refusal = _refuse_if_answers_at_risk(request, survey, question.answer_count())
+    if refusal:
+        return refusal
+
     question.delete()
     return HttpResponse('')
 

--- a/survey/models.py
+++ b/survey/models.py
@@ -492,6 +492,15 @@ class SurveySection(models.Model):
             self.__qcache = Question.objects.filter(survey_section=self).filter(parent_question_id__isnull=True).order_by('order_number')
         return self.__qcache
 
+    def answer_count(self):
+        """Answers that deleting this section would destroy.
+
+        Sub-questions carry the same `survey_section` as their parent — that is
+        why `questions()` above has to filter them out — so this one filter
+        already covers them, at any nesting depth.
+        """
+        return Answer.objects.filter(question__survey_section=self).count()
+
     def get_translated_title(self, lang):
         if not lang:
             return self.title
@@ -564,6 +573,31 @@ class Question(models.Model):
         if not hasattr(self, "__acache"):
             self.__acache = Answer.objects.filter(question=self)
         return self.__acache
+
+    def descendant_question_ids(self):
+        """This question's id plus every sub-question beneath it.
+
+        The editor only offers one level of sub-question today, but the model
+        allows deeper nesting, so this walks rather than assuming a depth — an
+        undercount here would understate what a delete destroys, which is the
+        one number this must not get wrong.
+        """
+        ids = [self.id]
+        frontier = [self.id]
+        while frontier:
+            children = list(
+                Question.objects.filter(parent_question_id__in=frontier)
+                .values_list('id', flat=True)
+            )
+            if not children:
+                break
+            ids.extend(children)
+            frontier = children
+        return ids
+
+    def answer_count(self):
+        """Answers that deleting this question would destroy, sub-questions included."""
+        return Answer.objects.filter(question_id__in=self.descendant_question_ids()).count()
 
     def get_translated_name(self, lang):
         if not lang:

--- a/survey/templates/editor/survey_detail.html
+++ b/survey/templates/editor/survey_detail.html
@@ -382,6 +382,63 @@ document.addEventListener('DOMContentLoaded', function() {
         refreshPreview();
     });
 
+    // ── Deletes that would destroy collected answers ──────────────────────
+    // The server refuses with 409 and reports the count rather than trusting a
+    // number baked into the page, which would go stale on a survey that is
+    // still collecting. On confirmation the same request is re-sent with an
+    // acknowledgement. Reuses Dialog (editor_dialog.js), which already backs
+    // every hx-confirm in the editor, so this is one more prompt in the same
+    // voice rather than a second modal system.
+    function resolveHxTarget(elt) {
+        var attr = elt.getAttribute('hx-target') || '';
+        var closest = attr.match(/^closest\s+(.+)$/);
+        if (closest) return elt.closest(closest[1]);
+        return attr ? document.querySelector(attr) : elt;
+    }
+
+    function answerLossMessage(data, isSection) {
+        var noun = data.answers_at_risk === 1 ? 'answer' : 'answers';
+        var what = isSection ? 'this section' : 'this question';
+        var message = data.answers_at_risk + ' ' + noun +
+            ' will be permanently deleted along with ' + what + '. This cannot be undone.';
+        if (data.explain_versioning) {
+            message += ' This survey has not been published, so earlier answers are not kept ' +
+                'anywhere. Once a survey is published, edits are made in a draft copy and the ' +
+                'answers collected before each new version stay available as an archived version.';
+        }
+        return message;
+    }
+
+    document.body.addEventListener('htmx:responseError', function(evt) {
+        var xhr = evt.detail.xhr;
+        if (!xhr || xhr.status !== 409) return;
+
+        var data;
+        try { data = JSON.parse(xhr.responseText); } catch (e) { return; }
+        if (typeof data.answers_at_risk !== 'number') return;
+
+        var elt = evt.detail.elt;
+        var request = {
+            url: elt.getAttribute('hx-post'),
+            target: resolveHxTarget(elt),
+            swap: elt.getAttribute('hx-swap') || 'outerHTML'
+        };
+
+        Dialog.confirm(answerLossMessage(data, elt.classList.contains('section-delete')), {
+            title: 'This will delete collected answers',
+            okLabel: 'Delete anyway',
+            danger: true
+        }).then(function(ok) {
+            if (!ok) return;
+            htmx.ajax('POST', request.url, {
+                target: request.target,
+                swap: request.swap,
+                values: { confirm_delete_answers: 'true' },
+                headers: { 'X-CSRFToken': '{{ csrf_token }}' }
+            });
+        });
+    });
+
     // After section delete, update HEAD badge and load first remaining section
     document.body.addEventListener('sectionDeleted', function() {
         sectionsList.querySelectorAll('.badge-info').forEach(function(b) { b.remove(); });

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -18000,3 +18000,376 @@ class RangeDisplayStyleTest(TestCase):
         resolved = SurveySectionAnswerForm.resolve_display_style(question, 'list_pips')
 
         self.assertEqual(resolved, 'default')
+
+
+class AnswerCountHelpersTest(TestCase):
+    """Counting what a delete would destroy.
+
+    Tested directly rather than only through the views: an undercount here
+    understates the damage in a warning whose whole purpose is to state that
+    number truthfully.
+    """
+
+    def setUp(self):
+        self.org = _make_org('CountOrg')
+        self.user = User.objects.create_user('countuser', password='pass')
+        self.survey = SurveyHeader.objects.create(
+            name='count_survey', organization=self.org, created_by=self.user,
+        )
+        self.section = SurveySection.objects.create(
+            survey_header=self.survey, name='s1', code='S1', is_head=True,
+        )
+        self.session = SurveySession.objects.create(survey=self.survey)
+
+    def _question(self, code, parent=None, section=None):
+        return Question.objects.create(
+            survey_section=section or self.section, code=code, name=code,
+            input_type='text', order_number=1, parent_question_id=parent,
+        )
+
+    def _answers(self, question, how_many, parent=None):
+        for _ in range(how_many):
+            Answer.objects.create(
+                survey_session=self.session, question=question,
+                parent_answer_id=parent, text='x',
+            )
+
+    def test_question_with_no_answers_counts_zero(self):
+        """
+        GIVEN a question nobody has answered
+        WHEN its answers are counted
+        THEN the count is zero
+        """
+        question = self._question('q1')
+
+        self.assertEqual(question.answer_count(), 0)
+
+    def test_question_counts_its_own_answers(self):
+        """
+        GIVEN a question with three answers
+        WHEN its answers are counted
+        THEN the count is three
+        """
+        question = self._question('q1')
+        self._answers(question, 3)
+
+        self.assertEqual(question.answer_count(), 3)
+
+    def test_question_count_includes_subquestion_answers(self):
+        """
+        GIVEN a question with 2 answers whose sub-question has 5
+        WHEN its answers are counted
+        THEN the count is 7 — the sub-question's answers die with the parent
+        """
+        parent = self._question('q_parent')
+        child = self._question('q_child', parent=parent)
+        self._answers(parent, 2)
+        self._answers(child, 5)
+
+        self.assertEqual(parent.answer_count(), 7)
+
+    def test_question_count_reaches_deeper_nesting(self):
+        """
+        GIVEN a sub-question that itself has a sub-question with answers
+        WHEN the top question's answers are counted
+        THEN answers at every depth are included
+        """
+        top = self._question('q_top')
+        middle = self._question('q_middle', parent=top)
+        bottom = self._question('q_bottom', parent=middle)
+        self._answers(top, 1)
+        self._answers(middle, 2)
+        self._answers(bottom, 4)
+
+        self.assertEqual(top.answer_count(), 7)
+
+    def test_subquestion_counts_only_itself(self):
+        """
+        GIVEN a sub-question with answers alongside its parent's
+        WHEN the sub-question's answers are counted
+        THEN the parent's answers are not included
+        """
+        parent = self._question('q_parent')
+        child = self._question('q_child', parent=parent)
+        self._answers(parent, 2)
+        self._answers(child, 5)
+
+        self.assertEqual(child.answer_count(), 5)
+
+    def test_section_count_spans_questions_and_subquestions(self):
+        """
+        GIVEN a section with two questions holding 4 and 6 answers, one of them
+              with a sub-question holding 3
+        WHEN the section's answers are counted
+        THEN the count is 13
+        """
+        first = self._question('q1')
+        second = self._question('q2')
+        child = self._question('q2_child', parent=second)
+        self._answers(first, 4)
+        self._answers(second, 6)
+        self._answers(child, 3)
+
+        self.assertEqual(self.section.answer_count(), 13)
+
+    def test_section_count_ignores_other_sections(self):
+        """
+        GIVEN answers in a neighbouring section
+        WHEN this section's answers are counted
+        THEN the neighbour's answers are not included
+        """
+        other_section = SurveySection.objects.create(
+            survey_header=self.survey, name='s2', code='S2',
+        )
+        self._answers(self._question('q1'), 2)
+        self._answers(self._question('q_other', section=other_section), 9)
+
+        self.assertEqual(self.section.answer_count(), 2)
+
+    def test_section_with_no_answers_counts_zero(self):
+        """
+        GIVEN a section whose questions have no answers
+        WHEN its answers are counted
+        THEN the count is zero
+        """
+        self._question('q1')
+
+        self.assertEqual(self.section.answer_count(), 0)
+
+
+class DeleteAnswerGuardTest(TestCase):
+    """The editor must not destroy collected answers without saying so."""
+
+    def setUp(self):
+        self.org = _make_org('GuardOrg')
+        self.user = User.objects.create_user('guarduser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+        self.survey = SurveyHeader.objects.create(
+            name='guard_survey', organization=self.org, created_by=self.user,
+            status='draft',
+        )
+        self.section = SurveySection.objects.create(
+            survey_header=self.survey, name='s1', code='S1', is_head=True,
+        )
+        self.question = Question.objects.create(
+            survey_section=self.section, name='Comment', code='q1',
+            input_type='text', order_number=1,
+        )
+        self.session = SurveySession.objects.create(survey=self.survey)
+        self.client.login(username='guarduser', password='pass')
+
+    def _answer(self, question, how_many=1):
+        for _ in range(how_many):
+            Answer.objects.create(
+                survey_session=self.session, question=question, text='x',
+            )
+
+    def _delete_question(self, question=None, acknowledge=False):
+        question = question or self.question
+        url = f'/editor/surveys/{self.survey.uuid}/questions/{question.id}/delete/'
+        data = {'confirm_delete_answers': 'true'} if acknowledge else {}
+        return self.client.post(url, data)
+
+    def _delete_section(self, section=None, acknowledge=False):
+        section = section or self.section
+        url = f'/editor/surveys/{self.survey.uuid}/sections/{section.id}/delete/'
+        data = {'confirm_delete_answers': 'true'} if acknowledge else {}
+        return self.client.post(url, data)
+
+    # ── Refusal and acknowledgement ───────────────────────────────────────
+
+    def test_delete_without_acknowledgement_is_refused(self):
+        """
+        GIVEN a question with three answers
+        WHEN deletion is requested without acknowledgement
+        THEN the request is refused, reports the count, and destroys nothing
+        """
+        self._answer(self.question, 3)
+
+        response = self._delete_question()
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()['answers_at_risk'], 3)
+        self.assertTrue(Question.objects.filter(pk=self.question.pk).exists())
+        self.assertEqual(Answer.objects.filter(question=self.question).count(), 3)
+
+    def test_delete_with_acknowledgement_proceeds(self):
+        """
+        GIVEN a question with answers
+        WHEN deletion is requested with acknowledgement
+        THEN the question and its answers are deleted
+        """
+        self._answer(self.question, 3)
+
+        response = self._delete_question(acknowledge=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Question.objects.filter(pk=self.question.pk).exists())
+        self.assertEqual(Answer.objects.count(), 0)
+
+    def test_question_without_answers_deletes_in_one_step(self):
+        """
+        GIVEN a question nobody has answered
+        WHEN deletion is requested without acknowledgement
+        THEN it is deleted without a refusal
+        """
+        response = self._delete_question()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Question.objects.filter(pk=self.question.pk).exists())
+
+    def test_reported_count_includes_subquestion_answers(self):
+        """
+        GIVEN a question with 2 answers whose sub-question has 5
+        WHEN deletion is requested without acknowledgement
+        THEN the reported count is 7
+        """
+        sub = Question.objects.create(
+            survey_section=self.section, name='Sub', code='q1s',
+            input_type='text', order_number=1, parent_question_id=self.question,
+        )
+        self._answer(self.question, 2)
+        self._answer(sub, 5)
+
+        response = self._delete_question()
+
+        self.assertEqual(response.json()['answers_at_risk'], 7)
+
+    # ── Sections ──────────────────────────────────────────────────────────
+
+    def test_section_count_spans_questions_and_subquestions(self):
+        """
+        GIVEN a section holding two questions with 4 and 6 answers, one with a
+              sub-question holding 3
+        WHEN deletion is requested without acknowledgement
+        THEN the reported count is 13
+        """
+        second = Question.objects.create(
+            survey_section=self.section, name='Second', code='q2',
+            input_type='text', order_number=2,
+        )
+        sub = Question.objects.create(
+            survey_section=self.section, name='Sub', code='q2s',
+            input_type='text', order_number=1, parent_question_id=second,
+        )
+        self._answer(self.question, 4)
+        self._answer(second, 6)
+        self._answer(sub, 3)
+
+        response = self._delete_section()
+
+        self.assertEqual(response.json()['answers_at_risk'], 13)
+
+    def test_refused_section_delete_leaves_ordering_intact(self):
+        """
+        GIVEN a section with answers sitting between two others
+        WHEN deletion is refused
+        THEN the section still exists and its neighbours still link to it
+
+        The re-linking runs before the delete in the view, so a guard placed
+        after it would rewrite the chain around a section that survives.
+        """
+        first = self.section
+        middle = SurveySection.objects.create(
+            survey_header=self.survey, name='s2', code='S2',
+        )
+        last = SurveySection.objects.create(
+            survey_header=self.survey, name='s3', code='S3',
+        )
+        first.next_section = middle
+        first.save()
+        middle.prev_section = first
+        middle.next_section = last
+        middle.save()
+        last.prev_section = middle
+        last.save()
+        middle_question = Question.objects.create(
+            survey_section=middle, name='Q', code='q_mid',
+            input_type='text', order_number=1,
+        )
+        self._answer(middle_question, 2)
+
+        response = self._delete_section(middle)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertTrue(SurveySection.objects.filter(pk=middle.pk).exists())
+        first.refresh_from_db()
+        last.refresh_from_db()
+        self.assertEqual(first.next_section_id, middle.pk)
+        self.assertEqual(last.prev_section_id, middle.pk)
+
+    def test_section_without_answers_deletes_in_one_step(self):
+        """
+        GIVEN a section whose questions have no answers
+        WHEN deletion is requested without acknowledgement
+        THEN it is deleted without a refusal
+        """
+        response = self._delete_section()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(SurveySection.objects.filter(pk=self.section.pk).exists())
+
+    # ── The versioning explanation ────────────────────────────────────────
+
+    def test_never_published_survey_gets_the_versioning_explanation(self):
+        """
+        GIVEN a survey that has never been published
+        WHEN a delete is refused
+        THEN the response says the versioning explanation applies
+        """
+        self._answer(self.question, 1)
+
+        response = self._delete_question()
+
+        self.assertTrue(response.json()['explain_versioning'])
+
+    def test_draft_copy_of_published_survey_does_not(self):
+        """
+        GIVEN a draft copy of a published survey
+        WHEN a delete is refused
+        THEN the versioning explanation does not apply — that author already
+             has version protection, so the sentence would be false
+        """
+        published = SurveyHeader.objects.create(
+            name='published_one', organization=self.org, created_by=self.user,
+            status='published',
+        )
+        draft = SurveyHeader.objects.create(
+            name='published_one_draft', organization=self.org, created_by=self.user,
+            status='draft', published_version=published, is_canonical=False,
+        )
+        section = SurveySection.objects.create(
+            survey_header=draft, name='s1', code='S1', is_head=True,
+        )
+        question = Question.objects.create(
+            survey_section=section, name='Q', code='q1',
+            input_type='text', order_number=1,
+        )
+        Answer.objects.create(
+            survey_session=SurveySession.objects.create(survey=draft),
+            question=question, text='x',
+        )
+
+        response = self.client.post(
+            f'/editor/surveys/{draft.uuid}/questions/{question.id}/delete/'
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertFalse(response.json()['explain_versioning'])
+
+    # ── The read-only lock still wins ─────────────────────────────────────
+
+    def test_published_survey_refuses_with_403_not_409(self):
+        """
+        GIVEN a published survey
+        WHEN deletion is requested, even with acknowledgement
+        THEN the structural lock refuses it and nothing is deleted
+        """
+        self._answer(self.question, 1)
+        self.survey.status = 'published'
+        self.survey.save()
+
+        response = self._delete_question(acknowledge=True)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Question.objects.filter(pk=self.question.pk).exists())


### PR DESCRIPTION
Backlog #98 — the cause of what Manuel Frost actually reported. He wrote that his export came back empty except for the last session and guessed his data was "older" than some change we had made. He was right that it was gone and wrong about why: he had edited the survey between test runs, and deleting a question takes its answers with it.

`Answer.question` is `on_delete=CASCADE` and `editor_question_delete` calls `question.delete()` with no check. The only thing in the way was `hx-confirm="Delete question 'X'?"` — written for a survey that had no responses.

## Scope was set by measurement, not by the title

**Versioning already protects published surveys.** `publish_draft` does not delete the old structure: it creates an archived `SurveyHeader` and *moves* the previous sections and sessions onto it (`versioning.py:236-260`), so the earlier version's questions stay live rows with their answers attached. Production bears that out — 61 archived headers currently hold 1060 questions and 3466 answers. Published and closed surveys are protected twice over, since structural edits are also locked.

What is unprotected is every survey that has never been published: **50 in `draft` holding 842 answers, 12 in `testing` holding 1471**. No archived version exists, so there is nowhere for the answers to go. That is exactly the state people are in while collecting their first responses, and where the reporter was.

That measurement is what decided the fix. Soft-delete would need new state on `Question`, a migration, and export and analytics changes — disproportionate for data belonging to surveys nobody has published. **The harm to fix is the silence, not the deletion.**

## How it works

The count is computed and enforced **on the server**, in the same request that would perform the delete. Without acknowledgement the endpoint returns 409 and touches nothing; with it, the delete proceeds.

Why not a better `hx-confirm` string: it is baked in when the list renders. On a survey that is actively collecting, "this will delete 3 answers" can be wrong by the time it is read, and a bare POST skips it entirely. A warning that is sometimes wrong about the number teaches the author to disbelieve it.

The count includes sub-questions at any depth — the editor offers one level today, but the model allows more, and an undercount would understate the one number this must not get wrong. Section deletes count across every question beneath them.

Questions with no answers still delete in one step. The extra prompt appears only when something is at stake, which is what keeps it readable.

The confirmation also explains what versioning would have preserved — but only for surveys never published, since for a draft copy the sentence would be false, and worded to state what versioning does rather than to advise publishing. Publishing a half-built survey to protect two test answers is worse advice than losing them.

## Worth a careful look in review

**The section guard runs before the neighbour re-linking.** The existing view re-links `prev_section`/`next_section` and *then* deletes. A guard placed after that would rewrite the section chain around a section that survives the refusal. `test_refused_section_delete_leaves_ordering_intact` covers it.

**The first version of this added its own modal.** The editor already routes every `hx-confirm` through `Dialog.confirm` (`editor_dialog.js`), so that put a second modal system alongside the existing one. It now calls the same `Dialog`, verified in the browser that only one modal is ever open.

## Verification

18 tests added — 8 on the counting traversal (including nesting deeper than the editor offers, and the zero cases), 10 on the guard (refusal, acknowledgement, sub-question and section counts, the ordering regression, the versioning flag on and off, and that the read-only lock still returns 403 rather than 409 and cannot be overridden by an acknowledgement). 897 pass.

Also exercised by hand on a seeded survey: a geo question whose own answers are zero but whose sub-question holds 3 reported 3, showed the versioning explanation, and took the sub-question with it on confirmation. Verified against the database rather than the DOM — the first DOM assertions raced the HTMX swap and read as failures when the rows were already gone.

## Filed rather than folded in

**#108 — editing a question's type or removing referenced choice codes invalidates stored answers just as silently.** `check_draft_compatibility` already detects exactly that, but only runs on the published path. It is arguably nastier than deletion: after a delete the question is visibly gone, whereas here nothing looks wrong until the export does.

## Artifacts

OpenSpec change `warn-before-destroying-answers` — proposal, design (D1–D4 with the alternatives rejected), specs under the new `destructive-edit-confirmation` capability, and tasks recording where the work diverged from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)