### PR TITLE
fix(analytics): make analytics and the export agree on ?version=

### DIFF
--- a/openspec/backlog/INDEX.md
+++ b/openspec/backlog/INDEX.md
@@ -109,4 +109,4 @@
 | 111 | bug | [Color, Icon and Image are offered on every question type](bug-question-fields-shown-for-every-type.md) | high | frontend | — | 2026-08-09 |
 | 112 | improvement | [Group the question type list — display blocks are not input types](improvement-group-question-type-list.md) | medium | frontend | — | 2026-08-09 |
 | 113 | bug | [Results-page preview always claims "Unlisted"](bug-results-preview-always-claims-unlisted.md) | medium | frontend | — | 2026-08-09 |
-| 114 | bug | [Analytics and export disagree on which version they show](bug-analytics-and-export-disagree-on-version.md) | high | backend | — | 2026-08-09 |
+| ~~114~~ | ~~bug~~ | ~~[Analytics and export disagree on which version they show](bug-analytics-and-export-disagree-on-version.md)~~ | ~~high~~ | ~~backend~~ | ~~—~~ | ~~2026-08-09~~ |

--- a/openspec/backlog/bug-analytics-and-export-disagree-on-version.md
+++ b/openspec/backlog/bug-analytics-and-export-disagree-on-version.md
@@ -4,6 +4,9 @@
 **Priority**: high
 **Area**: backend
 **Created**: 2026-08-09
+**Status**: fixed 2026-08-10 — `openspec/changes/version-filter-parity/`. One resolver in
+`survey/versioning.py` serves both surfaces; the default is the whole family on both, and `latest`
+means the canonical version on both.
 
 ## Description
 

--- a/openspec/changes/version-filter-parity/.openspec.yaml
+++ b/openspec/changes/version-filter-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/version-filter-parity/design.md
+++ b/openspec/changes/version-filter-parity/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`publish_draft()` moves the previous structure *and its sessions* onto an archived `SurveyHeader`,
+so "which versions am I looking at?" is a question every creator-facing read has to answer.
+`survey/versioning.py` already owns the family primitives (`canonical_of`, `family_ids`,
+`family_sessions`, `lineage_map`) and its module comment already states the rule: *every
+creator-facing count/aggregate must go through these helpers*. The `version` request parameter is
+the one part of that rule that was implemented twice, once per surface, and drifted.
+
+Two shapes are needed from a resolution:
+
+- Analytics wants **ids**, to filter `SurveySession.survey_id__in` and
+  `question__survey_section__survey_header_id__in`.
+- The export wants **header objects, in order, with filename prefixes**, because it walks each
+  version's questions and writes one file set per version.
+
+That difference is why there are two functions. It does not justify two parsers.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One parse of `version`, one fallback rule, one meaning for `latest`, shared by both surfaces.
+- Both shapes (ids, ordered headers) derived from that single resolution.
+- The default is deliberate and stated once, not implied by each caller's `GET.get` default.
+
+**Non-Goals**
+
+- Changing which sessions are clean (`is_deleted` / `validation_status`) or the `include_all=1`
+  behaviour.
+- A UI redesign of either version picker. The dashboard's Download button gets the scope appended;
+  nothing else moves.
+- Rejecting bad input with a 4xx. These are links a creator can bookmark and a version can be
+  deleted underneath them; falling back to the default is friendlier than an error page, and once
+  both surfaces fall back the same way the bug is gone either way.
+
+## Decisions
+
+### 1. The resolver lives in `versioning.py` and returns a scope object
+
+`resolve_version_scope(survey, version) -> VersionScope`, a small frozen dataclass:
+
+```python
+VersionScope(
+    value:    str,             # normalised: 'all' | 'vN'
+    headers:  list[SurveyHeader],  # canonical first, then archived newest-first
+    ids:      set[int],
+    is_family: bool,           # len(headers) > 1
+)
+```
+
+*Rationale.* `analytics.py` importing from `versioning.py` is the existing direction of dependency
+(it already imports `canonical_of`, `family_ids`, `lineage_map`); `views.py` importing from it adds
+no cycle. Putting the resolver in `analytics.py` and importing that into `views.py` would drag the
+whole analytics service layer into the export path.
+
+`analytics.py` keeps a `resolve_version_scope` name as a thin re-export returning `.ids`, so the two
+existing call sites (`analytics.py:137`, `analytics.py:1418`) and their `self.scope_ids` contract
+are untouched.
+
+### 2. Normalisation, in order
+
+1. Falsy (`None`, `''`) → the default.
+2. `'all'` → the family.
+3. `'latest'` → `canonical.version_number` — an alias, resolved before the numeric parse rather
+   than crashing inside it.
+4. `'vN'` / `'N'` → that version, if a header with that number exists in the family.
+5. Anything else, including a well-formed number for a version that does not exist → the default.
+
+*Rationale for `latest` as an alias rather than its own scope value:* the export's dropdown already
+links `?version=latest` and those links are in the wild; the analytics picker emits `v3`. Resolving
+`latest` to `vN` up front means one canonical form (`value` is always `all` or `vN`) with no third
+case for the UI to display.
+
+### 3. The default is `all`
+
+Both surfaces default to the whole family, which is what analytics does today.
+
+*Rationale.* The complaint the bug generates is "the export is broken" — the export is the surface
+that disagrees with what the creator just read. Making the export match the screen resolves it in
+the direction the creator already believes. "All versions" is also the honest answer to *how many
+responses does this survey have*, which is the question asked when no filter is stated.
+
+*Consequence, handled below:* the export's default changes behaviour for multi-version surveys.
+That is the point of the change, not a side effect — but it must not change filenames for the
+single-version majority.
+
+### 4. Filename prefixes follow the resolved scope, not the parameter
+
+Today `_get_version_surveys` prefixes `vN_` whenever the parameter is literally `'all'`, so under a
+default of `all` every single-version survey would suddenly download `v1_data.csv` instead of
+`data.csv`. Prefixes are therefore driven by `scope.is_family`: one header in scope → no prefix;
+more than one → `vN_` on each.
+
+This also fixes a latent oddity: `?version=all` on a single-version survey already produces a
+pointless `v1_` prefix today.
+
+### 5. The dashboard's Download button carries the on-screen scope
+
+`analytics_dashboard.html:379` links to `/download` bare. It gets `?version={{ current_version }}`,
+so the button exports exactly what the page above it is reporting. This is the shortest path a
+creator can walk into the inconsistency, and after the parity fix it stays correct by construction.
+
+## Risks / Trade-offs
+
+- **A multi-version survey's default download changes size.** A creator who bookmarked
+  `/download` and expected the current version now gets the family, with `vN_` prefixes. Mitigated
+  by: the dropdown still offers "Current (vN)" explicitly, and the previous default was the side of
+  the disagreement that under-reported — silently returning 2 of 111 rows is the worse failure.
+- **Unknown values stay silent.** `?version=bogus` returns the family with no warning. Both
+  surfaces now agree, so it can no longer produce contradictory numbers; a visible error for a
+  typo'd bookmark is not worth an error page.
+- **`latest` is kept alive.** It is a second name for `vN` and one more thing to remember. Removing
+  it would break existing dropdown links and any bookmark made from them.
+
+## Migration Plan
+
+None. No schema, no data. Deployment is a code swap; in-flight bookmarks keep working with the
+semantics described above.
+
+## Open Questions
+
+None. The default was chosen deliberately (decision 3).

