### PR TITLE
feat(editor): give closed surveys a way back into editing

### DIFF
--- a/openspec/backlog/INDEX.md
+++ b/openspec/backlog/INDEX.md
@@ -98,9 +98,10 @@
 | ~~97~~ | ~~bug~~ | ~~[datetime answers never appear in the CSV export](bug-datetime-missing-from-csv-export.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | ~~98~~ | ~~bug~~ | ~~[Deleting a question silently destroys all answers](bug-editing-question-destroys-answers.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-04~~ |
 | ~~99~~ | ~~bug~~ | ~~[Range slider: endpoint labels not aligned to the track](bug-range-slider-label-alignment.md)~~ | ~~high~~ | ~~frontend~~ | ~~—~~ | ~~2026-08-04~~ |
-| 100 | improvement | [Closed survey is a dead end — no way back to editing](improvement-closed-survey-edit-dead-end.md) | high | frontend | — | 2026-08-04 |
+| ~~100~~ | ~~improvement~~ | ~~[Closed survey is a dead end — no way back to editing](improvement-closed-survey-edit-dead-end.md)~~ | ~~high~~ | ~~frontend~~ | ~~—~~ | ~~2026-08-04~~ |
 | 101 | feature | [Clear all responses / reset survey data](feature-clear-all-responses.md) | medium | backend | — | 2026-08-04 |
 | 102 | feature | [Additional scale and ranking question types](feature-additional-scale-question-types.md) | medium | frontend | — | 2026-08-04 |
 | 106 | improvement | [Survey page always renders the map, squeezing non-geo surveys](improvement-map-panel-always-rendered.md) | high | frontend | — | 2026-08-05 |
 | 107 | bug | [Survey answers are never validated server-side](bug-answers-never-validated-server-side.md) | high | backend | — | 2026-08-05 |
 | 108 | bug | [Editing a question's type or choices invalidates stored answers](bug-question-edits-invalidate-stored-answers.md) | medium | backend | — | 2026-08-05 |
+| 109 | bug | [Multi-line template comments render into the page](bug-template-comments-leak-into-html.md) | medium | frontend | — | 2026-08-05 |

--- a/openspec/backlog/bug-template-comments-leak-into-html.md
+++ b/openspec/backlog/bug-template-comments-leak-into-html.md
@@ -1,0 +1,42 @@
+# Multi-line `{# #}` template comments render into the page
+
+**Type**: bug
+**Priority**: medium
+**Area**: frontend
+**Created**: 2026-08-05
+
+## Description
+
+Django's `{# ... #}` comment syntax is **single-line only**. A comment spanning more than one line is
+not stripped — it is emitted verbatim into the rendered HTML.
+
+Five templates carry multi-line `{# #}` comments, and at least two of them ship developer commentary
+to real visitors. Confirmed by fetching `/for-planners/`, which returns:
+
+```
+{# Per-page structured data for SEO landings. FAQPage + BreadcrumbList are
+{# Visible FAQ section for SEO landing pages. Renders nothing when n
+```
+
+Affected:
+
+- `survey/templates/partials/_landing_structured_data.html:1` — every SEO landing page
+- `survey/templates/partials/_faq_section.html:2` — every SEO landing page
+- `survey/templates/django_registration/activation_confirm.html:13`
+- `survey/templates/django_registration/resend_activation_done.html:12`
+- `survey/templates/django_registration/activation_failed.html:14`
+
+The landing-page ones are the ones that matter: those pages exist to be crawled, and they are
+currently serving stray internal notes about how the JSON-LD is built.
+
+## Notes
+
+- Found 2026-08-05 while verifying `closed-survey-edit-path` by hand. I had written the same defect
+  into `survey_detail.html` a minute earlier and only caught it because the banner was inspected in
+  a browser rather than trusted — which is also the argument for doing that check.
+- Fix is mechanical: `{% comment %}...{% endcomment %}` for anything multi-line, or collapse to one
+  line. Five files.
+- Worth a guard rather than only a fix, since nothing catches this today. A test that renders each
+  template and asserts no `{#` survives would do it, or a check in whatever lint step exists.
+- Not folded into `closed-survey-edit-path`: those templates are unrelated to that change, and a
+  fix touching SEO landing output belongs on its own commit where it can be reviewed as such.

--- a/openspec/backlog/improvement-closed-survey-edit-dead-end.md
+++ b/openspec/backlog/improvement-closed-survey-edit-dead-end.md
@@ -35,3 +35,15 @@ Publish to see what happens, then closes the survey to undo that, lands in this 
   what happens" case directly and needs no draft copy at all.
 - Also review the wording of the read-only banner: it states the lock without naming the next
   action, which is what left him stuck.
+- **2026-08-05 — FIXED** in change `closed-survey-edit-path`, branch `fix/closed-survey-edit-path`.
+  All three notes above were taken: the draft-copy route accepts `closed`, `published → draft` and
+  `closed → draft` are permitted while nothing has been collected, and the banner now always ends in
+  an action.
+- **5 of the 7 closed surveys in production were in the dead end** when this was written — no draft
+  copy, no offered route. 3 published surveys had zero sessions, the case the undo covers.
+- One refinement to the note above: the condition for returning to draft is not just "no sessions".
+  Publishing a new version moves the previous sessions onto an archived header, so a canonical survey
+  can show zero sessions while the survey has collected plenty. It also requires no archived
+  versions.
+- Publishing a draft of a closed survey deliberately leaves it closed. Editing a survey and reopening
+  it to respondents are two decisions, and "publish version" must not quietly mean the second.

--- a/openspec/changes/closed-survey-edit-path/.openspec.yaml
+++ b/openspec/changes/closed-survey-edit-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/closed-survey-edit-path/design.md
+++ b/openspec/changes/closed-survey-edit-path/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The lifecycle is `draft → testing → published → closed → archived`, with `testing → draft` the only
+backward step (`models.py:83-89`). Structural edits are blocked for `published` and `closed`
+(`_check_structural_edit_allowed`), and versioning supplies the sanctioned way to change a live
+survey: clone a draft copy, edit that, publish it as a new version while the previous structure and
+its sessions move onto an archived header.
+
+All of that is sound. What is missing is that the machinery is gated on `published` in two places
+that did not need to be — the template flag and the endpoint — leaving `closed` with the lock and
+none of the remedy.
+
+Two distinct situations get conflated in the reports, and separating them decides the design:
+
+- **A survey with responses that is closed.** The author wants to change it. Versioning already
+  answers this; only the gate is wrong.
+- **A survey published by accident, with nothing collected.** Versioning is a heavy answer to this —
+  a draft copy, a new version number, an archived header for a version nobody answered. What the
+  author wants is to undo the publish.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A closed survey has a visible, permitted route back to editing.
+- An accidental publish is reversible while nothing has been collected.
+- Editing a survey and reopening it to respondents remain separate decisions.
+- The read-only banner names the next action rather than only stating the lock.
+
+**Non-Goals:**
+
+- Returning a survey with responses to `draft`. Versioning exists precisely so that does not have to
+  happen, and permitting it would re-open the answer-destroying edits that the delete guard now
+  covers.
+- Editing published or closed surveys in place. The read-only lock stays exactly as it is.
+- Changing what `publish_draft` does to sections and sessions.
+- Reworking the status dropdown beyond the entries these rules add.
+
+## Decisions
+
+### D1 — Allow a draft copy from `closed`, not just `published`
+
+Both the template flag and `editor_create_draft` accept `closed` as well. Nothing else changes:
+`clone_survey_for_draft` copies structure and never reads the canonical's status, and `publish_draft`
+moves sections and sessions regardless of it.
+
+*Why not instead teach the author to Reopen first:* that is the existing path, and it requires
+reopening a survey to respondents purely to gain access to the editor. It makes the author take a
+public-facing action to achieve a private one, which is why nobody finds it.
+
+### D2 — Publishing a draft of a closed survey leaves it closed
+
+`publish_draft` does not currently touch the canonical's status, so this falls out for free. It is
+recorded as a decision rather than an accident because the alternative is tempting and wrong:
+"publish version" reading as "reopen to the public" would silently start collecting responses on a
+survey the author had deliberately closed.
+
+*Consequence to handle in the UI:* after publishing, the author is looking at a closed survey with
+their changes in place. The status dropdown already offers Reopen, so the second decision is one
+click away and is theirs to make.
+
+### D3 — Un-publish only while nothing has been collected
+
+Add `draft` to the valid transitions from `published` and `closed`, gated in `can_transition_to` on
+the survey having no sessions of its own **and** no archived versions.
+
+Both halves matter. Sessions alone would be satisfied by a survey that published v1, collected
+answers, then published v2 — the sessions moved onto the archived header, so the canonical shows
+zero while the survey plainly has history. Requiring `version_number == 1` and no archived versions
+closes that.
+
+*Why put a data condition inside `can_transition_to`:* it already carries conditions of this kind
+(`testing` and `published` require structure and a head section), so this is the established place
+for them rather than a new concept.
+
+*Why not a separate "unpublish" endpoint:* a transition is what this is, and the existing dropdown
+already drives transitions. A second mechanism for the same state change would be one more thing to
+keep consistent.
+
+### D4 — The banner names the action
+
+The read-only banner currently states the lock and, on published surveys, sometimes offers a button.
+It should always end in something the author can do: go to the existing draft, create one, or — when
+the survey has collected nothing — return it to draft.
+
+*Why this is part of the change rather than polish:* the reported failure was not that the action was
+forbidden, it was that the author could not see one. Fixing the permission without fixing the
+affordance would leave the bug reproducible for anyone who does not already know the answer.
+
+## Risks / Trade-offs
+
+**"Back to draft" on a published survey could be read as a safe undo in general** → It is only
+offered while nothing has been collected, which is exactly when it is safe. The risk is that an
+author sees it once and expects it later; mitigated by it simply not being there once a response
+arrives, rather than being there and failing.
+
+**Un-publishing breaks the public URL for anyone holding it** → That is what un-publishing means, and
+it is reversible by publishing again. It only applies to surveys nobody has answered, so nobody is
+mid-response when it happens.
+
+**Publishing a draft of a closed survey produces a new version that is not accepting responses** →
+Intended (D2), but potentially surprising. The status is visible in the header the whole time, and
+Reopen is adjacent.
+
+**A draft copy of a closed survey is a state that did not exist before** → It goes through the same
+`publish_draft` path as any other draft; the compatibility check and the archived-version mechanics
+do not read the canonical's status. Worth a test that asserts exactly that rather than trusting the
+reading.
+
+## Migration Plan
+
+No schema change and no migration. The rules are evaluated at request time, so the 5 closed surveys
+currently without an edit path gain one the moment this deploys, with no backfill.
+
+Rollback is a revert. Draft copies created from closed surveys in the meantime remain valid — they
+are ordinary drafts, and publishing them would still work.
+
+## Open Questions
+
+- Should `archived` get the same treatment? It is currently terminal, with no transitions out at all.
+  Nobody has reported it, and archiving is a deliberate end-of-life action rather than something you
+  click to see what happens, so it is left alone here.
+- When an author un-publishes to `draft`, should the test token be regenerated so previously shared
+  links stop working? Arguably yes for a survey being taken back into development, but it is a
+  separate decision about link hygiene and no one has asked for it.

--- a/openspec/changes/closed-survey-edit-path/proposal.md
+++ b/openspec/changes/closed-survey-edit-path/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+A closed survey cannot be edited and the editor offers no way out of that state.
+
+The read-only lock itself is right: a survey with live responses must not be edited in place, and
+versioning provides the correct route via a draft copy. The problem is that the route is only
+advertised, and only permitted, for `published`. `show_edit_published` requires
+`survey.status == 'published'` (`editor_views.py:146-148`) and `editor_create_draft` rejects
+anything else outright (`editor_views.py:1166-1167`). So on a **closed** survey the read-only banner
+renders with no action at all: no "Create a draft copy", no "Go to draft", and a status dropdown
+offering only Reopen and Archive.
+
+The actual sequence — Reopen, *then* create a draft copy — is not discoverable, and reopening a
+survey you deliberately closed looks wrong enough that a careful person will not try it. **5 of the
+7 closed surveys in production have no draft copy**, so they are in this state now.
+
+The user who reported it took the only path he could see: "I clicked on the publish-Button to see
+what happened. After that, i can't go back. So I closed the survey... I fixed that with a work-around:
+I make a copy to new one." That workaround costs him the responses and the survey URL.
+
+His path also exposes a second gap. He published to see what would happen, on a survey nobody had
+answered. There is no cheap undo for that: `published → draft` is not a valid transition at all, so
+an accidental publish is permanent even when nothing has been collected. **3 published surveys in
+production have zero sessions.**
+
+## What Changes
+
+- A closed survey offers the same "Create a draft copy" route a published one does, in the banner
+  and in the endpoint behind it.
+- Publishing that draft leaves the canonical survey closed. Editing a survey and reopening it to
+  respondents stay two separate decisions; publishing a new version SHALL NOT silently start
+  accepting responses again.
+- `published → draft` and `closed → draft` become valid **only** while the survey has never
+  collected anything — no sessions of its own and no archived versions. That covers the
+  publish-by-accident case directly and needs no draft copy.
+- The read-only banner names the next action instead of only stating the lock.
+
+Not in scope: letting a survey with responses return to `draft`. That is what versioning is for, and
+allowing it would put the answer-destroying edits that #98 just guarded back on the table by another
+route.
+
+## Capabilities
+
+### New Capabilities
+- `survey-edit-recovery`: how an author gets back to editing from a state where editing is locked —
+  which lifecycle transitions are permitted when, when a draft copy may be created, and what the
+  editor tells them.
+
+### Modified Capabilities
+
+None. `survey-editor` in `openspec/specs/` does not specify the lifecycle or the read-only banner,
+so there is no existing requirement to amend.
+
+## Impact
+
+- `survey/models.py` — `VALID_TRANSITIONS` and `can_transition_to`, plus a helper for "has never
+  collected anything".
+- `survey/editor_views.py` — `editor_create_draft`, `show_edit_published`.
+- `survey/templates/editor/survey_detail.html` — the read-only banner and the status dropdown.
+- No migration; this is lifecycle rules and template gating over existing fields.
+- Backlog #100 closed. Answers the reporter's sixth point, and makes his copy-the-survey workaround
+  unnecessary.

--- a/openspec/changes/closed-survey-edit-path/specs/survey-edit-recovery/spec.md
+++ b/openspec/changes/closed-survey-edit-path/specs/survey-edit-recovery/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: A closed survey can be taken back into editing via a draft copy
+
+An owner SHALL be able to create a draft copy of a `closed` survey, on the same terms as a
+`published` one. The editor SHALL offer this route wherever the survey is read-only.
+
+#### Scenario: Draft copy created from a closed survey
+
+- **WHEN** an owner creates a draft copy of a closed survey
+- **THEN** the draft is created and linked to it
+- **AND** the closed survey itself is unchanged
+
+#### Scenario: The read-only banner offers the route
+
+- **WHEN** an owner opens a closed survey that has no draft copy
+- **THEN** the read-only notice offers to create one
+
+#### Scenario: An existing draft is linked rather than duplicated
+
+- **WHEN** an owner opens a closed survey that already has a draft copy
+- **THEN** the read-only notice links to that draft
+- **AND** a second draft cannot be created
+
+### Requirement: Publishing a draft never reopens a closed survey
+
+Publishing a draft of a `closed` survey SHALL apply the changes and leave the survey closed.
+Accepting responses again SHALL remain a separate, explicit action.
+
+#### Scenario: Closed survey stays closed after its draft is published
+
+- **WHEN** a draft copy of a closed survey is published
+- **THEN** the canonical survey carries the draft's structure
+- **AND** its status is still `closed`
+- **AND** its version number has increased
+
+#### Scenario: The previous version is archived as usual
+
+- **WHEN** a draft copy of a closed survey is published
+- **THEN** the previous structure and its sessions are moved to an archived version, exactly as for
+  a published survey
+
+### Requirement: A survey that has collected nothing can be returned to draft
+
+`published → draft` and `closed → draft` SHALL be permitted only while the survey has no sessions of
+its own and no archived versions. Otherwise they SHALL be refused.
+
+#### Scenario: Accidental publish is undone
+
+- **WHEN** an owner returns a published survey with no sessions and no archived versions to draft
+- **THEN** the transition succeeds
+- **AND** the survey becomes editable again
+
+#### Scenario: A survey with responses cannot be returned to draft
+
+- **WHEN** an owner attempts to return a published survey that has sessions to draft
+- **THEN** the transition is refused
+- **AND** the survey's status is unchanged
+
+#### Scenario: A survey with earlier versions cannot be returned to draft
+
+- **WHEN** an owner attempts to return a survey to draft that has no sessions of its own but does
+  have an archived version
+- **THEN** the transition is refused
+
+  Sessions move onto the archived header when a new version is published, so a canonical survey can
+  show zero sessions while the survey has collected plenty.
+
+#### Scenario: A closed survey that collected nothing can be returned to draft
+
+- **WHEN** an owner returns a closed survey with no sessions and no archived versions to draft
+- **THEN** the transition succeeds
+
+### Requirement: The read-only notice always names an available action
+
+Wherever a survey is read-only, the editor SHALL name what the author can do next rather than only
+stating that editing is blocked.
+
+#### Scenario: Locked survey without a draft
+
+- **WHEN** an owner opens a read-only survey that has no draft copy
+- **THEN** the notice offers to create one
+
+#### Scenario: Locked survey that collected nothing
+
+- **WHEN** an owner opens a read-only survey with no sessions and no archived versions
+- **THEN** the notice offers to return it to draft

--- a/openspec/changes/closed-survey-edit-path/tasks.md
+++ b/openspec/changes/closed-survey-edit-path/tasks.md
@@ -1,0 +1,60 @@
+## 1. "Has never collected anything"
+
+- [ ] 1.1 Add a model helper for the condition both new transitions depend on: no sessions of the
+      survey's own **and** no archived versions. Both halves — sessions move onto the archived header
+      when a version is published, so a canonical survey can read zero while the survey has history.
+- [ ] 1.2 Test it directly: fresh survey, survey with sessions, survey whose sessions moved to an
+      archived version, draft copy.
+
+## 2. Lifecycle rules
+
+- [ ] 2.1 Add `draft` to the transitions permitted from `published` and `closed`.
+- [ ] 2.2 Gate both in `can_transition_to` on 1.1, with a refusal message that says why rather than
+      just "cannot transition".
+- [ ] 2.3 Confirm the existing conditions on `testing` and `published` are untouched.
+
+## 3. Draft copies from closed surveys
+
+- [ ] 3.1 `editor_create_draft`: accept `closed` as well as `published` (it currently rejects
+      everything else with a 400).
+- [ ] 3.2 `show_edit_published`: same, so the banner offers the route.
+- [ ] 3.3 Verify `publish_draft` needs no change — it must archive the previous version and leave the
+      canonical's status alone, so a closed survey stays closed (design D2). Assert rather than
+      assume.
+
+## 4. The banner
+
+- [ ] 4.1 The read-only notice always ends in an action: go to the existing draft, create one, or
+      return the survey to draft when it has collected nothing.
+- [ ] 4.2 Add the "Back to Draft" entry to the status dropdown under the same condition.
+- [ ] 4.3 Word it so returning to draft does not read as a general undo — it is only there while
+      nothing has been collected, and it should be obvious that it is about an unpublished mistake.
+
+## 5. Tests
+
+- [ ] 5.1 Draft copy can be created from a closed survey; the closed survey is unchanged.
+- [ ] 5.2 Publishing that draft leaves the canonical `closed`, bumps the version, and archives the
+      previous structure and sessions.
+- [ ] 5.3 `published → draft` succeeds with no sessions and no archived versions.
+- [ ] 5.4 `published → draft` is refused once a session exists.
+- [ ] 5.5 `published → draft` is refused when sessions moved to an archived version — the case a
+      naive session count would miss.
+- [ ] 5.6 `closed → draft` succeeds under the same condition.
+- [ ] 5.7 A second draft copy still cannot be created while one exists.
+- [ ] 5.8 The structural read-only lock is unchanged: editing a closed survey directly is still 403.
+
+## 6. Verify
+
+- [ ] 6.1 Run the full survey suite.
+- [ ] 6.2 Walk it by hand: close a survey, create a draft from the banner, edit, publish, confirm it
+      is still closed and the changes are live, then Reopen.
+- [ ] 6.3 Walk the accidental-publish path by hand: publish a survey with no responses, return it to
+      draft, confirm it is editable.
+
+## 7. Close the loop
+
+- [ ] 7.1 Strike backlog #100 and record that 5 of 7 closed surveys in production were in the dead
+      end when this was written.
+- [ ] 7.2 Note for the reply owed to the reporter: his workaround — copying the survey — is no longer
+      necessary, and his sixth point is answered. Worth saying plainly that the route existed but
+      only for published surveys, rather than implying he missed it.

--- a/openspec/changes/closed-survey-edit-path/tasks.md
+++ b/openspec/changes/closed-survey-edit-path/tasks.md
@@ -1,60 +1,76 @@
 ## 1. "Has never collected anything"
 
-- [ ] 1.1 Add a model helper for the condition both new transitions depend on: no sessions of the
+- [x] 1.1 Add a model helper for the condition both new transitions depend on: no sessions of the
       survey's own **and** no archived versions. Both halves — sessions move onto the archived header
       when a version is published, so a canonical survey can read zero while the survey has history.
-- [ ] 1.2 Test it directly: fresh survey, survey with sessions, survey whose sessions moved to an
+- [x] 1.2 Test it directly: fresh survey, survey with sessions, survey whose sessions moved to an
       archived version, draft copy.
 
 ## 2. Lifecycle rules
 
-- [ ] 2.1 Add `draft` to the transitions permitted from `published` and `closed`.
-- [ ] 2.2 Gate both in `can_transition_to` on 1.1, with a refusal message that says why rather than
+- [x] 2.1 Add `draft` to the transitions permitted from `published` and `closed`.
+- [x] 2.2 Gate both in `can_transition_to` on 1.1, with a refusal message that says why rather than
       just "cannot transition".
-- [ ] 2.3 Confirm the existing conditions on `testing` and `published` are untouched.
+- [x] 2.3 Confirm the existing conditions on `testing` and `published` are untouched.
 
 ## 3. Draft copies from closed surveys
 
-- [ ] 3.1 `editor_create_draft`: accept `closed` as well as `published` (it currently rejects
+- [x] 3.1 `editor_create_draft`: accept `closed` as well as `published` (it currently rejects
       everything else with a 400).
-- [ ] 3.2 `show_edit_published`: same, so the banner offers the route.
-- [ ] 3.3 Verify `publish_draft` needs no change — it must archive the previous version and leave the
+- [x] 3.2 `show_edit_published`: same, so the banner offers the route.
+- [x] 3.3 Verify `publish_draft` needs no change — it must archive the previous version and leave the
       canonical's status alone, so a closed survey stays closed (design D2). Assert rather than
       assume.
 
 ## 4. The banner
 
-- [ ] 4.1 The read-only notice always ends in an action: go to the existing draft, create one, or
+- [x] 4.1 The read-only notice always ends in an action: go to the existing draft, create one, or
       return the survey to draft when it has collected nothing.
-- [ ] 4.2 Add the "Back to Draft" entry to the status dropdown under the same condition.
-- [ ] 4.3 Word it so returning to draft does not read as a general undo — it is only there while
+- [x] 4.2 Add the "Back to Draft" entry to the status dropdown under the same condition.
+- [x] 4.3 Word it so returning to draft does not read as a general undo — it is only there while
       nothing has been collected, and it should be obvious that it is about an unpublished mistake.
 
 ## 5. Tests
 
-- [ ] 5.1 Draft copy can be created from a closed survey; the closed survey is unchanged.
-- [ ] 5.2 Publishing that draft leaves the canonical `closed`, bumps the version, and archives the
+- [x] 5.1 Draft copy can be created from a closed survey; the closed survey is unchanged.
+- [x] 5.2 Publishing that draft leaves the canonical `closed`, bumps the version, and archives the
       previous structure and sessions.
-- [ ] 5.3 `published → draft` succeeds with no sessions and no archived versions.
-- [ ] 5.4 `published → draft` is refused once a session exists.
-- [ ] 5.5 `published → draft` is refused when sessions moved to an archived version — the case a
+- [x] 5.3 `published → draft` succeeds with no sessions and no archived versions.
+- [x] 5.4 `published → draft` is refused once a session exists.
+- [x] 5.5 `published → draft` is refused when sessions moved to an archived version — the case a
       naive session count would miss.
-- [ ] 5.6 `closed → draft` succeeds under the same condition.
-- [ ] 5.7 A second draft copy still cannot be created while one exists.
-- [ ] 5.8 The structural read-only lock is unchanged: editing a closed survey directly is still 403.
+- [x] 5.6 `closed → draft` succeeds under the same condition.
+- [x] 5.7 A second draft copy still cannot be created while one exists.
+- [x] 5.8 The structural read-only lock is unchanged: editing a closed survey directly is still 403.
 
 ## 6. Verify
 
-- [ ] 6.1 Run the full survey suite.
-- [ ] 6.2 Walk it by hand: close a survey, create a draft from the banner, edit, publish, confirm it
+- [x] 6.1 Run the full survey suite.
+- [x] 6.2 Walk it by hand: close a survey, create a draft from the banner, edit, publish, confirm it
       is still closed and the changes are live, then Reopen.
-- [ ] 6.3 Walk the accidental-publish path by hand: publish a survey with no responses, return it to
+
+  Walked on a seeded closed survey with 3 sessions. The banner offered "Create a draft copy", the
+  draft was created and edited, and publishing left the canonical `closed` at version 2 with the
+  edit in place and all 3 sessions moved onto the archived version. Reopen remains a separate click,
+  which is the point.
+- [x] 6.3 Walk the accidental-publish path by hand: publish a survey with no responses, return it to
       draft, confirm it is editable.
+
+  Walked, and it caught a defect the test suite could not: my banner comment used `{# #}` across
+  three lines, which Django does not strip — it rendered into the page. Fixed here with
+  `{% comment %}`. Checking the other templates turned up five more instances of the same thing, two
+  of them leaking onto every SEO landing page; filed as **#109** rather than folded in, since those
+  templates are unrelated to this change.
 
 ## 7. Close the loop
 
-- [ ] 7.1 Strike backlog #100 and record that 5 of 7 closed surveys in production were in the dead
+- [x] 7.1 Strike backlog #100 and record that 5 of 7 closed surveys in production were in the dead
       end when this was written.
-- [ ] 7.2 Note for the reply owed to the reporter: his workaround — copying the survey — is no longer
+
+  Struck, with one refinement recorded on the item: the note there proposed gating the undo on
+  `SurveySession.objects.filter(survey=...).exists()` alone, which would be wrong — sessions move to
+  the archived header on publish, so a canonical survey can read zero while having history. The
+  condition also requires no archived versions.
+- [x] 7.2 Note for the reply owed to the reporter: his workaround — copying the survey — is no longer
       necessary, and his sixth point is answered. Worth saying plainly that the route existed but
       only for published surveys, rather than implying he missed it.

--- a/survey/editor_views.py
+++ b/survey/editor_views.py
@@ -184,9 +184,15 @@ def editor_survey_detail(request, survey_uuid):
     # Versioning context
     draft_copy = survey.get_draft_copy() if not survey.is_draft_copy else None
     show_edit_published = (
-        is_owner and survey.status == 'published' and not survey.has_draft_copy()
+        is_owner and survey.status in ('published', 'closed') and not survey.has_draft_copy()
     )
     show_draft_actions = is_owner and survey.is_draft_copy
+    # An accidental publish is undoable while nothing has been collected. Offered
+    # alongside the draft-copy route so the read-only notice always ends in an
+    # action the author can take.
+    show_back_to_draft = (
+        is_owner and is_read_only and not survey.is_draft_copy and survey.has_never_collected()
+    )
 
     return render(request, 'editor/survey_detail.html', {
         'survey': survey,
@@ -200,6 +206,7 @@ def editor_survey_detail(request, survey_uuid):
         'draft_copy': draft_copy,
         'show_edit_published': show_edit_published,
         'show_draft_actions': show_draft_actions,
+        'show_back_to_draft': show_back_to_draft,
     })
 
 
@@ -1163,8 +1170,13 @@ def editor_create_draft(request, survey_uuid):
     """Create a draft copy of a published survey for editing."""
     survey = request.survey
 
-    if survey.status != 'published':
-        return HttpResponse('Only published surveys can have draft copies', status=400)
+    # Closed as well as published: a closed survey is read-only for the same
+    # reason and needs the same way out. Nothing downstream reads the canonical's
+    # status — clone_survey_for_draft copies structure, and publish_draft archives
+    # the previous version and leaves the status alone, so a closed survey stays
+    # closed after its draft is published.
+    if survey.status not in ('published', 'closed'):
+        return HttpResponse('Only published or closed surveys can have draft copies', status=400)
 
     if survey.has_draft_copy():
         return HttpResponse('A draft already exists for this survey', status=409)

--- a/survey/models.py
+++ b/survey/models.py
@@ -80,11 +80,15 @@ BASEMAP_CHOICES = [
     ('topo', _('Topo')),
 ]
 
+# `published`/`closed` -> `draft` is permitted only while the survey has never
+# collected anything; the condition lives in can_transition_to. It is an undo for
+# publishing by accident, not a way to edit a survey that has responses — that is
+# what draft copies and versioning are for.
 VALID_TRANSITIONS = {
     "draft": ["testing", "published"],
     "testing": ["draft", "published"],
-    "published": ["closed"],
-    "closed": ["published", "archived"],
+    "published": ["closed", "draft"],
+    "closed": ["published", "archived", "draft"],
     "archived": [],
 }
 
@@ -378,6 +382,14 @@ class SurveyHeader(models.Model):
             if not self._has_head_section():
                 return False, "Survey must have a head section"
 
+        if new_status == "draft" and self.status in ("published", "closed"):
+            if not self.has_never_collected():
+                return False, (
+                    "This survey has already collected responses. "
+                    "Create a draft copy to edit it instead — that keeps the "
+                    "responses collected so far as an archived version."
+                )
+
         return True, ""
 
     def _has_survey_structure(self):
@@ -434,6 +446,20 @@ class SurveyHeader(models.Model):
         return self.deleted_at + timedelta(days=self.TRASH_RETENTION_DAYS)
 
     # Versioning methods
+    def has_never_collected(self):
+        """True when nothing has ever been recorded against this survey.
+
+        Both halves are needed. Publishing a new version moves the previous
+        sessions onto an archived header, so a canonical survey can show zero
+        sessions of its own while the survey has collected plenty — checking
+        only the session count would read that as untouched.
+        """
+        if SurveySession.objects.filter(survey=self).exists():
+            return False
+        return not SurveyHeader.objects.filter(
+            canonical_survey=self, is_canonical=False,
+        ).exists()
+
     def has_draft_copy(self):
         return self.draft_copies.exists()
 

--- a/survey/templates/editor/survey_detail.html
+++ b/survey/templates/editor/survey_detail.html
@@ -26,8 +26,14 @@
         <button class="dropdown-item" onclick="doTransition('draft')">Back to Draft</button>
         {% elif survey.status == 'published' %}
         <button class="dropdown-item" onclick="doTransition('closed')">Close Survey</button>
+        {% if show_back_to_draft %}
+        <button class="dropdown-item" onclick="doTransition('draft')">Back to Draft</button>
+        {% endif %}
         {% elif survey.status == 'closed' %}
         <button class="dropdown-item" onclick="doTransition('published')">Reopen</button>
+        {% if show_back_to_draft %}
+        <button class="dropdown-item" onclick="doTransition('draft')">Back to Draft</button>
+        {% endif %}
         <button class="dropdown-item" onclick="doTransition('archived')">Archive</button>
         {% endif %}
     </div>
@@ -53,9 +59,19 @@
 {% if is_read_only and not survey.is_draft_copy %}
 <div class="alert alert-warning mb-0 rounded-0 text-center flex-shrink-0" style="font-size:0.85rem;">
     <i class="fas fa-lock"></i> This survey is <strong>read-only</strong>.
-    {% if draft_copy %}
+    {% if show_back_to_draft %}
+    {% comment %}
+    Nothing has been collected, so publishing can simply be undone — no draft
+    copy, no new version. Offered first because it is what someone who published
+    by accident actually wants. Note {# #} is single-line only in Django; a
+    multi-line one renders into the page.
+    {% endcomment %}
+    Nothing has been collected yet, so you can take it back into editing.
+    <button class="btn btn-sm btn-primary ml-2" onclick="doTransition('draft')">Back to editing</button>
+    {% elif draft_copy %}
     <a href="{% url 'editor_survey_detail' draft_copy.uuid %}" class="ml-2 btn btn-sm btn-outline-dark">Go to draft &rarr;</a>
     {% elif show_edit_published %}
+    Edit it in a draft copy — the responses collected so far stay as an archived version.
     <form method="post" action="{% url 'editor_create_draft' survey.uuid %}" class="d-inline ml-2">
         {% csrf_token %}
         <button type="submit" class="btn btn-sm btn-primary">Create a draft copy</button>

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -18373,3 +18373,256 @@ class DeleteAnswerGuardTest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertTrue(Question.objects.filter(pk=self.question.pk).exists())
+
+
+class ClosedSurveyEditPathTest(TestCase):
+    """Getting back to editing from a read-only survey."""
+
+    def setUp(self):
+        self.org = _make_org('RecoveryOrg')
+        self.user = User.objects.create_user('recoveryuser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+        self.client.login(username='recoveryuser', password='pass')
+
+    def _survey(self, status='published', name=None):
+        survey = SurveyHeader.objects.create(
+            name=name or f'recovery_{status}_{id(self)}', organization=self.org,
+            created_by=self.user, status=status,
+        )
+        section = SurveySection.objects.create(
+            survey_header=survey, name='s1', code='S1', is_head=True,
+        )
+        Question.objects.create(
+            survey_section=section, name='Comment', code='q1',
+            input_type='text', order_number=1,
+        )
+        return survey
+
+    def _transition(self, survey, status):
+        return self.client.post(
+            f'/editor/surveys/{survey.uuid}/transition/', {'status': status},
+        )
+
+    def _create_draft(self, survey):
+        return self.client.post(f'/editor/surveys/{survey.uuid}/create-draft/')
+
+    # ── Draft copies from closed surveys ──────────────────────────────────
+
+    def test_draft_copy_can_be_created_from_a_closed_survey(self):
+        """
+        GIVEN a closed survey with no draft copy
+        WHEN the owner creates one
+        THEN the draft exists and the closed survey is untouched
+        """
+        survey = self._survey(status='closed')
+
+        response = self._create_draft(survey)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(survey.has_draft_copy())
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'closed')
+
+    def test_closed_survey_banner_offers_the_route(self):
+        """
+        GIVEN a closed survey with responses and no draft copy
+        WHEN the owner opens the editor
+        THEN the read-only notice offers to create a draft copy
+        """
+        survey = self._survey(status='closed')
+        SurveySession.objects.create(survey=survey)
+
+        response = self.client.get(f'/editor/surveys/{survey.uuid}/')
+
+        self.assertTrue(response.context['show_edit_published'])
+        self.assertContains(response, 'Create a draft copy')
+
+    def test_second_draft_copy_is_still_refused(self):
+        """
+        GIVEN a closed survey that already has a draft copy
+        WHEN another is requested
+        THEN it is refused
+        """
+        survey = self._survey(status='closed')
+        self._create_draft(survey)
+
+        response = self._create_draft(survey)
+
+        self.assertEqual(response.status_code, 409)
+
+    def test_publishing_a_draft_leaves_the_survey_closed(self):
+        """
+        GIVEN a closed survey whose draft copy has been edited
+        WHEN the draft is published
+        THEN the changes land, the version increases, and the survey stays
+             closed — publishing must not silently reopen it to respondents
+        """
+        survey = self._survey(status='closed')
+        session = SurveySession.objects.create(survey=survey)
+        self._create_draft(survey)
+        draft = survey.get_draft_copy()
+
+        publish_draft(draft)
+
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'closed')
+        self.assertEqual(survey.version_number, 2)
+        archived = SurveyHeader.objects.get(canonical_survey=survey, is_canonical=False)
+        session.refresh_from_db()
+        self.assertEqual(session.survey_id, archived.id)
+
+    # ── Undoing a publish that collected nothing ──────────────────────────
+
+    def test_published_survey_with_nothing_collected_returns_to_draft(self):
+        """
+        GIVEN a published survey nobody has answered
+        WHEN the owner returns it to draft
+        THEN it becomes editable again
+        """
+        survey = self._survey(status='published')
+
+        response = self._transition(survey, 'draft')
+
+        self.assertIn(response.status_code, (200, 302))
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'draft')
+
+    def test_closed_survey_with_nothing_collected_returns_to_draft(self):
+        """
+        GIVEN a closed survey nobody has answered
+        WHEN the owner returns it to draft
+        THEN it becomes editable again
+        """
+        survey = self._survey(status='closed')
+
+        self._transition(survey, 'draft')
+
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'draft')
+
+    def test_survey_with_responses_cannot_return_to_draft(self):
+        """
+        GIVEN a published survey that has collected a response
+        WHEN the owner attempts to return it to draft
+        THEN it is refused and the status is unchanged
+        """
+        survey = self._survey(status='published')
+        SurveySession.objects.create(survey=survey)
+
+        response = self._transition(survey, 'draft')
+
+        self.assertEqual(response.status_code, 400)
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'published')
+
+    def test_survey_whose_sessions_moved_to_an_archive_cannot_return_to_draft(self):
+        """
+        GIVEN a survey whose responses moved onto an archived version when a new
+              version was published, leaving it with no sessions of its own
+        WHEN the owner attempts to return it to draft
+        THEN it is refused
+
+        A plain session count would read this survey as untouched.
+        """
+        survey = self._survey(status='published')
+        SurveySession.objects.create(survey=survey)
+        self._create_draft(survey)
+        publish_draft(survey.get_draft_copy())
+        survey.refresh_from_db()
+        self.assertEqual(SurveySession.objects.filter(survey=survey).count(), 0)
+
+        response = self._transition(survey, 'draft')
+
+        self.assertEqual(response.status_code, 400)
+        survey.refresh_from_db()
+        self.assertEqual(survey.status, 'published')
+
+    def test_back_to_draft_is_not_offered_once_a_response_exists(self):
+        """
+        GIVEN a published survey with a response
+        WHEN the owner opens the editor
+        THEN the undo is not offered
+        """
+        survey = self._survey(status='published')
+        SurveySession.objects.create(survey=survey)
+
+        response = self.client.get(f'/editor/surveys/{survey.uuid}/')
+
+        self.assertFalse(response.context['show_back_to_draft'])
+
+    def test_back_to_draft_is_offered_when_nothing_collected(self):
+        """
+        GIVEN a published survey nobody has answered
+        WHEN the owner opens the editor
+        THEN the undo is offered
+        """
+        survey = self._survey(status='published')
+
+        response = self.client.get(f'/editor/surveys/{survey.uuid}/')
+
+        self.assertTrue(response.context['show_back_to_draft'])
+
+    # ── The lock itself is unchanged ──────────────────────────────────────
+
+    def test_structural_edits_are_still_blocked_on_a_closed_survey(self):
+        """
+        GIVEN a closed survey
+        WHEN a question deletion is attempted directly
+        THEN it is still refused by the read-only lock
+        """
+        survey = self._survey(status='closed')
+        question = Question.objects.filter(survey_section__survey_header=survey).first()
+
+        response = self.client.post(
+            f'/editor/surveys/{survey.uuid}/questions/{question.id}/delete/'
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Question.objects.filter(pk=question.pk).exists())
+
+
+class HasNeverCollectedTest(TestCase):
+    """The condition both new transitions depend on."""
+
+    def setUp(self):
+        self.org = _make_org('CollectedOrg')
+        self.user = User.objects.create_user('collecteduser', password='pass')
+
+    def _survey(self, name, status='published'):
+        return SurveyHeader.objects.create(
+            name=name, organization=self.org, created_by=self.user, status=status,
+        )
+
+    def test_fresh_survey_has_never_collected(self):
+        """
+        GIVEN a survey with no sessions and no versions
+        WHEN the condition is evaluated
+        THEN it is true
+        """
+        self.assertTrue(self._survey('fresh').has_never_collected())
+
+    def test_survey_with_a_session_has_collected(self):
+        """
+        GIVEN a survey with one session
+        WHEN the condition is evaluated
+        THEN it is false
+        """
+        survey = self._survey('with_session')
+        SurveySession.objects.create(survey=survey)
+
+        self.assertFalse(survey.has_never_collected())
+
+    def test_survey_with_an_archived_version_has_collected(self):
+        """
+        GIVEN a survey with no sessions of its own but an archived version
+        WHEN the condition is evaluated
+        THEN it is false — the sessions moved there when the version was published
+        """
+        survey = self._survey('with_history')
+        SurveyHeader.objects.create(
+            name='with_history_v1', organization=self.org, created_by=self.user,
+            status='closed', is_canonical=False, canonical_survey=survey,
+            version_number=1,
+        )
+
+        self.assertFalse(survey.has_never_collected())


### PR DESCRIPTION
Backlog #100 — the sixth point in Manuel Frost's report, and the one where he had to invent a workaround.

> "I clicked on the publish-Button to see what happened. After that, i can't go back. So I closed the survey... Is there any possibility to unlock the survey to the edit-mode? I fixed that with a work-around: I make a copy to new one."

Copying the survey cost him the responses and the URL. He did not miss anything — the route genuinely was not there.

## What was wrong

The read-only lock itself is right and stays: a survey with live responses must not be edited in place, and versioning provides the sanctioned route via a draft copy. But the remedy was gated on `published` in two places that did not need it — `show_edit_published` (`editor_views.py:146-148`) and `editor_create_draft`, which rejected anything else with a 400.

So a **closed** survey got the lock and none of the way out: the banner rendered with no action at all, and the status dropdown offered only Reopen and Archive. The real sequence — Reopen, *then* create a draft copy — requires reopening a survey to the public purely to gain access to the editor, which is why nobody finds it.

**5 of the 7 closed surveys in production have no draft copy**, so they were in this state.

## Two rules, because the report contains two situations

**A survey with responses that is closed.** Versioning already answers this; only the gate was wrong. A draft copy can now be created from `closed` as well as `published`, and publishing it **leaves the survey closed**. That falls out of `publish_draft` not touching the canonical's status, but it is asserted rather than assumed — "publish version" must not quietly mean "start accepting responses again" on a survey the author deliberately closed. Reopen stays one adjacent click, and remains the author's decision.

**A survey published by accident, with nothing collected.** Versioning is a heavy answer to this — a draft copy, a new version, an archived header for a version nobody answered. What the author wants is to undo the publish. So `published → draft` and `closed → draft` are now valid while the survey has never collected anything. **3 published surveys in production have zero sessions.**

## The condition is not "no sessions"

The backlog item proposed gating on `SurveySession.objects.filter(survey=...).exists()`. That would be wrong: publishing a new version *moves* the previous sessions onto the archived header, so a canonical survey can read zero sessions while the survey has collected plenty. The condition requires no sessions of its own **and** no archived versions.

`test_survey_whose_sessions_moved_to_an_archive_cannot_return_to_draft` is the test for the case a naive count would miss.

Returning a survey **with** responses to draft stays forbidden. Versioning exists so that need not happen, and allowing it would route around the answer-destroying edits #52 just guarded.

## The banner is part of the fix

The reported failure was not that the action was forbidden — it was that the author could not see one. The read-only notice now always ends in something to do: go to the existing draft, create one, or return the survey to draft when it has collected nothing. Fixing the permission without the affordance would leave the bug reproducible for anyone who does not already know the answer.

## Verification

14 tests added, 911 pass. Both paths also walked by hand:

- Closed survey with 3 sessions → banner offered the draft copy → edited → published → canonical still `closed` at v2, edit live, all 3 sessions moved to the archived version.
- Published survey with no responses → "Back to editing" → `Draft · v1`, banner gone, questions editable.

**That manual walk caught something the suite could not.** My banner comment used `{# #}` across three lines. Django's `{# #}` is single-line only, so it rendered into the page. Fixed here with `{% comment %}`.

Checking the other templates found five more instances of the same defect, two of them leaking developer commentary onto every SEO landing page — confirmed by fetching `/for-planners/`, which returns internal notes about how the JSON-LD is built. Filed as **#109** rather than folded in: those templates are unrelated to this change, and a fix touching SEO landing output should be reviewed as its own commit. It is mechanical, five files, and probably wants a guard so nothing catches it next time either.

## Artifacts

OpenSpec change `closed-survey-edit-path` — proposal, design (D1–D4), specs under the new `survey-edit-recovery` capability, and tasks recording the manual walks and what they turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)