--- a/openspec/changes/version-filter-parity/proposal.md
+++ b/openspec/changes/version-filter-parity/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The two surfaces that report a survey's responses — the analytics dashboard and the data export —
+resolve `?version=` with two separate implementations, and the two disagree. A creator reads 111
+responses on screen, downloads the data, and gets 2 rows.
+
+`resolve_version_scope` (`survey/analytics.py:16`) returns header ids; `_get_version_surveys`
+(`survey/views.py:1009`) returns `(survey, prefix)` tuples. They were written for different callers
+and never reconciled:
+
+- **Different defaults.** With no parameter, analytics defaults to `all`
+  (`analytics_views.py:87`, `147`, `196`); the export defaults to the current version only
+  (`views.py:1009-1011`).
+- **`latest` means opposite things.** The export handles `'latest'` as canonical-only.
+  `resolve_version_scope` cannot parse it — `int('latest'.lstrip('v'))` raises, `num` becomes `None`,
+  and it falls through to the whole family. The same word narrows one surface and widens the other.
+- **Unknown values fall in opposite directions** for the same reason: analytics widens to the
+  family, the export narrows to the current version.
+
+Measured on `Ameelia Mirt` (canonical v3, archived v2), local data:
+
+| `?version=` | Analytics "Total Sessions" | Export CSV rows |
+|---|---|---|
+| *(none)* | 111 | 2 |
+| `latest` | 111 | 2 |
+| `all` | 111 | 111 |
+| `v3` (current) | 2 | 2 |
+| `v2` | 109 | 109 |
+| `bogus` | 111 | 2 |
+
+Every number there is correct — each is a right answer to a different question. The defect is that
+one URL asks two questions.
+
+The Download button on the analytics dashboard itself (`analytics_dashboard.html:379`) carries no
+`version` at all, so the most direct path from "111 on screen" to "2 rows in the file" is a single
+click inside the dashboard that is showing the 111.
+
+## What Changes
+
+- One resolver, in `survey/versioning.py`, serves both surfaces. Analytics and the export SHALL
+  answer the same question for the same URL.
+- **The default is `all`** — the whole version family — on both surfaces. Analytics already
+  defaults there; the export follows. A survey with one version is unaffected: its family is itself.
+- **`latest` means the canonical version** on both surfaces, identical to `vN` where N is the
+  current version number.
+- An unparseable value falls back to the default (`all`) on both surfaces, rather than to opposite
+  ends as it does now.
+- Export filenames are prefixed `vN_` only when the resolved scope actually spans more than one
+  version, so a single-version survey's download keeps its current filenames under the new default.
+- The Download button on the analytics dashboard carries the version scope currently on screen.
+
+Not in scope: changing which sessions count as clean (the trashed / not-approved filter), the
+`include_all=1` escape hatch, or the analytics numbers themselves. They are correct today.
+
+## Capabilities
+
+### New Capabilities
+
+- `version-filter-scope`: how a `version` request parameter resolves to a set of survey versions,
+  and the guarantee that every creator-facing surface resolves it the same way.
+
+### Modified Capabilities
+
+- `version-export-ui`: the plain "Download Data" link for a single-version survey is specified as
+  "pointing to the latest version"; under the new default it points at the family. For a
+  single-version survey those are the same set, but the requirement text has to say so.
+
+## Impact
+
+- `survey/versioning.py` — the shared resolver (it already owns `canonical_of` / `family_ids`).
+- `survey/analytics.py` — `resolve_version_scope` becomes a re-export of the shared one.
+- `survey/views.py` — `_get_version_surveys` and `download_data`'s default.
+- `survey/templates/editor/analytics_dashboard.html` — Download button carries the version scope.
+- No migration. No model changes.
+- Backlog #114 closed. Same complaint shape as the export bugs #96/#97 — a creator concluding the
+  export is broken — and it costs the same support round-trip.

--- a/openspec/changes/version-filter-parity/specs/version-export-ui/spec.md
+++ b/openspec/changes/version-filter-parity/specs/version-export-ui/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Version-aware download dropdown in editor dashboard
+
+The editor dashboard SHALL display a dropdown menu for "Download Data" when a survey has more than one version. The dropdown SHALL offer options to download data for specific versions or all versions.
+
+For surveys with only one version (no archived history), the system SHALL display a plain "Download Data" link with no `version` parameter. That link resolves to the survey's version family, which for a single-version survey is the survey itself — the same data as before, with unprefixed filenames.
+
+#### Scenario: Survey with single version shows plain link
+- **WHEN** a survey has `version_number=1` and no archived versions
+- **THEN** the dashboard displays a plain "Download Data" link to `/surveys/<uuid>/download`
+- **AND** that download contains the survey's responses with unprefixed filenames
+
+#### Scenario: Survey with multiple versions shows dropdown
+- **WHEN** a survey has `version_number > 1` (archived versions exist)
+- **THEN** the dashboard displays a "Download Data" dropdown with options:
+  - "All Versions" linking to `?version=all`
+  - "Current (vN)" linking to `?version=latest` where N is the current version number
+  - One entry per archived version "vM" linking to `?version=vM` in descending order
+
+#### Scenario: "Current (vN)" downloads only the current version
+- **WHEN** the "Current (vN)" option is used
+- **THEN** the download contains only the canonical version's responses, with unprefixed filenames
+
+#### Scenario: Archived versions are prefetched efficiently
+- **WHEN** the editor dashboard loads a list of surveys
+- **THEN** the archived versions for all surveys SHALL be loaded in a single batched query (no N+1)

--- a/openspec/changes/version-filter-parity/specs/version-filter-scope/spec.md
+++ b/openspec/changes/version-filter-parity/specs/version-filter-scope/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: One resolution of the version filter serves every surface
+
+The `version` request parameter SHALL be resolved by a single shared function. Every creator-facing
+surface that reports responses — the analytics dashboard and its partials, and the data export —
+SHALL resolve the same parameter value to the same set of survey versions.
+
+#### Scenario: Analytics and export agree with no parameter
+
+- **WHEN** a survey with a current version and archived versions is opened in analytics with no
+  `version` parameter, and its data is downloaded with no `version` parameter
+- **THEN** both cover the same set of sessions
+
+#### Scenario: Analytics and export agree on every accepted value
+
+- **WHEN** the same `version` value is passed to analytics and to the export
+- **THEN** both resolve it to the same set of survey versions
+
+### Requirement: The default scope is the whole version family
+
+When no `version` parameter is supplied, both surfaces SHALL report the survey's whole version
+family — the canonical survey plus its archived versions.
+
+#### Scenario: Export with no parameter covers the family
+
+- **WHEN** data is downloaded for a survey with archived versions and no `version` parameter
+- **THEN** the export contains the responses of every version in the family
+
+#### Scenario: A single-version survey is unaffected
+
+- **WHEN** data is downloaded for a survey that has no archived versions and no `version` parameter
+- **THEN** the export contains that survey's responses
+- **AND** the filenames carry no version prefix
+
+### Requirement: `latest` names the canonical version on every surface
+
+The value `latest` SHALL resolve to the canonical (current) version alone, identically to `vN`
+where N is the canonical version number.
+
+#### Scenario: `latest` narrows analytics
+
+- **WHEN** analytics is opened with `version=latest` on a survey with archived versions
+- **THEN** only the canonical version's sessions are reported
+
+#### Scenario: `latest` and the explicit current version agree
+
+- **WHEN** `version=latest` and `version=vN` (N = the canonical version number) are requested on the
+  same surface
+- **THEN** both resolve to the canonical version alone
+
+### Requirement: An explicit version resolves to that version alone
+
+A value of the form `vN` or `N` SHALL resolve to the family member with that version number.
+
+#### Scenario: An archived version is selected
+
+- **WHEN** `version=vM` names an archived version of the survey
+- **THEN** only that archived version's sessions are reported
+
+#### Scenario: The canonical version is selected
+
+- **WHEN** `version=vN` names the canonical version
+- **THEN** only the canonical version's sessions are reported
+
+### Requirement: Unrecognised values fall back to the default on every surface
+
+A `version` value that cannot be resolved SHALL fall back to the default scope — this covers
+unparseable text and version numbers that do not exist in the family. The fallback SHALL be the same
+on every surface; no surface may narrow while another widens.
+
+#### Scenario: Unparseable value
+
+- **WHEN** `version=bogus` is passed to analytics and to the export
+- **THEN** both report the whole version family
+
+#### Scenario: A version number outside the family
+
+- **WHEN** `version=v99` is passed on a survey whose highest version is lower
+- **THEN** both report the whole version family
+
+### Requirement: Export filenames are prefixed only when the scope spans versions
+
+When the resolved scope contains more than one version, each version's exported files SHALL be
+prefixed `vN_`. When it contains exactly one, filenames SHALL carry no prefix.
+
+#### Scenario: Family scope prefixes each version
+
+- **WHEN** a survey with a canonical and an archived version is exported with `version=all`
+- **THEN** the archive contains one prefixed file set per version
+
+#### Scenario: Single-version scope carries no prefix
+
+- **WHEN** `version=all` is requested on a survey that has no archived versions
+- **THEN** the exported filenames carry no version prefix
+
+### Requirement: The analytics Download action exports what the page reports
+
+The Download action on the analytics dashboard SHALL carry the version scope currently selected on
+that page.
+
+#### Scenario: Download follows the version picker
+
+- **WHEN** a creator selects a version in the analytics version picker and then uses the page's
+  Download action
+- **THEN** the exported data covers that version scope

--- a/openspec/changes/version-filter-parity/tasks.md
+++ b/openspec/changes/version-filter-parity/tasks.md
@@ -1,0 +1,51 @@
+# Tasks
+
+## 1. Shared resolver
+
+- [x] 1.1 Add `VersionScope` and `resolve_version_scope(survey, version)` to `survey/versioning.py`:
+      normalise falsy → `all`, `latest` → `vN` (canonical), `vN`/`N` → that family member,
+      anything unresolvable → `all`. Return `value`, `headers` (canonical first, archived
+      newest-first), `ids`, `is_family`.
+- [x] 1.2 Replace `resolve_version_scope` in `survey/analytics.py` with a thin wrapper returning
+      `.ids`, so `SurveyAnalyticsService`/`PerformanceAnalyticsService` `self.scope_ids` is unchanged.
+      `_scope_surveys` now reads the scope's headers instead of re-querying and re-sorting them.
+- [x] 1.3 Rewrite `_get_version_surveys` (`survey/views.py`) on top of the shared resolver, with
+      `vN_` prefixes only when `scope.is_family`.
+
+## 2. Export default
+
+- [x] 2.1 `download_data` passes the raw parameter through (no per-caller default); the resolver
+      supplies `all`.
+- [x] 2.2 Verify `include_all=1` and the excluded-session pre-computation still cover every header
+      in scope — both already iterate `version_surveys`, which is now the resolved scope.
+
+## 3. UI
+
+- [x] 3.1 Analytics dashboard Download button carries `?version={{ current_version }}`
+      (`analytics_dashboard.html:379`).
+- [x] 3.2 Export dropdown's `latest` links (`_survey_more_menu.html`) still read correctly — under
+      the new semantics `latest` is the canonical version, which is what "Current (vN)" claims.
+      No change needed.
+
+## 4. Tests (`survey/tests.py`, GIVEN/WHEN/THEN)
+
+- [x] 4.1 `VersionScopeResolverTest`: default, `all`, `latest`, `vN` canonical, `vM` archived, bare
+      `N`, `bogus`, out-of-family `v99`, single-version survey, resolution from an archived header.
+- [x] 4.2 `VersionFilterParityTest.test_both_surfaces_resolve_every_value_identically`.
+- [x] 4.3 Export tests: no parameter on a multi-version survey yields the family's rows (the
+      111-vs-2 case); `latest` narrows both surfaces.
+- [x] 4.4 Prefix tests: `version=all` on a single-version survey produces unprefixed filenames;
+      on a multi-version survey produces one `vN_` set per version.
+- [x] 4.5 Dashboard Download link carries the on-screen version.
+- [x] 4.6 Update `test_download_no_version_param_returns_latest` — the default is now the family.
+
+## 5. Verification
+
+- [x] 5.1 `./run_tests.sh survey` green — 1047 tests, OK (1 skipped). (The worktree's venv was
+      missing `nh3`, which is in the Pipfile; installing it cleared 5 unrelated errors in the
+      thanks-page tests.)
+- [x] 5.2 Live check against local data (`Ameelia Mirt`, canonical v3 + archived v2, the
+      public-results worktree's db): both columns now match for every row of the backlog table —
+      *(none)* 111/111, `latest` 2/2, `all` 111/111, `v3` 2/2, `v2` 109/109, `bogus` 111/111.
+      Filenames: prefixed `v3_`/`v2_` for family scopes, unprefixed for single-version scopes.
+- [x] 5.3 Strike #114 in `openspec/backlog/INDEX.md` and mark the item file fixed.

--- a/survey/analytics.py
+++ b/survey/analytics.py
@@ -10,30 +10,20 @@ from .models import (
     SurveyHeader, SurveySession, SurveySection, Answer, Question, SurveyEvent,
     VALIDATION_STATUS_CHOICES,
 )
-from .versioning import canonical_of, family_ids, lineage_map
+from .versioning import (
+    canonical_of, lineage_map,
+    resolve_version_scope as resolve_scope,
+)
 
 
 def resolve_version_scope(survey, version):
-    """Resolve a version filter value to a set of SurveyHeader ids.
+    """The SurveyHeader ids a version filter value resolves to.
 
-    version: 'all' (default) → the whole family; 'vN' / 'N' → that single
-    version's header. Unknown values fall back to 'all'.
+    Parsing lives in versioning.resolve_version_scope so the export and
+    analytics cannot drift apart on what a value means; this only unwraps the
+    ids the analytics services filter by.
     """
-    canonical = canonical_of(survey)
-    if version and version != 'all':
-        try:
-            num = int(str(version).lstrip('v'))
-        except (TypeError, ValueError):
-            num = None
-        if num is not None:
-            if num == canonical.version_number:
-                return {canonical.id}
-            match = SurveyHeader.objects.filter(
-                canonical_survey=canonical, version_number=num,
-            ).values_list('id', flat=True).first()
-            if match is not None:
-                return {match}
-    return family_ids(canonical)
+    return resolve_scope(survey, version).ids
 
 
 def version_choices(survey):
@@ -134,7 +124,8 @@ class SurveyAnalyticsService:
     def __init__(self, survey, include_deleted=False, version='all'):
         self.survey = survey
         self.version = version
-        self.scope_ids = resolve_version_scope(survey, version)
+        self.scope = resolve_scope(survey, version)
+        self.scope_ids = self.scope.ids
         if include_deleted:
             self.base_qs = SurveySession.objects.filter(survey_id__in=self.scope_ids)
         else:
@@ -145,11 +136,7 @@ class SurveyAnalyticsService:
     @property
     def _scope_surveys(self):
         """SurveyHeaders in scope (canonical first)."""
-        if not hasattr(self, '_scope_surveys_cache'):
-            headers = list(SurveyHeader.objects.filter(id__in=self.scope_ids))
-            headers.sort(key=lambda h: (not h.is_canonical, -h.version_number))
-            self._scope_surveys_cache = headers
-        return self._scope_surveys_cache
+        return self.scope.headers
 
     @property
     def _lineages(self):

--- a/survey/templates/editor/analytics_dashboard.html
+++ b/survey/templates/editor/analytics_dashboard.html
@@ -376,7 +376,7 @@
             {% endfor %}
         </select>
         {% endif %}
-        <a href="/surveys/{{ survey.uuid }}/download" class="btn btn-sm btn-outline-secondary"
+        <a href="/surveys/{{ survey.uuid }}/download?version={{ current_version }}" class="btn btn-sm btn-outline-secondary"
            style="{% if not version_choices %}margin-left:auto;{% else %}margin-left:0.5rem;{% endif %}margin-bottom:0.25rem;font-size:0.8rem;" title="Download clean responses (CSV + GeoJSON)">
             <i class="fas fa-download"></i> Download data
         </a>

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -9240,16 +9240,308 @@ class VersionedDownloadTest(TestCase):
             has_v1 = any(f.startswith('v1_') for f in filenames)
             self.assertTrue(has_v2 or has_v1)
 
-    def test_download_no_version_param_returns_latest(self):
+    def test_download_no_version_param_returns_whole_family(self):
         """
-        GIVEN a canonical survey
-        WHEN download_data is called without version param
-        THEN it defaults to latest (current canonical data)
+        GIVEN a canonical survey with an archived version
+        WHEN download_data is called without a version param
+        THEN it defaults to the whole family, matching what analytics reports
         """
         url = f'/surveys/{self.survey.uuid}/download'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/zip')
+        body = _zip_text(response)
+        self.assertIn('v2 answer', body)
+        self.assertIn('v1 answer', body)
+
+
+def _zip_text(response):
+    """Concatenated text of every file in a download_data ZIP response."""
+    chunks = []
+    with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+        for name in zf.namelist():
+            chunks.append(zf.read(name).decode('utf-8', errors='replace'))
+    return '\n'.join(chunks)
+
+
+class VersionScopeResolverTest(TestCase):
+    """Tests for the shared version filter resolver (backlog #114)."""
+
+    def setUp(self):
+        self.org = _make_org('ScopeOrg')
+        self.survey = SurveyHeader.objects.create(
+            name='scope_survey', organization=self.org,
+            status='published', version_number=3,
+        )
+        self.archived = SurveyHeader.objects.create(
+            name='scope_survey', organization=self.org, status='closed',
+            is_canonical=False, canonical_survey=self.survey, version_number=2,
+        )
+        self.solo = SurveyHeader.objects.create(
+            name='solo_survey', organization=self.org,
+            status='published', version_number=1,
+        )
+
+    def test_no_value_resolves_to_the_family(self):
+        """
+        GIVEN a survey with an archived version
+        WHEN the version filter is absent
+        THEN the scope is the whole family
+        """
+        from .versioning import resolve_version_scope
+
+        scope = resolve_version_scope(self.survey, None)
+        self.assertEqual(scope.value, 'all')
+        self.assertEqual(scope.ids, {self.survey.id, self.archived.id})
+        self.assertTrue(scope.is_family)
+
+    def test_all_resolves_to_the_family(self):
+        """
+        GIVEN a survey with an archived version
+        WHEN the version filter is 'all'
+        THEN the scope is the whole family, canonical first
+        """
+        from .versioning import resolve_version_scope
+
+        scope = resolve_version_scope(self.survey, 'all')
+        self.assertEqual([h.id for h in scope.headers], [self.survey.id, self.archived.id])
+
+    def test_latest_resolves_to_the_canonical_version_alone(self):
+        """
+        GIVEN a survey with an archived version
+        WHEN the version filter is 'latest'
+        THEN only the canonical version is in scope
+        """
+        from .versioning import resolve_version_scope
+
+        scope = resolve_version_scope(self.survey, 'latest')
+        self.assertEqual(scope.value, 'v3')
+        self.assertEqual(scope.ids, {self.survey.id})
+        self.assertFalse(scope.is_family)
+
+    def test_latest_and_explicit_current_version_agree(self):
+        """
+        GIVEN a survey whose canonical version is v3
+        WHEN 'latest' and 'v3' are resolved
+        THEN both give the same scope
+        """
+        from .versioning import resolve_version_scope
+
+        self.assertEqual(
+            resolve_version_scope(self.survey, 'latest').ids,
+            resolve_version_scope(self.survey, 'v3').ids,
+        )
+
+    def test_archived_version_resolves_alone(self):
+        """
+        GIVEN a survey with archived v2
+        WHEN the version filter is 'v2'
+        THEN only the archived header is in scope
+        """
+        from .versioning import resolve_version_scope
+
+        self.assertEqual(resolve_version_scope(self.survey, 'v2').ids, {self.archived.id})
+
+    def test_bare_number_is_accepted(self):
+        """
+        GIVEN a survey with archived v2
+        WHEN the version filter is '2' without the v prefix
+        THEN it resolves to the same version as 'v2'
+        """
+        from .versioning import resolve_version_scope
+
+        self.assertEqual(resolve_version_scope(self.survey, '2').ids, {self.archived.id})
+
+    def test_unparseable_value_falls_back_to_the_family(self):
+        """
+        GIVEN a survey with an archived version
+        WHEN the version filter is not a version at all
+        THEN the scope falls back to the family
+        """
+        from .versioning import resolve_version_scope
+
+        scope = resolve_version_scope(self.survey, 'bogus')
+        self.assertEqual(scope.value, 'all')
+        self.assertEqual(scope.ids, {self.survey.id, self.archived.id})
+
+    def test_version_outside_the_family_falls_back_to_the_family(self):
+        """
+        GIVEN a survey whose highest version is 3
+        WHEN the version filter names v99
+        THEN the scope falls back to the family rather than to an empty set
+        """
+        from .versioning import resolve_version_scope
+
+        self.assertEqual(
+            resolve_version_scope(self.survey, 'v99').ids,
+            {self.survey.id, self.archived.id},
+        )
+
+    def test_single_version_survey_is_never_a_family(self):
+        """
+        GIVEN a survey with no archived versions
+        WHEN any filter value is resolved
+        THEN the scope holds that survey alone and is not a family
+        """
+        from .versioning import resolve_version_scope
+
+        for value in (None, 'all', 'latest', 'v1', 'bogus'):
+            with self.subTest(value=value):
+                scope = resolve_version_scope(self.solo, value)
+                self.assertEqual(scope.ids, {self.solo.id})
+                self.assertFalse(scope.is_family)
+
+    def test_an_archived_header_resolves_against_its_family(self):
+        """
+        GIVEN an archived version header rather than the canonical one
+        WHEN a filter value is resolved against it
+        THEN the family is resolved from the canonical survey all the same
+        """
+        from .versioning import resolve_version_scope
+
+        scope = resolve_version_scope(self.archived, 'all')
+        self.assertEqual(scope.ids, {self.survey.id, self.archived.id})
+
+
+class VersionFilterParityTest(TestCase):
+    """Analytics and the export must answer the same question for the same URL.
+
+    Backlog #114: they used to disagree on the default, on 'latest', and on
+    unparseable values.
+    """
+
+    def setUp(self):
+        self.org = _make_org('ParityOrg')
+        self.user = User.objects.create_user(username='parityuser', password='pass')
+        Membership.objects.create(user=self.user, organization=self.org, role='owner')
+        self.client.login(username='parityuser', password='pass')
+        self.survey = SurveyHeader.objects.create(
+            name='parity_survey', organization=self.org, created_by=self.user,
+            status='published', version_number=2,
+        )
+        self.section = SurveySection.objects.create(
+            survey_header=self.survey, name='sec', code='S1', is_head=True,
+        )
+        self.question = Question.objects.create(
+            survey_section=self.section, code='Q1', order_number=1,
+            name='Q?', input_type='text',
+        )
+        Answer.objects.create(
+            survey_session=SurveySession.objects.create(survey=self.survey),
+            question=self.question, text='current answer',
+        )
+        self.archived = SurveyHeader.objects.create(
+            name='parity_survey', organization=self.org, status='closed',
+            is_canonical=False, canonical_survey=self.survey, version_number=1,
+        )
+        arch_section = SurveySection.objects.create(
+            survey_header=self.archived, name='sec_old', code='S1', is_head=True,
+        )
+        arch_question = Question.objects.create(
+            survey_section=arch_section, code='Q1', order_number=1,
+            name='Q?', input_type='text',
+        )
+        for _ in range(3):
+            Answer.objects.create(
+                survey_session=SurveySession.objects.create(survey=self.archived),
+                question=arch_question, text='archived answer',
+            )
+
+    def test_both_surfaces_resolve_every_value_identically(self):
+        """
+        GIVEN a survey with a current and an archived version
+        WHEN each accepted filter value is resolved on both surfaces
+        THEN the analytics scope and the exported headers are the same set
+        """
+        from .analytics import resolve_version_scope as analytics_scope
+        from .views import _get_version_surveys
+
+        for value in (None, '', 'all', 'latest', 'v2', 'v1', '1', 'bogus', 'v99'):
+            with self.subTest(value=value):
+                export_ids = {s.id for s, _ in _get_version_surveys(self.survey, value)}
+                self.assertEqual(analytics_scope(self.survey, value), export_ids)
+
+    def test_analytics_and_export_agree_on_the_default_count(self):
+        """
+        GIVEN 1 session on the current version and 3 on the archived one
+        WHEN neither surface is given a version parameter
+        THEN both report all 4 (this is the 111-vs-2 bug)
+        """
+        service = SurveyAnalyticsService(self.survey, version='all')
+        self.assertEqual(service.get_overview()['total_sessions'], 4)
+
+        response = self.client.get(f'/surveys/{self.survey.uuid}/download')
+        body = _zip_text(response)
+        self.assertIn('current answer', body)
+        self.assertIn('archived answer', body)
+
+    def test_latest_narrows_both_surfaces(self):
+        """
+        GIVEN a survey with an archived version
+        WHEN version=latest is requested
+        THEN analytics reports only the current version's session
+        AND the export contains only the current version's answer
+        """
+        service = SurveyAnalyticsService(self.survey, version='latest')
+        self.assertEqual(service.get_overview()['total_sessions'], 1)
+
+        response = self.client.get(f'/surveys/{self.survey.uuid}/download?version=latest')
+        body = _zip_text(response)
+        self.assertIn('current answer', body)
+        self.assertNotIn('archived answer', body)
+
+    def test_family_export_prefixes_each_version(self):
+        """
+        GIVEN a survey with two versions
+        WHEN the whole family is exported
+        THEN each version's files carry its own vN_ prefix
+        """
+        response = self.client.get(f'/surveys/{self.survey.uuid}/download?version=all')
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            names = zf.namelist()
+        self.assertTrue(any(n.startswith('v2_') for n in names), names)
+        self.assertTrue(any(n.startswith('v1_') for n in names), names)
+
+    def test_single_version_export_is_never_prefixed(self):
+        """
+        GIVEN a survey with no archived versions
+        WHEN it is exported with version=all
+        THEN the filenames carry no version prefix
+        """
+        solo = SurveyHeader.objects.create(
+            name='solo_parity', organization=self.org, created_by=self.user,
+            status='published', version_number=1,
+        )
+        section = SurveySection.objects.create(
+            survey_header=solo, name='sec', code='S1', is_head=True,
+        )
+        question = Question.objects.create(
+            survey_section=section, code='Q1', order_number=1,
+            name='Q?', input_type='text',
+        )
+        Answer.objects.create(
+            survey_session=SurveySession.objects.create(survey=solo),
+            question=question, text='solo answer',
+        )
+
+        response = self.client.get(f'/surveys/{solo.uuid}/download?version=all')
+        with zipfile.ZipFile(BytesIO(response.content), 'r') as zf:
+            names = zf.namelist()
+        self.assertTrue(names)
+        self.assertFalse([n for n in names if n.startswith('v1_')], names)
+
+    def test_dashboard_download_button_carries_the_version_scope(self):
+        """
+        GIVEN the analytics dashboard filtered to one version
+        WHEN the page is rendered
+        THEN its Download link exports that same version
+        """
+        url = f'/editor/surveys/{self.survey.uuid}/analytics/?version=v1'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, f'/surveys/{self.survey.uuid}/download?version=v1',
+        )
 
 
 class SerializationVersioningTest(TestCase):

--- a/survey/versioning.py
+++ b/survey/versioning.py
@@ -6,6 +6,8 @@ Provides draft-copy workflow for published surveys:
 - check_draft_compatibility(): Verify backward compatibility before publish
 - publish_draft(): Atomically publish a draft copy as a new version
 """
+from dataclasses import dataclass, field
+
 from django.db import transaction
 from django.db.models import Q
 
@@ -60,6 +62,81 @@ def family_sessions(survey, include_deleted=False):
     if not include_deleted:
         qs = qs.filter(is_deleted=False)
     return qs
+
+
+# ─── The `version` request filter ────────────────────────────────────────────
+#
+# Analytics and the data export both accept ?version=. They used to parse it
+# separately and disagreed: different defaults, and 'latest' narrowed one
+# surface while widening the other. One resolver serves both — the shapes they
+# need (ids for analytics, ordered headers for the export) come off one scope.
+
+@dataclass(frozen=True)
+class VersionScope:
+    """The version(s) a `version` filter value resolves to.
+
+    value:   the normalised filter value — always 'all' or 'vN'
+    headers: the SurveyHeaders in scope, canonical first then archived
+             newest-first (the export writes one file set per header, in order)
+    """
+    value: str
+    headers: list = field(default_factory=list)
+
+    @property
+    def ids(self):
+        return {header.id for header in self.headers}
+
+    @property
+    def is_family(self):
+        """True when the scope spans more than one version."""
+        return len(self.headers) > 1
+
+
+def family_headers(survey):
+    """The family's SurveyHeaders: canonical first, then archived newest-first."""
+    canonical = canonical_of(survey)
+    archived = list(
+        SurveyHeader.objects
+        .filter(canonical_survey=canonical)
+        .order_by('-version_number')
+    )
+    return [canonical] + archived
+
+
+def _requested_version_number(version, canonical):
+    """The version number a filter value names, or None for the whole family.
+
+    'latest' is an alias for the canonical version — resolved here rather than
+    crashing inside the int() parse, which is how the two surfaces used to
+    diverge. Anything unrecognised returns None, i.e. the default scope.
+    """
+    if not version:
+        return None
+    value = str(version).strip().lower()
+    if value in ('', 'all'):
+        return None
+    if value == 'latest':
+        return canonical.version_number
+    try:
+        return int(value.lstrip('v'))
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_version_scope(survey, version=None):
+    """Resolve a `version` filter value to a VersionScope.
+
+    Missing, 'all', or unresolvable values → the whole family. 'latest', 'vN'
+    and 'N' → that single version, when the family has one with that number.
+    """
+    canonical = canonical_of(survey)
+    headers = family_headers(canonical)
+    num = _requested_version_number(version, canonical)
+    if num is not None:
+        for header in headers:
+            if header.version_number == num:
+                return VersionScope(value=f'v{num}', headers=[header])
+    return VersionScope(value='all', headers=headers)
 
 
 def lineage_map(survey):

--- a/survey/views.py
+++ b/survey/views.py
@@ -42,6 +42,7 @@ import pandas as pd
 from .access_control import check_survey_access
 from .audit import audit
 from .trash import trash_survey, restore_survey, purge_survey, purge_expired_surveys
+from .versioning import resolve_version_scope
 import hmac
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -1009,30 +1010,18 @@ def survey_section(request, survey_slug, section_name):
 def _get_version_surveys(survey, version_param):
 	"""Resolve which survey(s) to export based on version parameter.
 
-	Returns list of (survey, prefix) tuples. prefix is empty string for single-version export.
+	Returns list of (survey, prefix) tuples. The prefix is empty when the scope
+	is a single version, so a single-version survey keeps unprefixed filenames
+	whatever the parameter says.
+
+	The parameter itself is parsed by versioning.resolve_version_scope — the
+	same call the analytics dashboard makes, so both surfaces answer the same
+	question for the same URL.
 	"""
-	if not version_param or version_param == 'latest':
-		return [(survey, '')]
-
-	if version_param == 'all':
-		# Current canonical + all archived versions
-		result = [(survey, f'v{survey.version_number}_')]
-		for archived in survey.get_version_history():
-			result.append((archived, f'v{archived.version_number}_'))
-		return result
-
-	# Parse "vN" format
-	if version_param.startswith('v') and version_param[1:].isdigit():
-		version_num = int(version_param[1:])
-		if version_num == survey.version_number:
-			return [(survey, '')]
-		archived = SurveyHeader.objects.filter(
-			canonical_survey=survey, version_number=version_num, is_canonical=False
-		).first()
-		if archived:
-			return [(archived, '')]
-
-	return [(survey, '')]
+	scope = resolve_version_scope(survey, version_param)
+	if scope.is_family:
+		return [(header, f'v{header.version_number}_') for header in scope.headers]
+	return [(header, '') for header in scope.headers]
 
 
 @login_required


### PR DESCRIPTION
## Problem

The two surfaces that report a survey's responses resolved `?version=` with two separate
implementations, and they disagreed. A creator read 111 responses in analytics, downloaded the
data, and got 2 rows in the CSV.

Measured on `Ameelia Mirt` (canonical v3, archived v2), before this change:

| `?version=` | Analytics | Export rows |
|---|---|---|
| *(none)* | 111 | 2 |
| `latest` | 111 | 2 |
| `all` | 111 | 111 |
| `v3` | 2 | 2 |
| `v2` | 109 | 109 |
| `bogus` | 111 | 2 |

Every number is correct — each is a right answer to a different question. The defect was that one
URL asked two.

Three divergences: different defaults (`all` vs. current version); `latest` handled by the export as
canonical-only but crashing the analytics parse (`int('latest'.lstrip('v'))`) and falling through to
the whole family; and unparseable values falling to opposite ends for the same reason.

## Change

One resolver in `survey/versioning.py` serves both surfaces. It returns a `VersionScope` — the
normalised value, the headers in scope (canonical first), their ids, and whether the scope spans
versions.

- **The default is the whole family on both surfaces.** Analytics already did this; the export
  follows, so the download matches what the creator just read.
- **`latest` is the canonical version on both**, resolved as an alias before the numeric parse.
- **Unresolvable values fall back to the default on both**, instead of to opposite ends.
- **Filename prefixes follow the resolved scope**, not the literal word `all` — a single-version
  survey keeps unprefixed filenames under the new default, and `?version=all` stops emitting a
  pointless `v1_` prefix for surveys that have only one version.
- **The Download button on the analytics dashboard carries the on-screen version.** It carried none
  at all, which made one click inside the dashboard the shortest path into the disagreement.

After the change every row of the table above matches: *(none)* 111/111, `latest` 2/2, `all`
111/111, `v3` 2/2, `v2` 109/109, `bogus` 111/111.

## Behaviour change to be aware of

For a **multi-version** survey, `/download` with no parameter now returns the whole family with
`vN_` prefixes rather than the current version only. That is the point of the change — the previous
default was the side of the disagreement that under-reported — and the dropdown still offers
"Current (vN)" explicitly.

## Tests

`./run_tests.sh survey` — 1047 tests, OK (1 skipped).

New: `VersionScopeResolverTest` (10 resolver cases) and `VersionFilterParityTest` (both surfaces
resolve all 9 accepted values identically, the default count, `latest` narrowing both, prefix rules,
and the dashboard's Download link). `test_download_no_version_param_returns_latest` was rewritten for
the new default.

## OpenSpec

`openspec/changes/version-filter-parity/` — new capability `version-filter-scope`, modified
`version-export-ui`. Closes backlog #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)